### PR TITLE
Exclude com.cognite.data protobuf classes from test coverage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,8 @@ lazy val library = (project in file("."))
     },
     assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false),
     mappings in (Compile, packageBin) ++= mappings.in(macroSub, Compile, packageBin).value,
-    mappings in (Compile, packageSrc) ++= mappings.in(macroSub, Compile, packageSrc).value
+    mappings in (Compile, packageSrc) ++= mappings.in(macroSub, Compile, packageSrc).value,
+    coverageExcludedPackages := "com.cognite.data.*"
   )
 
 lazy val fatJar = project.settings(


### PR DESCRIPTION
Doesn't seem to make a difference when building on Jenkins (strange) but it changes coverage from 48% to 71% when I run the build locally on my machine.
