### PR TITLE
Fix publishing of fat jar

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ podTemplate(label: label,
                 }
                 if (env.BRANCH_NAME == 'master') {
                     stage('Deploy') {
-                        sh('sbt -Dsbt.log.noformat=true publish')
+                        sh('sbt -Dsbt.log.noformat=true library/publish fatJar/publish')
                     }
                 }
             }

--- a/build.sbt
+++ b/build.sbt
@@ -3,14 +3,6 @@ val circeVersion = "0.9.3"
 val Specs2Version = "4.2.0"
 val artifactory = "https://cognite.jfrog.io/cognite/"
 
-assemblyMergeStrategy in assembly := {
-  case "io.netty.versions.properties" => MergeStrategy.first
-  case PathList("META-INF", xs @ _*) => MergeStrategy.discard
-  case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
-    oldStrategy(x)
-}
-
 resolvers += "libs-release" at artifactory + "libs-release/"
 publishTo := {
   if (isSnapshot.value)
@@ -19,13 +11,18 @@ publishTo := {
     Some("releases"  at artifactory + "libs-release-local/")
 }
 
-lazy val root = (project in file("."))
+lazy val commonSettings = Seq(
+  organization := "com.cognite.spark.datasource",
+  version := "0.3.0",
+  scalaVersion := "2.11.12",
+  fork in Test := true
+)
+
+lazy val library = (project in file("."))
   .settings(
-    organization := "com.cognite.spark.datasource",
+    commonSettings,
     name := "cdp-spark-datasource",
-    version := "0.3.0",
     assemblyJarName in assembly := s"${normalizedName.value}-${version.value}-jar-with-dependencies.jar",
-    scalaVersion := "2.11.12",
     scalastyleFailOnWarning := true,
     scalastyleFailOnError := true,
     libraryDependencies ++= Seq(
@@ -54,22 +51,28 @@ lazy val root = (project in file("."))
         exclude("org.glassfish.hk2.external", "javax.inject"),
       "org.apache.spark" %% "spark-sql" % sparkVersion % Provided
         exclude("org.glassfish.hk2.external", "javax.inject")
-    )
+    ),
+    assemblyShadeRules in assembly := Seq(
+      ShadeRule.rename("com.google.protobuf.**" -> "repackaged.cognite_spark_datasource.com.google.protobuf.@1").inAll,
+      ShadeRule.rename("io.circe.**" -> "repackaged.cognite_spark_datasource.io.circe.@1").inAll,
+      ShadeRule.rename("cats.**" -> "repackaged.cognite_spark_datasource.cats.@1").inAll,
+      ShadeRule.rename("shapeless.**" -> "repackaged.cognite_spark_datasource.shapeless.@1").inAll,
+      ShadeRule.rename("jawn.**" -> "repackaged.cognite_spark_datasource.jawn.@1").inAll
+    ),
+    assemblyMergeStrategy in assembly := {
+      case "io.netty.versions.properties" => MergeStrategy.first
+      case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+      case x =>
+        val oldStrategy = (assemblyMergeStrategy in assembly).value
+        oldStrategy(x)
+    },
+    assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
   )
 
-assemblyShadeRules in assembly := Seq(
-  ShadeRule.rename("com.google.protobuf.**" -> "repackaged.cognite_spark_datasource.com.google.protobuf.@1").inAll,
-  ShadeRule.rename("io.circe.**" -> "repackaged.cognite_spark_datasource.io.circe.@1").inAll,
-  ShadeRule.rename("cats.**" -> "repackaged.cognite_spark_datasource.cats.@1").inAll,
-  ShadeRule.rename("shapeless.**" -> "repackaged.cognite_spark_datasource.shapeless.@1").inAll
+lazy val fatJar = project.settings(
+  commonSettings,
+  name := "cdp-spark-datasource-fat",
+  packageBin in Compile := (assembly in (library, Compile)).value
 )
 
-artifact in (Compile, assembly) := {
-  val art = (artifact in (Compile, assembly)).value
-  art.withClassifier(Some("assembly"))
-}
-addArtifact(artifact in (Compile, assembly), assembly)
-
-fork in Test := true
 javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:+CMSClassUnloadingEnabled")
-assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)


### PR DESCRIPTION
The classifier setting has to be removed here https://github.com/cognitedata/docker-spark/blob/master/Jenkinsfile#L51 when upgrading.

This will fix issues that Jetfire is seeing when upgrading CDP Spark datasource https://github.com/cognitedata/transformers-backend/pull/252 by making it rely on the fat jar, and where the pom file got no dependencies (except from scala). 