### PR TITLE
Add a relation helper

### DIFF
--- a/macro/src/main/scala/SparkSchemaHelper.scala
+++ b/macro/src/main/scala/SparkSchemaHelper.scala
@@ -1,0 +1,77 @@
+package com.cognite.spark.datasource
+
+import scala.language.experimental.macros
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.StructType
+
+import scala.reflect.macros.blackbox.Context
+
+class SparkSchemaHelperImpl(val c: Context) {
+  def asRow[T: c.WeakTypeTag](x: c.Expr[T]): c.Expr[Row] = {
+    import c.universe._
+
+    val constructor = weakTypeOf[T].decl(termNames.CONSTRUCTOR).asMethod
+    val params = constructor.paramLists.flatten.map(param => q"$x.${param.name.toTermName}")
+
+    val row = symbolOf[Row.type].asClass.module
+    c.Expr[Row](q"$row(..$params)")
+  }
+
+  def fromRow[T: c.WeakTypeTag](r: c.Expr[Row]): c.Expr[T] = {
+    import c.universe._
+
+    val constructor = weakTypeOf[T].decl(termNames.CONSTRUCTOR).asMethod
+    val params = constructor.paramLists.flatten.map((param: Symbol) => {
+      val name = param.name.toString
+      val innerType = if (param.typeSignature <:< typeOf[Option[_]]) {
+        param.typeSignature.typeArgs.head
+      } else {
+        param.typeSignature
+      }
+
+      val isSequenceWithOptionalVal = innerType <:< typeOf[Seq[Option[_]]]
+      val isMapWithOptionalVal = innerType <:< typeOf[Map[_, Option[_]]]
+      val rowType = if (isSequenceWithOptionalVal) {
+        typeOf[Seq[Any]]
+      } else if (isMapWithOptionalVal) {
+        typeOf[Map[Any, Any]]
+      } else {
+        innerType
+      }
+
+      val column = q"Option($r.getAs[$rowType]($name))"
+      val (baseExpr, isOuterOption) = if (param.typeSignature <:< typeOf[Option[_]]) {
+        (column, true)
+      } else {
+        (q"""$column.getOrElse(throw new IllegalArgumentException("Row is missing required column named '" + $name + "'."))""", false)
+      }
+
+      val resExpr = if (isMapWithOptionalVal) {
+        if (isOuterOption) {
+          q"$baseExpr.map(_.mapValues(Option(_)))"
+        } else {
+          q"$baseExpr.mapValues(Option(_))"
+        }
+      } else if (isSequenceWithOptionalVal) {
+        if (isOuterOption) {
+          q"$baseExpr.map(_.map(Option(_)))"
+        } else {
+          q"$baseExpr.map(Option(_))"
+        }
+      } else {
+        baseExpr
+      }
+      q"$resExpr.asInstanceOf[${param.typeSignature}]"
+    })
+    c.Expr(q"new ${weakTypeOf[T]}(..$params)")
+  }
+}
+
+object SparkSchemaHelper {
+  def structType[T]()(implicit encoder: StructTypeEncoder[T]): StructType = {
+    encoder.structType()
+  }
+
+  def asRow[T](x: T): Row = macro SparkSchemaHelperImpl.asRow[T]
+  def fromRow[T](r: Row): T = macro SparkSchemaHelperImpl.fromRow[T]
+}

--- a/macro/src/main/scala/StructTypeEncoder.scala
+++ b/macro/src/main/scala/StructTypeEncoder.scala
@@ -1,0 +1,59 @@
+package com.cognite.spark.datasource
+
+import scala.language.experimental.macros
+import org.apache.spark.sql.types.{StructField, StructType}
+
+import scala.reflect.macros.blackbox.Context
+
+trait StructTypeEncoder[T] {
+  def structType(): StructType
+}
+
+object StructTypeEncoder {
+  implicit def defaultStructTypeEncoder[T]: StructTypeEncoder[T] = macro structTypeEncoder_impl[T]
+  // scalastyle:off method.name
+  def structTypeEncoder_impl[T: c.WeakTypeTag](c: Context): c.Expr[StructTypeEncoder[T]] = {
+    import c.universe._
+    val structField = symbolOf[StructField.type].asClass.module
+    val structType = symbolOf[StructType.type].asClass.module
+
+    val constructor = weakTypeOf[T].decl(termNames.CONSTRUCTOR).asMethod
+    val structFields = constructor.paramLists.flatten.map((param: Symbol) => {
+      val (dt, nullable) = typeToStructType(c)(param.typeSignature)
+      val name = param.name.toString
+      q"$structField($name, $dt, $nullable)"
+    })
+    val body = q"def structType() = $structType(Seq(..$structFields))"
+    c.Expr[StructTypeEncoder[T]](q"new StructTypeEncoder[${weakTypeOf[T]}] {..$body}")
+  }
+
+  // scalastyle:off cyclomatic.complexity
+  private def typeToStructType(c: Context)(t: c.Type): (c.Tree, Boolean) = {
+    import c.universe._
+    val nullable = t <:< weakTypeOf[Option[_]]
+    val rt = if (nullable) {
+      t.typeArgs.head // Fetch the type param of Option[_]
+    } else {
+      t
+    }
+
+    val dt = rt match {
+      case x if x =:= weakTypeOf[Boolean] => q"DataTypes.BooleanType"
+      case x if x =:= weakTypeOf[Byte] => q"DataTypes.ByteType"
+      case x if x =:= weakTypeOf[Short] => q"DataTypes.ShortType"
+      case x if x =:= weakTypeOf[Int] => q"DataTypes.IntegerType"
+      case x if x =:= weakTypeOf[Long] => q"DataTypes.LongType"
+      case x if x =:= weakTypeOf[Float] => q"DataTypes.FloatType"
+      case x if x =:= weakTypeOf[Double] => q"DataTypes.DoubleType"
+      case x if x =:= weakTypeOf[String] => q"DataTypes.StringType"
+      case x if x <:< weakTypeOf[Map[_,_]] =>
+        val (valueDt, valueNullable) = typeToStructType(c)(rt.typeArgs(1))
+        val keyDt = typeToStructType(c)(rt.typeArgs.head)._1
+        q"DataTypes.createMapType($keyDt, $valueDt, $valueNullable)"
+      case x if x <:< weakTypeOf[Seq[_]] =>
+        val (valueDt, valueNullable) = typeToStructType(c)(rt.typeArgs.head)
+        q"DataTypes.createArrayType($valueDt, $valueNullable)"
+    }
+    (dt, nullable)
+  }
+}

--- a/src/test/scala/com/cognite/spark/datasource/BasicUseTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/BasicUseTest.scala
@@ -136,7 +136,7 @@ class BasicUseTest extends FunSuite with SparkTest with CdpConnector {
        |subtype,
        |null as assetIds,
        |bigint(0) as id,
-       |map() as metadata,
+       |map("foo", null, "bar", "test") as metadata,
        |"$source" as source,
        |sourceId
        |from sourceEvent

--- a/src/test/scala/com/cognite/spark/datasource/SparkSchemaHelperTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/SparkSchemaHelperTest.scala
@@ -1,0 +1,87 @@
+// scalastyle:off
+package com.cognite.spark.datasource
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
+import org.scalatest.{FlatSpec, Matchers}
+import SparkSchemaHelper._
+
+case class TestTypeBasic(a: Int, b: Double, c: Byte, d: Float, x: Map[String, String], g: Long, f: Seq[Long], s: String)
+case class TestTypeOption(a: Option[Int], b: Option[Double], c: Option[Byte],
+                          d: Option[Float], x: Option[Map[String, Option[String]]],
+                          g: Option[Long], f: Option[Seq[Option[Long]]], s: Option[String])
+
+class SparkSchemaHelperTest extends FlatSpec with Matchers {
+  "SparkSchemaHelper structType" should "generate StructType from basic case class" in {
+    structType[TestTypeBasic] should be (StructType(Seq(
+      StructField("a", DataTypes.IntegerType, false),
+      StructField("b", DataTypes.DoubleType, false),
+      StructField("c", DataTypes.ByteType, false),
+      StructField("d", DataTypes.FloatType, false),
+      StructField("x", DataTypes.createMapType(DataTypes.StringType, DataTypes.StringType, false), false),
+      StructField("g", DataTypes.LongType, false),
+      StructField("f", DataTypes.createArrayType(DataTypes.LongType, false), false),
+      StructField("s", DataTypes.StringType, false)
+    )))
+  }
+
+  it should "generate StructType from optional case class" in {
+    structType[TestTypeOption] should be (StructType(Seq(
+      StructField("a", DataTypes.IntegerType, true),
+      StructField("b", DataTypes.DoubleType, true),
+      StructField("c", DataTypes.ByteType, true),
+      StructField("d", DataTypes.FloatType, true),
+      StructField("x", DataTypes.createMapType(DataTypes.StringType, DataTypes.StringType, true), true),
+      StructField("g", DataTypes.LongType, true),
+      StructField("f", DataTypes.createArrayType(DataTypes.LongType, true), true),
+      StructField("s", DataTypes.StringType, true)
+    )))
+  }
+
+  "SparkSchemaHelper fromRow" should "construct type from Row" in {
+    val r = new GenericRowWithSchema(Array(1, 2.toDouble, 3.toByte,
+      4.toFloat, Map("foo" -> "bar"), 5.toLong, Seq[Long](10), "foo"), structType[TestTypeBasic])
+    fromRow[TestTypeBasic](r) should be(TestTypeBasic(1, 2, 3, 4, Map("foo" -> "bar"), 5, Seq(10), "foo"))
+  }
+
+  it should "construct optional type from Row of null" in {
+    val r = new GenericRowWithSchema(Array(null, null, null, null, null, null, null, null), structType[TestTypeOption])
+    fromRow[TestTypeOption](r) should be(
+      TestTypeOption(None, None, None, None, None, None, None, None))
+  }
+
+  it should "construct optional type from Row of map values that are null" in {
+    val r = new GenericRowWithSchema(Array(null, null, null, null, Map("foo" -> null), null, null, null), structType[TestTypeOption])
+    fromRow[TestTypeOption](r) should be(
+      TestTypeOption(None, None, None, None, Some(Map("foo" -> None)), None, None, None))
+  }
+
+  it should "construct optional type from Row of map values that can be null" in {
+    val r = new GenericRowWithSchema(Array(null, null, null, null, Map("foo" -> "row", "bar" -> null), null, null, null), structType[TestTypeOption])
+    fromRow[TestTypeOption](r) should be(
+      TestTypeOption(None, None, None, None, Some(Map("foo" -> Some("row"), "bar" -> None)), None, None, None))
+  }
+
+  it should "construct optional type from Row of seq values that can be null" in {
+    val r = new GenericRowWithSchema(Array(null, null, null, null, null, null, Seq(20L, null), null), structType[TestTypeOption])
+    fromRow[TestTypeOption](r) should be(
+      TestTypeOption(None, None, None, None, None, None, Some(Seq(Some(20), None)), None))
+  }
+
+  "SparkSchemaHelper asRow" should "construct Row from type" in {
+    asRow(TestTypeBasic(1, 2, 3, 4, Map("foo" -> "bar"), 5, Seq(10), "foo")) should
+      be(Row(1, 2.toDouble, 3.toByte, 4.toFloat, Map("foo" -> "bar"), 5.toLong, Seq[Long](10), "foo"))
+  }
+
+  it should "construct Row from optional map type" in {
+    asRow(TestTypeOption(None, None, None, None, Some(Map("foo" -> Some("row"), "bar" -> None)), None, None, None)) should
+      be(Row(None, None, None, None, Some(Map("foo" -> Some("row"), "bar" -> None)), None, None, None))
+  }
+
+  it should "construct Row from optional seq type" in {
+    val x = TestTypeOption(None, None, None, None, None, None, Some(Seq(None, Some(10L))), None)
+    asRow(x) should
+      be(Row(None, None, None, None, None, None, Some(Seq(None, Some(10L))), None))
+  }
+}


### PR DESCRIPTION
This helper adds the ability to create a schema from a type + create a row from a type + convert a row to a type automagically. This makes it a lot less error prone. It also handles Option as Circe, where optional fields are set to be nullable in the schema. 

Work in progress, but what do you think @wjoel?