### PR TITLE
Release 0.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val root = (project in file("."))
   .settings(
     organization := "com.cognite.spark.datasource",
     name := "cdp-spark-datasource",
-    version := "0.1.6-SNAPSHOT",
+    version := "0.2.0",
     assemblyJarName in assembly := s"${normalizedName.value}-${version.value}-jar-with-dependencies.jar",
     scalaVersion := "2.11.12",
     scalastyleFailOnWarning := true,


### PR DESCRIPTION
Backwards incompatible changes:
- rename time series datapoints to "datapoints"
- introduce time series metadata as "timeseries"
- update to Spark 2.4.0