### PR TITLE
Added support for single aggregate

### DIFF
--- a/src/main/scala/com/cognite/spark/connector/DefaultSource.scala
+++ b/src/main/scala/com/cognite/spark/connector/DefaultSource.scala
@@ -31,7 +31,9 @@ class DefaultSource extends RelationProvider
     resourceType match {
       case "timeseries" =>
         val tagId = parameters.getOrElse("tagId", sys.error("tagId must be specified"))
-        new TimeSeriesRelation(apiKey, project, tagId, schema, limit, batchSize)(sqlContext)
+        val aggregates = parameters.get("aggregates")
+        val granularity = parameters.get("granularity")
+        new TimeSeriesRelation(apiKey, project, tagId, schema, limit, batchSize, aggregates, granularity)(sqlContext)
       case "tables" =>
         val database = parameters.getOrElse("database", sys.error("Database must be specified"))
         val tableName = parameters.getOrElse("table", sys.error("Table must be specified"))


### PR DESCRIPTION
A single aggregate can now be used, together with granularity. Added aggregates and granularity as options, transformed key of resultant response-value to same key as for no aggregates (as that is what cdp-spark-connector supports) (this is why only one aggregate is supported) and worked around bug with getting timestamps before start time.