### PR TITLE
Include all fields from API

### DIFF
--- a/src/main/scala/com/cognite/spark/datasource/AssetsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/AssetsRelation.scala
@@ -17,13 +17,31 @@ import scala.concurrent.ExecutionContext
 case class PostAssetsDataItems[A](items: Seq[A])
 
 case class AssetsItem(
-    name: String,
+    id: Long,
+    path: Option[Seq[Long]],
+    depth: Option[Long],
+    name: Option[String],
     parentId: Option[Long],
     description: Option[String],
     metadata: Option[Map[String, Option[String]]],
-    id: Long)
+    source: Option[String],
+    sourceId: Option[String],
+    createdTime: Long,
+    lastUpdatedTime: Long)
 
-case class PostAssetsItem(name: String, description: String, metadata: Map[String, String])
+case class PostAssetsItem(
+    name: String,
+    refId: Option[String],
+    parentName: Option[String],
+    parentRefId: Option[String],
+    parentId: Option[Long],
+    description: Option[String],
+    source: Option[String],
+    sourceId: Option[String],
+    metadata: Option[Map[String, Option[String]]],
+    createdTime: Long,
+    lastUpdatedTime: Long
+)
 
 class AssetsRelation(config: RelationConfig, assetPath: Option[String])(val sqlContext: SQLContext)
     extends CdpRelation[AssetsItem](config, "assets")

--- a/src/main/scala/com/cognite/spark/datasource/CdpRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/CdpRelation.scala
@@ -10,6 +10,15 @@ import org.apache.spark.sql.{Row, SQLContext}
 import scala.reflect._
 import scala.reflect.runtime.universe._
 
+case class Setter[A](set: A, setNull: Boolean)
+object Setter {
+  def apply[A](set: Option[A]): Option[Setter[A]] =
+    set match {
+      case None => None
+      case _ => Some(new Setter(set.get, false))
+    }
+}
+
 abstract class CdpRelation[T: DerivedDecoder: TypeTag: ClassTag](
     config: RelationConfig,
     shortName: String)

--- a/src/main/scala/com/cognite/spark/datasource/TimeSeriesRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/TimeSeriesRelation.scala
@@ -15,14 +15,6 @@ import scala.concurrent.ExecutionContext
 case class PostTimeSeriesDataItems[A](items: Seq[A])
 case class TimeSeriesConflict(notFound: Seq[Long])
 case class TimeSeriesNotFound(notFound: Seq[String])
-case class Setter[A](set: A, setNull: Boolean)
-object Setter {
-  def apply[A](set: Option[A]): Option[Setter[A]] =
-    set match {
-      case None => None
-      case _ => Some(new Setter(set.get, false))
-    }
-}
 
 case class TimeSeriesItem(
     name: String,

--- a/src/test/scala/com/cognite/spark/datasource/BasicUseTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/BasicUseTest.scala
@@ -106,7 +106,9 @@ class BasicUseTest extends FunSuite with SparkTest with CdpConnector {
                  |map('foo', 'bar', 'nullValue', null) as metadata,
                  |null as assetIds,
                  |'nulltest' as source,
-                 |null as sourceId
+                 |null as sourceId,
+                 |0 as createdTime,
+                 |0 as lastUpdatedTime
      """.stripMargin)
       .write
       .insertInto("destinationEvent")
@@ -154,7 +156,9 @@ class BasicUseTest extends FunSuite with SparkTest with CdpConnector {
        |bigint(0) as id,
        |map("foo", null, "bar", "test") as metadata,
        |"$source" as source,
-       |sourceId
+       |sourceId,
+       |createdTime,
+       |lastUpdatedTime
        |from sourceEvent
        |limit 100
      """.stripMargin)
@@ -179,7 +183,9 @@ class BasicUseTest extends FunSuite with SparkTest with CdpConnector {
        |bigint(0) as id,
        |metadata,
        |"$source" as source,
-       |sourceId
+       |sourceId,
+       |createdTime,
+       |lastUpdatedTime
        |from sourceEvent
      """.stripMargin)
       .select(destinationDf.columns.map(col): _*)


### PR DESCRIPTION
Add some fields from data sources that have been left out. Events used
0.5 for updates, that had to be upgraded to 0.6 to allow for more fields,
which also gave need for the UpdateEventItem.