### PR TITLE
Set "onlyCursors=true" when retrieving asset cursors

### DIFF
--- a/src/main/scala/com/cognite/spark/datasource/AssetsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/AssetsRelation.scala
@@ -61,7 +61,7 @@ class AssetsRelation(apiKey: String,
         }
         asRow(a)
       },
-      getUrl, getUrl, apiKey, project, batchSize, maxRetries, limit)
+      getUrl.param("onlyCursors", "true"), getUrl, apiKey, project, batchSize, maxRetries, limit)
   }
 
   override def insert(df: org.apache.spark.sql.DataFrame, overwrite: scala.Boolean): scala.Unit = {
@@ -83,7 +83,7 @@ class AssetsRelation(apiKey: String,
       })
   }
 
-  def baseAssetsURL(project: String, version: String = "0.5"): Uri = {
+  def baseAssetsURL(project: String, version: String = "0.6"): Uri = {
     uri"https://api.cognitedata.com/api/$version/projects/$project/assets"
   }
 }

--- a/src/test/scala/com/cognite/spark/datasource/BasicUseTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/BasicUseTest.scala
@@ -31,6 +31,17 @@ class BasicUseTest extends FunSuite with SparkTest with CdpConnector {
     assert(res.length == 6)
   }
 
+  test("assets with very small batchSize") {
+    val df = spark.read.format("com.cognite.spark.datasource")
+      .option("apiKey", apiKey)
+      .option("type", "assets")
+      .option("batchSize", "1")
+      .option("limit", "1000")
+      .load()
+
+    assert(df.count() == 6)
+  }
+
   test("smoke test raw") {
     val df = spark.read.format("com.cognite.spark.datasource")
       .option("apiKey", apiKey)


### PR DESCRIPTION
We're already doing this for events, but it's supported and useful for assets as well.