### PR TITLE
Remove dependency on spark-metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val library = (project in file("."))
 
       "org.scalatest" %% "scalatest" % "3.0.5" % Test,
 
-      "com.groupon.dse" % "spark-metrics" % "2.4.0-cognite" % Provided,
+      "org.eclipse.jetty" % "jetty-servlet" % "9.3.24.v20180605" % Provided,
       // TODO: check if we really need spark-hive
       "org.apache.spark" %% "spark-hive" % sparkVersion % Provided
         exclude("org.glassfish.hk2.external", "javax.inject"),

--- a/src/main/scala/com/cognite/spark/datasource/DefaultSource.scala
+++ b/src/main/scala/com/cognite/spark/datasource/DefaultSource.scala
@@ -1,5 +1,6 @@
 package com.cognite.spark.datasource
 
+import org.apache.spark.SparkContext
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.sources.{
   BaseRelation,
@@ -8,6 +9,7 @@ import org.apache.spark.sql.sources.{
   SchemaRelationProvider
 }
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.datasource.MetricsSource
 
 case class RelationConfig(
     apiKey: String,

--- a/src/main/scala/com/cognite/spark/datasource/MetricsSource.scala
+++ b/src/main/scala/com/cognite/spark/datasource/MetricsSource.scala
@@ -1,0 +1,61 @@
+package org.apache.spark.datasource
+
+import scala.collection.JavaConverters._
+import java.util.concurrent.ConcurrentHashMap
+
+import com.codahale.metrics._
+import org.apache.spark._
+
+class MetricsSource(val metricNamespace: String) {
+
+  class LazyWrapper[T](wrapped: => T) {
+    lazy val value = wrapped
+  }
+
+  private def wrap[T](value: => T): LazyWrapper[T] =
+    new LazyWrapper[T](value)
+
+  private def unwrap[T](lazyWrapper: LazyWrapper[T]): T =
+    lazyWrapper.value
+
+  // Keeps track of all the Metric instances that are being published
+  val metricsMap = new ConcurrentHashMap[String, LazyWrapper[Metric]]().asScala
+
+  def getOrElseUpdate(metricName: String, metric: => Metric): Metric = {
+    val wrapped = wrap(metric)
+    metricsMap.putIfAbsent(metricName, wrapped) match {
+      case Some(wrappedMetric) => wrappedMetric.value
+      case None => {
+        registerMetricSource(metricName, wrapped.value)
+        wrapped.value
+      }
+    }
+  }
+
+  def getOrCreateCounter(metricName: String): Counter =
+    getOrElseUpdate(metricName, new Counter).asInstanceOf[Counter]
+
+  /**
+    * Register a [[Metric]] with Spark's [[org.apache.spark.metrics.MetricsSystem]].
+    *
+    * Since updates to an external [[MetricRegistry]] that is already registered with the
+    * [[org.apache.spark.metrics.MetricsSystem]] aren't propagated to Spark's internal [[MetricRegistry]] instance, a new
+    * [[MetricRegistry]] must be created for each new [[Metric]] that needs to be published.
+    *
+    * @param metricName name of the Metric
+    * @param metric [[Metric]] instance to be published
+    */
+  def registerMetricSource(metricName: String, metric: Metric): Unit = {
+    val env = SparkEnv.get
+    env.metricsSystem.registerSource(
+      new Source {
+        override val sourceName = s"${env.conf.getAppId}.$metricNamespace.${env.executorId}."
+        override def metricRegistry: MetricRegistry = {
+          val metrics = new MetricRegistry
+          metrics.register(metricName, metric)
+          metrics
+        }
+      }
+    )
+  }
+}

--- a/src/main/scala/com/cognite/spark/datasource/Source.scala
+++ b/src/main/scala/com/cognite/spark/datasource/Source.scala
@@ -1,0 +1,4 @@
+package org.apache.spark.datasource
+
+// Workaround to use Source since it is private to org.apache.spark
+trait Source extends org.apache.spark.metrics.source.Source

--- a/src/main/scala/com/cognite/spark/datasource/ThreeDModelRevisionSectorsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/ThreeDModelRevisionSectorsRelation.scala
@@ -1,12 +1,12 @@
 package com.cognite.spark.datasource
 
 import com.softwaremill.sttp._
-import org.apache.spark.groupon.metrics.UserMetricsSystem
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Row, SQLContext}
 import org.apache.spark.sql.sources.{BaseRelation, TableScan}
 import org.apache.spark.sql.types.{DataTypes, StructType}
 import io.circe.generic.auto._
+import org.apache.spark.datasource.MetricsSource
 
 case class ThreeDModelRevisionSectorsItem(
     id: Int,
@@ -18,7 +18,7 @@ case class ThreeDModelRevisionSectorsItem(
     threedFiles: Seq[Map[String, Long]])
 
 class ThreeDModelRevisionSectorsRelation(config: RelationConfig, modelId: Long, revisionId: Long)(
-    @transient val sqlContext: SQLContext)
+    val sqlContext: SQLContext)
     extends BaseRelation
     with CdpConnector
     with TableScan
@@ -26,8 +26,9 @@ class ThreeDModelRevisionSectorsRelation(config: RelationConfig, modelId: Long, 
   @transient lazy private val batchSize = config.batchSize.getOrElse(Constants.DefaultBatchSize)
   @transient lazy private val maxRetries = config.maxRetries.getOrElse(Constants.DefaultMaxRetries)
 
+  @transient lazy private val metricsSource = new MetricsSource(config.metricsPrefix)
   @transient lazy private val threeDModelRevisionSectorsRead =
-    UserMetricsSystem.counter(s"${config.metricsPrefix}assets.read")
+    metricsSource.getOrCreateCounter(s"assets.read")
 
   import SparkSchemaHelper._
 


### PR DESCRIPTION
Remove dependency on Groupon's spark-metrics library by implementing this
in cdp-spark-datasource. This is a WIP, currently experiencing concurrency issues with this on jetfire-backend tests.