### PR TITLE
 Fix upsert for Events

### DIFF
--- a/src/test/scala/com/cognite/spark/connector/BasicUseTest.scala
+++ b/src/test/scala/com/cognite/spark/connector/BasicUseTest.scala
@@ -165,13 +165,16 @@ class BasicUseTest extends FunSuite with DataFrameSuiteBase {
        |"$source" as source,
        |sourceId
        |from sourceEvent
+       |limit 100
      """.stripMargin)
       .select(destinationDf.columns.map(col): _*)
       .write
       .insertInto("destinationEvent")
 
     // Check if post worked
-    assert(eventDescriptions().map(_.getString(0)).forall(_ == "bar"))
+    val descriptionsAfterPost = eventDescriptions()
+    assert(descriptionsAfterPost.length == 100)
+    assert(descriptionsAfterPost.map(_.getString(0)).forall(_ == "bar"))
 
     // Update events
     sqlContext.sql(s"""
@@ -192,7 +195,9 @@ class BasicUseTest extends FunSuite with DataFrameSuiteBase {
       .insertInto("destinationEvent")
 
     // Check if upsert worked
-    assert(eventDescriptions().map(_.getString(0)).forall(_ == "foo"))
+    val descriptionsAfterUpdate = eventDescriptions()
+    assert(descriptionsAfterUpdate.length == 1000)
+    assert(descriptionsAfterUpdate.map(_.getString(0)).forall(_ == "foo"))
   }
 
   def cleanupEvents(source: String): Unit = {


### PR DESCRIPTION
The old implementation didn't consider the fact that if there are conflicts the rest of the events will not be processed by CDP.

Quote from CDP documentation:
> Responds with a 409 (CONFLICT) if the source & sourceId already exists. It will not proceed if there is a conflict, so no events will be created in that case. The JSON body contains a field called 'duplicates', which is a list of conflicting items, where each item has an id, source and sourceId.

Depends on #49 