### PR TITLE
Use publicdata API key for read tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,8 @@ podTemplate(label: label,
                                            resourceRequestCpu: '1000m',
                                            resourceLimitCpu: '3800m',
                                            resourceLimitMemory: '3500Mi',
-                                           envVars: [secretEnvVar(key: 'TEST_API_KEY', secretName: 'jetfire-test-api-key', secretKey: 'jetfireTestApiKey.txt'),
+                                           envVars: [secretEnvVar(key: 'TEST_API_KEY_WRITE', secretName: 'jetfire-test-api-key', secretKey: 'jetfireTestApiKey.txt'),
+                                                     secretEnvVar(key: 'TEST_API_KEY_READ', secretName: 'jetfire-test-api-key', secretKey: 'publicDataApiKey'),
                                                      secretEnvVar(key: 'CODECOV_TOKEN', secretName: 'codecov-token-cdp-spark-connector', secretKey: 'token.txt'),
                                                      // /codecov-script/upload-report.sh relies on the following
                                                      // Jenkins and GitHub environment variables.

--- a/README.md
+++ b/README.md
@@ -6,15 +6,30 @@ Writes to all types are done in parallel through asynchronous writes.
 
 ## Build the project with sbt:
 
-The project runs some tests against the jetfiretest2 project, to make them pass set the environment
-variable `TEST_API_KEY` to an API key with access to the `jetfiretest2` project.
-
-For more information about Jetfire see https://cognitedata.atlassian.net/wiki/spaces/cybertron/pages/575602824/Jetfire
-and https://docs.google.com/presentation/d/11oM_Z-NbFAl-ULOvBzG6YmSVRYbPCDuFOnjLed8IuwM
-or go to https://jetfire.cogniteapp.com/ to try it out.
+The project runs read-only integration tests against the Open Industrial Data project. Head over to 
+https://openindustrialdata.com/ to get an API key and store it in the environment variable `TEST_API_KEY_READ`. 
+To run the write integration tests you'll also need to set the environment variable `TEST_API_KEY_WRITE` 
+to an API key to a project where you have write access.
 
 First run `sbt compile` to generate Scala sources for protobuf.
-Then run `sbt assembly` to create `~/path-to-repo/target/scala-2.11/cdp-spark-datasource-*-jar-with-dependencies.jar`.
+
+To run all tests run `sbt test`.
+
+To run groups of tests enter sbt shell mode `sbt>`
+
+To run only the read-only tests run `sbt> testOnly -- -n ReadTest`
+
+To run only the write tests run `sbt> testOnly -- -n WriteTest`
+
+To run all tests except the write tests run `sbt> testOnly -- -l WriteTest`
+
+Run `sbt assembly` to create `~/path-to-repo/target/scala-2.11/cdp-spark-datasource-*-jar-with-dependencies.jar`.
+
+To skip the read/write tests in assembly you can add `test in assembly := {}` to build.sbt, or run:
+
+Windows: `sbt "set test in assembly := {}" assembly`
+
+Linux/macos: `sbt 'set test in assembly := {}' assembly`
 
 
 ## Run it with spark-shell

--- a/src/test/scala/com/cognite/spark/datasource/SparkTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/SparkTest.scala
@@ -1,6 +1,10 @@
 package com.cognite.spark.datasource
 
 import org.apache.spark.sql.SparkSession
+import org.scalatest.Tag
+
+object ReadTest extends Tag("ReadTest")
+object WriteTest extends Tag("WriteTest")
 
 trait SparkTest {
   val spark: SparkSession = SparkSession.builder()

--- a/src/test/scala/com/cognite/spark/datasource/URLTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/URLTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.FunSuite
 
 class URLTest extends FunSuite with SparkTest with CdpConnector {
 
-  val apiKey = System.getenv("TEST_API_KEY")
+  val readApiKey = System.getenv("TEST_API_KEY_READ")
 
   test("verify path encoding of base url") {
     val dataPointsRelation = new DataPointsRelation("", "statøil",
@@ -13,8 +13,8 @@ class URLTest extends FunSuite with SparkTest with CdpConnector {
   }
 
   test("verify that correct project is retrieved from TEST_API_KEY"){
-    val project = getProject(apiKey, Constants.DefaultMaxRetries)
-    assert(project == "jetfiretest2")
+    val project = getProject(readApiKey, Constants.DefaultMaxRetries)
+    assert(project == "publicdata")
   }
 }
 


### PR DESCRIPTION
Split tests to use two API keys, one for reads and one for writes. Tag
tests as ReadTest or WriteTest to enable running groups of tests.

Rewrite some write tests to work with any project where the user has write
access rather than relying on certain tables to exist.