### PR TITLE
We always set end to the latest value, but end is exclusive.

### DIFF
--- a/src/main/scala/com/cognite/spark/connector/TimeSeriesRelation.scala
+++ b/src/main/scala/com/cognite/spark/connector/TimeSeriesRelation.scala
@@ -119,7 +119,7 @@ class TimeSeriesRelation(apiKey: String,
       case None => {
         getLatestDatapoint()
           .getOrElse(sys.error("Failed to get latest datapoint for " + path))
-          .timestamp
+          .timestamp + 1
       }
     }
 


### PR DESCRIPTION
The timeseries/data api call is called with start and end set, and if
the dataframe doesn't specify the end, it defaults to the latest data
point available (this is wise to make a recomputed RDD be more stable).

Since "end" is exclusive in our API, this means we always lose the last
entry when no end is specified.

This always sets the end to the next timestep after the latest
update. This makes it include the last entry.