### PR TITLE
Remove dependency on cognite-data

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ podTemplate(label: label,
                     sh('cp /sbt-credentials/repositories /root/.sbt/')
                 }
                 stage('Run tests') {
-                    sh('sbt -Dsbt.log.noformat=true scalastyle coverage test coverageReport')
+                    sh('sbt -Dsbt.log.noformat=true compile scalastyle coverage test coverageReport')
                 }
                 stage("Upload report to codecov.io") {
                     sh('bash </codecov-script/upload-report.sh')

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ For more information about Jetfire see https://cognitedata.atlassian.net/wiki/sp
 and https://docs.google.com/presentation/d/11oM_Z-NbFAl-ULOvBzG6YmSVRYbPCDuFOnjLed8IuwM
 or go to https://jetfire.cogniteapp.com/ to try it out.
 
-Run `sbt assembly` to create `~/path-to-repo/target/scala-2.11/cdp-spark-datasource-*-jar-with-dependencies.jar`.
+First run `sbt compile` to generate Scala sources for protobuf.
+Then run `sbt assembly` to create `~/path-to-repo/target/scala-2.11/cdp-spark-datasource-*-jar-with-dependencies.jar`.
 
 
 ## Run it with spark-shell

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,10 @@ lazy val commonSettings = Seq(
   }
 )
 
+PB.targets in Compile := Seq(
+  scalapb.gen() -> (sourceManaged in Compile).value
+)
+
 lazy val library = (project in file("."))
   .settings(
     commonSettings,
@@ -26,6 +30,8 @@ lazy val library = (project in file("."))
     scalastyleFailOnWarning := true,
     scalastyleFailOnError := true,
     libraryDependencies ++= Seq(
+      "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf",
+  
       "org.specs2" %% "specs2-core" % Specs2Version % Test,
 
       "com.softwaremill.sttp" %% "core" % "1.5.0",
@@ -38,9 +44,7 @@ lazy val library = (project in file("."))
       "io.circe" %% "circe-parser" % circeVersion,
       "io.circe" %% "circe-literal" % circeVersion,
       "io.circe" %% "circe-generic-extras" % circeVersion,
-
-      "com.cognite.data" % "cognite-data" % "0.24",
-
+      
       "org.scalatest" %% "scalatest" % "3.0.5" % Test,
 
       "com.groupon.dse" % "spark-metrics" % "2.4.0-cognite" % Provided,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,5 @@ addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.2")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.19")
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.8.2"

--- a/src/main/protobuf/DataPoints.proto
+++ b/src/main/protobuf/DataPoints.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package api.v2;
+
+option java_package = "com.cognite.data.api.v2";
+option csharp_namespace = "Cognite.Data.Api.V2";
+option java_multiple_files = true;
+
+message StringDatapoint {
+  int64 timestamp = 1;
+  string value = 2;
+}
+
+message NumericDatapoint {
+  int64 timestamp = 1;
+  double value = 2;
+}
+
+message StringTimeseriesData {
+  repeated StringDatapoint points = 1;
+}
+
+message NumericTimeseriesData {
+  repeated NumericDatapoint points = 1;
+}
+
+message TimeseriesData {
+  oneof data {
+    StringTimeseriesData stringData = 1;
+    NumericTimeseriesData numericData = 2;
+  }
+}
+
+message NamedTimeseriesData {
+  string name = 1;
+  oneof data {
+    StringTimeseriesData stringData = 2;
+    NumericTimeseriesData numericData = 3;
+  }
+}
+
+message MultiNamedTimeseriesData {
+  repeated NamedTimeseriesData namedTimeseriesData = 1;
+}


### PR DESCRIPTION
Removed dependency on internal library with non-stable definitions to
prepare for open sourcing cdp-spark-datasource.

Implemented protobuf using ScalaPB and rewrote code to use Scala syntax
(cognite-data is written in Java).