### PR TITLE
Allow base URL to be configured

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ podTemplate(label: label,
                                            resourceLimitMemory: '3500Mi',
                                            envVars: [secretEnvVar(key: 'TEST_API_KEY_WRITE', secretName: 'jetfire-test-api-key', secretKey: 'jetfireTestApiKey.txt'),
                                                      secretEnvVar(key: 'TEST_API_KEY_READ', secretName: 'jetfire-test-api-key', secretKey: 'publicDataApiKey'),
+                                                     secretEnvVar(key: 'TEST_API_KEY_GREENFIELD', secretName: 'jetfire-test-api-key', secretKey: 'greenfieldApiKey'),
                                                      secretEnvVar(key: 'CODECOV_TOKEN', secretName: 'codecov-token-cdp-spark-connector', secretKey: 'token.txt'),
                                                      // /codecov-script/upload-report.sh relies on the following
                                                      // Jenkins and GitHub environment variables.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ See instructions below for examples using different resource types.
 The project runs read-only integration tests against the Open Industrial Data project. Head over to
 https://openindustrialdata.com/ to get an API key and store it in the environment variable `TEST_API_KEY_READ`.
 To run the write integration tests you'll also need to set the environment variable `TEST_API_KEY_WRITE`
-to an API key to a project where you have write access.
+to an API key to a project where you have write access. To run tests against greenfield set the environment
+variable `TEST_API_KEY_GREENFIELD` to an API key with read access to the project cdp-spark-datasource-test. 
 
 ### Setting up
 First run `sbt compile` to generate Scala sources for protobuf.
@@ -47,6 +48,8 @@ To run groups of tests enter sbt shell mode `sbt>`
 To run only the read-only tests run `sbt> testOnly -- -n ReadTest`
 
 To run only the write tests run `sbt> testOnly -- -n WriteTest`
+
+To run only the greenfield tests run `sbt> testOnly -- -n GreenfieldTest`
 
 To run all tests except the write tests run `sbt> testOnly -- -l WriteTest`
 

--- a/src/main/scala/com/cognite/spark/datasource/AssetsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/AssetsRelation.scala
@@ -83,7 +83,7 @@ class AssetsRelation(config: RelationConfig, assetPath: Option[String])(val sqlC
   }
 
   def baseAssetsURL(project: String, version: String = "0.6"): Uri =
-    uri"https://api.cognitedata.com/api/$version/projects/$project/assets"
+    uri"${config.baseUrl}/api/$version/projects/$project/assets"
 }
 
 object AssetsRelation {

--- a/src/main/scala/com/cognite/spark/datasource/CdpConnector.scala
+++ b/src/main/scala/com/cognite/spark/datasource/CdpConnector.scala
@@ -28,14 +28,14 @@ case class CdpApiException(url: Uri, code: Int, message: String)
 trait CdpConnector {
   import CdpConnector._
 
-  def getProject(apiKey: String, maxRetries: Int): String = {
-    val loginStatusUrl = uri"https://api.cognitedata.com/login/status"
+  def getProject(apiKey: String, maxRetries: Int, baseUrl: String): String = {
+    val loginStatusUrl = uri"$baseUrl/login/status"
     val jsonResult = getJson[Data[Login]](apiKey, loginStatusUrl, maxRetries)
     jsonResult.unsafeRunSync().data.project
   }
 
-  def baseUrl(project: String, version: String = "0.5"): Uri =
-    uri"https://api.cognitedata.com/api/$version/projects/$project"
+  def baseUrl(project: String, version: String, baseUrl: String): Uri =
+    uri"$baseUrl/api/$version/projects/$project"
 
   def getJson[A: Decoder](apiKey: String, url: Uri, maxRetries: Int): IO[A] = {
     val result = sttp

--- a/src/main/scala/com/cognite/spark/datasource/Constants.scala
+++ b/src/main/scala/com/cognite/spark/datasource/Constants.scala
@@ -9,4 +9,5 @@ object Constants {
   val DefaultDataPointsAggregationBatchSize = 10000
   val DefaultInitialRetryDelay = 150.millis
   val DefaultMaxBackoffDelay = 120.seconds
+  val DefaultBaseUrl = "https://api.cognitedata.com"
 }

--- a/src/main/scala/com/cognite/spark/datasource/DataPointsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/DataPointsRelation.scala
@@ -201,7 +201,7 @@ class DataPointsRelation(config: RelationConfig, suppliedSchema: Option[StructTy
 
   def getLatestDataPoint(timeSeriesName: String): Option[DataPoint] = {
     val url =
-      uri"https://api.cognitedata.com/api/0.5/projects/${config.project}/timeseries/latest/$timeSeriesName"
+      uri"${config.baseUrl}/api/0.5/projects/${config.project}/timeseries/latest/$timeSeriesName"
     val getLatest = sttp
       .header("Accept", "application/json")
       .header("api-key", config.apiKey)
@@ -379,5 +379,5 @@ class DataPointsRelation(config: RelationConfig, suppliedSchema: Option[StructTy
   }
 
   def baseDataPointsUrl(project: String): Uri =
-    uri"${baseUrl(project, "0.5")}/timeseries/data"
+    uri"${baseUrl(project, "0.5", Constants.DefaultBaseUrl)}/timeseries/data"
 }

--- a/src/main/scala/com/cognite/spark/datasource/DefaultSource.scala
+++ b/src/main/scala/com/cognite/spark/datasource/DefaultSource.scala
@@ -18,7 +18,8 @@ case class RelationConfig(
     limit: Option[Int],
     maxRetries: Option[Int],
     collectMetrics: Boolean,
-    metricsPrefix: String)
+    metricsPrefix: String,
+    baseUrl: String)
 
 class DefaultSource
     extends RelationProvider
@@ -57,8 +58,10 @@ class DefaultSource
 
   def parseRelationConfig(parameters: Map[String, String]): RelationConfig = {
     val maxRetries = toPositiveInt(parameters, "maxRetries")
+    val baseUrl = parameters.getOrElse("baseUrl", Constants.DefaultBaseUrl)
     val apiKey = parameters.getOrElse("apiKey", sys.error("ApiKey must be specified."))
-    val project = getProject(apiKey, maxRetries.getOrElse(Constants.DefaultMaxRetries))
+    val project =
+      getProject(apiKey, maxRetries.getOrElse(Constants.DefaultMaxRetries), baseUrl)
     val batchSize = toPositiveInt(parameters, "batchSize")
     val limit = toPositiveInt(parameters, "limit")
     val metricsPrefix = parameters.get("metricsPrefix") match {
@@ -66,7 +69,15 @@ class DefaultSource
       case None => ""
     }
     val collectMetrics = toBoolean(parameters, "collectMetrics")
-    RelationConfig(apiKey, project, batchSize, limit, maxRetries, collectMetrics, metricsPrefix)
+    RelationConfig(
+      apiKey,
+      project,
+      batchSize,
+      limit,
+      maxRetries,
+      collectMetrics,
+      metricsPrefix,
+      baseUrl)
   }
 
   // scalastyle:off cyclomatic.complexity method.length

--- a/src/main/scala/com/cognite/spark/datasource/EventsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/EventsRelation.scala
@@ -133,10 +133,10 @@ class EventsRelation(config: RelationConfig)(@transient val sqlContext: SQLConte
   }
 
   def baseEventsURL(project: String, version: String = "0.6"): Uri =
-    uri"https://api.cognitedata.com/api/$version/projects/$project/events"
+    uri"${config.baseUrl}/api/$version/projects/$project/events"
 
   def baseEventsURLOld(project: String): Uri =
     // TODO: API is failing with "Invalid field - items[0].starttime - expected an object but got number" in 0.6
     // That's why we need 0.5 support, however should be removed when fixed
-    uri"https://api.cognitedata.com/api/0.5/projects/$project/events"
+    uri"${config.baseUrl}/api/0.5/projects/$project/events"
 }

--- a/src/main/scala/com/cognite/spark/datasource/FilesRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/FilesRelation.scala
@@ -58,5 +58,5 @@ class FilesRelation(config: RelationConfig)(val sqlContext: SQLContext)
   }
 
   def baseFilesUrl(project: String, version: String = "0.6"): Uri =
-    uri"https://api.cognitedata.com/api/$version/projects/$project/files"
+    uri"${config.baseUrl}/api/$version/projects/$project/files"
 }

--- a/src/main/scala/com/cognite/spark/datasource/RawTableRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/RawTableRelation.scala
@@ -136,7 +136,7 @@ class RawTableRelation(
   }
 
   def baseRawTableURL(project: String, database: String, table: String): Uri =
-    uri"${baseUrl(project, "0.5")}/raw/$database/$table"
+    uri"${baseUrl(project, "0.5", config.baseUrl)}/raw/$database/$table"
 }
 
 object RawTableRelation {

--- a/src/main/scala/com/cognite/spark/datasource/ThreeDModelRevisionMappingsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/ThreeDModelRevisionMappingsRelation.scala
@@ -51,5 +51,5 @@ class ThreeDModelRevisionMappingsRelation(config: RelationConfig, modelId: Long,
   }
 
   def base3dModelRevisionMappingsUrl(project: String, version: String = "0.6"): Uri =
-    uri"https://api.cognitedata.com/api/$version/projects/$project/3d/models/$modelId/revisions/$revisionId/mappings"
+    uri"${config.baseUrl}/api/$version/projects/$project/3d/models/$modelId/revisions/$revisionId/mappings"
 }

--- a/src/main/scala/com/cognite/spark/datasource/ThreeDModelRevisionNodesRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/ThreeDModelRevisionNodesRelation.scala
@@ -56,5 +56,5 @@ class ThreeDModelRevisionNodesRelation(config: RelationConfig, modelId: Long, re
   }
 
   def base3dModelRevisionMappingsUrl(project: String, version: String = "0.6"): Uri =
-    uri"https://api.cognitedata.com/api/$version/projects/$project/3d/models/$modelId/revisions/$revisionId/nodes"
+    uri"${config.baseUrl}/api/$version/projects/$project/3d/models/$modelId/revisions/$revisionId/nodes"
 }

--- a/src/main/scala/com/cognite/spark/datasource/ThreeDModelRevisionSectorsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/ThreeDModelRevisionSectorsRelation.scala
@@ -55,5 +55,5 @@ class ThreeDModelRevisionSectorsRelation(config: RelationConfig, modelId: Long, 
   }
 
   def baseThreeDModelReviewSectorsUrl(project: String, version: String = "0.6"): Uri =
-    uri"https://api.cognitedata.com/api/$version/projects/$project/3d/models/$modelId/revisions/$revisionId/sectors"
+    uri"${config.baseUrl}/api/$version/projects/$project/3d/models/$modelId/revisions/$revisionId/sectors"
 }

--- a/src/main/scala/com/cognite/spark/datasource/ThreeDModelRevisionsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/ThreeDModelRevisionsRelation.scala
@@ -59,5 +59,5 @@ class ThreeDModelRevisionsRelation(config: RelationConfig, modelId: Long)(
   }
 
   def base3dModelRevisionsUrl(project: String, version: String = "0.6"): Uri =
-    uri"https://api.cognitedata.com/api/$version/projects/$project/3d/models/$modelId/revisions"
+    uri"${config.baseUrl}/api/$version/projects/$project/3d/models/$modelId/revisions"
 }

--- a/src/main/scala/com/cognite/spark/datasource/ThreeDModelsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/ThreeDModelsRelation.scala
@@ -45,5 +45,5 @@ class ThreeDModelsRelation(config: RelationConfig)(val sqlContext: SQLContext)
   }
 
   def base3dModelsUrl(project: String, version: String = "0.6"): Uri =
-    uri"https://api.cognitedata.com/api/$version/projects/$project/3d/models"
+    uri"${config.baseUrl}/api/$version/projects/$project/3d/models"
 }

--- a/src/main/scala/com/cognite/spark/datasource/TimeSeriesRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/TimeSeriesRelation.scala
@@ -97,5 +97,5 @@ class TimeSeriesRelation(config: RelationConfig)(val sqlContext: SQLContext)
   }
 
   def baseTimeSeriesUrl(project: String): Uri =
-    uri"${baseUrl(project)}/timeseries"
+    uri"${baseUrl(project, "0.5", config.baseUrl)}/timeseries"
 }

--- a/src/test/scala/com/cognite/spark/datasource/BaseUrlTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/BaseUrlTest.scala
@@ -1,0 +1,25 @@
+package com.cognite.spark.datasource
+
+import org.scalatest.FlatSpec
+
+class BaseUrlTest extends FlatSpec with SparkTest {
+  private val greenfieldApiKey = System.getenv("TEST_API_KEY_GREENFIELD")
+  private val readApiKey = System.getenv("TEST_API_KEY_READ")
+
+  it should "read different files metadata from greenfield and api" taggedAs GreenfieldTest in {
+    val dfGreenfield = spark.read
+      .format("com.cognite.spark.datasource")
+      .option("apiKey", greenfieldApiKey)
+      .option("type", "files")
+      .option("baseUrl", "https://greenfield.cognitedata.com")
+      .load()
+
+    val dfApi = spark.read
+      .format("com.cognite.spark.datasource")
+      .option("apiKey", readApiKey)
+      .option("type", "files")
+      .load()
+
+    assert(dfGreenfield.count != dfApi.count)
+  }
+}

--- a/src/test/scala/com/cognite/spark/datasource/BasicUseTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/BasicUseTest.scala
@@ -210,7 +210,7 @@ class BasicUseTest extends FunSuite with SparkTest with CdpConnector {
   def cleanupEvents(source: String): Unit = {
     import io.circe.generic.auto._
 
-    val project = getProject(writeApiKey, Constants.DefaultMaxRetries)
+    val project = getProject(writeApiKey, Constants.DefaultMaxRetries, Constants.DefaultBaseUrl)
 
     val events = get[EventItem](
       writeApiKey,

--- a/src/test/scala/com/cognite/spark/datasource/SparkTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/SparkTest.scala
@@ -7,6 +7,7 @@ import org.scalatest.Tag
 
 object ReadTest extends Tag("ReadTest")
 object WriteTest extends Tag("WriteTest")
+object GreenfieldTest extends Tag("GreenfieldTest")
 
 trait SparkTest extends CdpConnector {
   val spark: SparkSession = SparkSession.builder()
@@ -16,7 +17,7 @@ trait SparkTest extends CdpConnector {
     .getOrCreate()
 
   def getThreeDModelIdAndRevisionId(apiKey: String): (String, String) = {
-    val project = getProject(apiKey, 10)
+    val project = getProject(apiKey, 10, Constants.DefaultBaseUrl)
 
     val modelUrl = uri"https://api.cognitedata.com/api/0.6/projects/$project/3d/models"
     val models = getJson[Data[Items[ModelItem]]](apiKey, modelUrl, 10).unsafeRunSync()

--- a/src/test/scala/com/cognite/spark/datasource/URLTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/URLTest.scala
@@ -8,12 +8,13 @@ class URLTest extends FunSuite with SparkTest with CdpConnector {
 
   test("verify path encoding of base url") {
     val dataPointsRelation = new DataPointsRelation(RelationConfig("", "statøil", None, None,
-      None, false, ""), None)(spark.sqlContext)
-    assert("https://api.cognitedata.com/api/0.5/projects/stat%C3%B8il/timeseries/data" == dataPointsRelation.baseDataPointsUrl("statøil").toString)
+      None, false, "","https://api.cognitedata.com"), None)(spark.sqlContext)
+    assert("https://api.cognitedata.com/api/0.5/projects/stat%C3%B8il/timeseries/data"
+      == dataPointsRelation.baseDataPointsUrl("statøil").toString)
   }
 
   test("verify that correct project is retrieved from TEST_API_KEY"){
-    val project = getProject(readApiKey, Constants.DefaultMaxRetries)
+    val project = getProject(readApiKey, Constants.DefaultMaxRetries, Constants.DefaultBaseUrl)
     assert(project == "publicdata")
   }
 }


### PR DESCRIPTION
Refactor code to let users specify other base URLs than
api.cognitedata.com, such as greenfield.cognitedata.com.