### PR TITLE
Use Jetfire test project instead to AkerBP for testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ def label = "cdp-spark-${UUID.randomUUID().toString().substring(0, 5)}"
 podTemplate(label: label,
             containers: [containerTemplate(name: 'maven',
                                            image: 'maven:3.5.2-jdk-8',
+                                           envVars: [secretEnvVar(key: 'TEST_API_KEY', secretName: 'jetfire-test-api-key', secretKey: 'jetfireTestApiKey.txt')],
                                            resourceRequestCpu: '100m',
                                            resourceLimitCpu: '2000m',
                                            resourceRequestMemory: '3000Mi',
@@ -42,15 +43,11 @@ podTemplate(label: label,
                 sh('cp /maven-credentials/settings.xml /root/.m2')
             }
             stage('Test') {
-                // TODO: mock out server responses so we don't need a real API key to run tests
-                //sh('mvn test || true')
-                //junit(allowEmptyResults: false, testResults: '**/target/surefire-reports/*.xml')
-                //summarizeTestResults()
-                sh('mvn -B verify -DskipTests')
+                sh('mvn -B verify')
             }
             if (env.BRANCH_NAME == 'master') {
                 stage('Deploy') {
-                    sh('mvn -B deploy -DskipTests')
+                    sh('mvn -B deploy')
                 }
             }
         }

--- a/src/test/scala/com/cognite/spark/connector/BasicUseTest.scala
+++ b/src/test/scala/com/cognite/spark/connector/BasicUseTest.scala
@@ -8,13 +8,13 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class BasicUseTest extends FunSuite with DataFrameSuiteBase {
-  val apiKey = System.getenv("COGNITE_API_KEY")
+  val apiKey = System.getenv("TEST_API_KEY")
   test("Use our own custom format for timeseries") {
     val df = sqlContext.read.format("com.cognite.spark.connector")
-      .option("project", "akerbp")
+      .option("project", "jetfiretest2")
       .option("apiKey", apiKey)
       .option("type", "timeseries")
-      .option("tagId", "00ADD0002/B1/5mMid")
+      .option("tagId", "Bitbay USD")
       .load()
     assert(df.schema.length == 3)
 
@@ -25,67 +25,66 @@ class BasicUseTest extends FunSuite with DataFrameSuiteBase {
 
   test("Iterate over period longer than limit") {
     val df = sqlContext.read.format("com.cognite.spark.connector")
-      .option("project", "akerbp")
+      .option("project", "jetfiretest2")
       .option("apiKey", apiKey)
       .option("type", "timeseries")
-      .option("batchSize", "100")
-      .option("limit", "1000")
-      .option("tagId", "00ADD0002/B1/5mMid")
+      .option("batchSize", "40")
+      .option("limit", "100")
+      .option("tagId", "Bitbay USD")
       .load()
       .where("timestamp > 0 and timestamp < 1790902000001")
-    assert(df.count() == 1000)
+    assert(df.count() == 100)
   }
 
   test("test that we handle initial data set below batch size.") {
     val df = sqlContext.read.format("com.cognite.spark.connector")
-      .option("project", "akerbp")
+      .option("project", "jetfiretest2")
       .option("apiKey", apiKey)
       .option("type", "timeseries")
       .option("batchSize", "2000")
-      .option("limit", "1000")
-      .option("tagId", "00ADD0002/B1/5mMid")
+      .option("limit", "100")
+      .option("tagId", "Bitbay USD")
       .load()
-    assert(df.count() == 1000)
+    assert(df.count() == 100)
   }
 
   test("test that we handle initial data set with the same size as the batch size.") {
     val df = sqlContext.read.format("com.cognite.spark.connector")
-      .option("project", "akerbp")
+      .option("project", "jetfiretest2")
       .option("apiKey", apiKey)
       .option("type", "timeseries")
-      .option("batchSize", "1000")
-      .option("limit", "1000")
-      .option("tagId", "00ADD0002/B1/5mMid")
+      .option("batchSize", "100")
+      .option("limit", "100")
+      .option("tagId", "Bitbay USD")
       .load()
-      .where("timestamp >= 0 and timestamp <= 1390902000001")
-    assert(df.count() == 1000)
+      .where("timestamp >= 0 and timestamp <= 1790902000001")
+    assert(df.count() == 100)
   }
 
   test("smoke test assets") {
     val df = sqlContext.read.format("com.cognite.spark.connector")
-      .option("project", "akerbp")
+      .option("project", "jetfiretest2")
       .option("apiKey", apiKey)
       .option("type", "assets")
       .option("batchSize", "1000")
       .option("limit", "1000")
-      .option("assetsPath", "[\"IAA\"]")
       .load()
 
     df.createTempView("assets")
     val res = sqlContext.sql("select * from assets")
       .collect()
-    assert(res.length == 1000)
+    assert(res.length == 6)
   }
 
   test("smoke test tables") {
     val df = sqlContext.read.format("com.cognite.spark.connector")
-      .option("project", "akerbp")
+      .option("project", "jetfiretest2")
       .option("apiKey", apiKey)
       .option("type", "tables")
       .option("batchSize", "1000")
       .option("limit", "1000")
-      .option("database", "cow")
-      .option("table", "Workpermit")
+      .option("database", "testdb")
+      .option("table", "cryptoAssets")
       .option("inferSchema", "true")
       .option("inferSchemaLimit", "100")
       .load()
@@ -98,7 +97,7 @@ class BasicUseTest extends FunSuite with DataFrameSuiteBase {
 
   test("smoke test events") {
     val df = sqlContext.read.format("com.cognite.spark.connector")
-      .option("project", "akerbp")
+      .option("project", "jetfiretest2")
       .option("apiKey", apiKey)
       .option("type", "events")
       .option("batchSize", "500")


### PR DESCRIPTION
We need to update the ENV variable on the servers, but I am not sure how to do it. Let me know here and I will do it.

I created a new tenant called jetfiretest2, and we can use it for cross project transforms as well. I am creating a PR for cross project transforms in transformers-backend now.