### PR TITLE
Only depend on macroSub internally

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ lazy val macroSub = (project in file("macro"))
   )
 
 lazy val library = (project in file("."))
-  .dependsOn(macroSub)
+  .dependsOn(macroSub % "compile-internal, test-internal")
   .settings(
     commonSettings,
     name := "cdp-spark-datasource",


### PR DESCRIPTION
To fix issues where the consumer of the library get errors about 'macroSub' not found.

Based on https://www.scala-sbt.org/1.0/docs/Macro-Projects.html#Distribution

Commited with @Tapped 