### PR TITLE
Fix JSON serializing/deserializing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <scala.version>2.11.12</scala.version>
     <scala.compat.version>2.11</scala.compat.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <circe.version>0.9.3</circe.version>
   </properties>
 
   <dependencies>
@@ -48,6 +49,21 @@
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-scala_${scala.compat.version}</artifactId>
       <version>2.6.7</version>
+    </dependency>
+    <dependency>
+      <groupId>io.circe</groupId>
+      <artifactId>circe-core_${scala.compat.version}</artifactId>
+      <version>${circe.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.circe</groupId>
+      <artifactId>circe-generic_${scala.compat.version}</artifactId>
+      <version>${circe.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.circe</groupId>
+      <artifactId>circe-parser_${scala.compat.version}</artifactId>
+      <version>${circe.version}</version>
     </dependency>
     <dependency>
       <groupId>com.cognite.data</groupId>
@@ -95,6 +111,13 @@
                 <arg>-dependencyfile</arg>
                 <arg>${project.build.directory}/.scala_dependencies</arg>
               </args>
+              <compilerPlugins>
+                <compilerPlugin>
+                  <groupId>org.scalamacros</groupId>
+                  <artifactId>paradise_${scala.version}</artifactId>
+                  <version>2.1.1</version>
+                </compilerPlugin>
+              </compilerPlugins>
             </configuration>
           </execution>
         </executions>

--- a/src/main/scala/com/cognite/spark/connector/AssetsTableRelation.scala
+++ b/src/main/scala/com/cognite/spark/connector/AssetsTableRelation.scala
@@ -8,14 +8,14 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation, TableScan}
 import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
 import org.apache.spark.sql.{Row, SQLContext}
+import io.circe.generic.auto._
 
 case class PostAssetsDataItems[A](items: Seq[A])
 
 case class AssetsItem(name: String,
-                      // FIXME: parentId is optional
-                      parentId: Long,
-                      description: String,
-                      metadata: Map[String, String],
+                      parentId: Option[Long],
+                      description: Option[String],
+                      metadata: Option[Map[String, String]],
                       id: Long)
 
 case class PostAssetsItem(name: String,

--- a/src/test/scala/com/cognite/spark/connector/BasicUseTest.scala
+++ b/src/test/scala/com/cognite/spark/connector/BasicUseTest.scala
@@ -61,4 +61,38 @@ class BasicUseTest extends FunSuite with DataFrameSuiteBase {
     assert(df.count() == 1000)
   }
 
+  test("smoke test assets") {
+    val df = sqlContext.read.format("com.cognite.spark.connector")
+      .option("project", "akerbp")
+      .option("apiKey", apiKey)
+      .option("type", "assets")
+      .option("batchSize", "1000")
+      .option("limit", "1000")
+      .option("assetsPath", "[\"IAA\"]")
+      .load()
+
+    df.createTempView("assets")
+    val res = sqlContext.sql("select * from assets")
+      .collect()
+    assert(res.length == 1000)
+  }
+
+  test("smoke test tables") {
+    val df = sqlContext.read.format("com.cognite.spark.connector")
+      .option("project", "akerbp")
+      .option("apiKey", apiKey)
+      .option("type", "tables")
+      .option("batchSize", "1000")
+      .option("limit", "1000")
+      .option("database", "cow")
+      .option("table", "Workpermit")
+      .option("inferSchema", "true")
+      .option("inferSchemaLimit", "100")
+      .load()
+
+    df.createTempView("tables")
+    val res = sqlContext.sql("select * from tables")
+        .collect()
+    assert(res.length == 1000)
+  }
 }


### PR DESCRIPTION
JSON serializing broke in last version. Use Circe instead of Jackson when it comes to generic serialization. Not all usages of Jacksons has been removed yet.

So the issue is that Jackson is not supporting the powerful generic system in Scala, and breaks at runtime with a weird error. 