### PR TITLE
Add support for writing in save mode

### DIFF
--- a/src/main/scala/com/cognite/spark/datasource/CdpRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/CdpRelation.scala
@@ -1,6 +1,6 @@
 package com.cognite.spark.datasource
+import cats.effect.IO
 import org.apache.spark.sql.sources.{BaseRelation, TableScan}
-import io.circe.generic.auto._
 import io.circe.generic.decoding.DerivedDecoder
 import com.softwaremill.sttp.Uri
 import org.apache.spark.datasource.MetricsSource
@@ -49,4 +49,21 @@ abstract class CdpRelation[T: DerivedDecoder: TypeTag: ClassTag](
   def listUrl(): Uri
 
   def cursors(): Iterator[(Option[String], Option[Int])] = NextCursorIterator(listUrl(), config)
+
+  def insert(rows: Seq[Row]): IO[Unit] =
+    throw new IllegalArgumentException(
+      s"""${shortName} does not support the "onconflict" option "abort".""")
+
+  def upsert(rows: Seq[Row]): IO[Unit] =
+    throw new IllegalArgumentException(
+      s"""${shortName} does not support the "onconflict" option "upsert".""")
+
+  def update(rows: Seq[Row]): IO[Unit] =
+    throw new IllegalArgumentException(
+      s"""${shortName} does not support the "onconflict" option "update".""")
+
+  def delete(rows: Seq[Row]): IO[Unit] =
+    throw new IllegalArgumentException(
+      s"""${shortName} does not support the "onconflict" option "delete".""")
+
 }

--- a/src/test/scala/com/cognite/spark/datasource/CdpRddTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/CdpRddTest.scala
@@ -13,7 +13,7 @@ import io.circe.parser.decode
 case class Number(number: Int)
 
 class CdpRddTest extends FlatSpec with Matchers with SparkTest {
-  val defaultConfig = RelationConfig("apiKey", "project", None, None, 1, 2, collectMetrics = false, "", "https://api.cognitedata.com")
+  val defaultConfig = RelationConfig("apiKey", "project", None, None, 1, 2, collectMetrics = false, "", "https://api.cognitedata.com", OnConflict.ABORT)
   class TestRdd(config: RelationConfig, nextCursorIterator: Iterator[(Option[String], Option[Int])])
     extends CdpRdd[Number](spark.sparkContext, (n: Number) => Row(n.number),
     uri"http://localhost/api",

--- a/src/test/scala/com/cognite/spark/datasource/DataPointsRelationTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/DataPointsRelationTest.scala
@@ -241,6 +241,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with SparkTest {
       .load()
     destinationDf.createTempView("destinationDatapoints")
 
+    spark.sparkContext.setLogLevel("OFF") // Removing expected Spark executor Errors from the console
     val e = intercept[SparkException] {
       spark.sql(s"""
                    |select "timeseries_does_not_exist" as name,
@@ -256,5 +257,6 @@ class DataPointsRelationTest extends FlatSpec with Matchers with SparkTest {
     e.getCause shouldBe a[CdpApiException]
     val cdpApiException = e.getCause.asInstanceOf[CdpApiException]
     assert(cdpApiException.code == 404)
+    spark.sparkContext.setLogLevel("WARN")
   }
 }

--- a/src/test/scala/com/cognite/spark/datasource/EventsRelationTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/EventsRelationTest.scala
@@ -2,6 +2,7 @@ package com.cognite.spark.datasource
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions.col
 import com.softwaremill.sttp._
+import org.apache.spark.SparkException
 import org.scalatest.{FlatSpec, Matchers}
 
 class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
@@ -72,12 +73,22 @@ class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
     .select(col("description"))
     .collect()
 
+  val destinationDf: DataFrame = spark.read.format("com.cognite.spark.datasource")
+    .option("apiKey", writeApiKey)
+    .option("type", "events")
+    .load()
+  destinationDf.createOrReplaceTempView("destinationEvent")
+
+  val sourceDf: DataFrame = spark.read.format("com.cognite.spark.datasource")
+    .option("apiKey", readApiKey)
+    .option("type", "events")
+    .option("limit", "1000")
+    .option("partitions", "1")
+    .load()
+  sourceDf.createOrReplaceTempView("sourceEvent")
+  sourceDf.cache()
+
   it should "allow null values for all event fields" taggedAs WriteTest in {
-    val destinationDf = spark.read.format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
-      .option("type", "events")
-      .load()
-    destinationDf.createOrReplaceTempView("destinationEvent")
 
     val source = "nulltest"
     cleanupEvents(source)
@@ -103,33 +114,17 @@ class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
       .write
       .insertInto("destinationEvent")
 
-    val rows = retryWhile[DataFrame](
-      spark.sql(s"""select * from destinationEvent where source = "$source""""),
-      rows => rows.count == 0)
-    assert(rows.count() == 1)
+    val rows = retryWhile[Array[Row]](
+      spark.sql(s"""select * from destinationEvent where source = "$source"""").collect,
+      rows => rows.length < 1)
+    assert(rows.length == 1)
     val storedMetadata = rows.head.getAs[Map[String, String]](6)
     assert(storedMetadata.size == 1)
     assert(storedMetadata.get("foo").contains("bar"))
   }
 
   it should "support upserts" taggedAs WriteTest in {
-    val sourceDf = spark.read.format("com.cognite.spark.datasource")
-      .option("apiKey", readApiKey)
-      .option("type", "events")
-      .option("limit", "1000")
-      .option("partitions", "1")
-      .load()
-
-    val destinationDf = spark.read.format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
-      .option("type", "events")
-      .option("partitions", "1")
-      .load()
-    destinationDf.createOrReplaceTempView("destinationEvent")
-
     val source = "spark-events-test"
-    sourceDf.createTempView("sourceEvent")
-    sourceDf.cache()
 
     // Cleanup events
     cleanupEvents(source)
@@ -190,10 +185,175 @@ class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
     assert(descriptionsAfterUpdate.length == 1000)
     assert(descriptionsAfterUpdate.map(_.getString(0)).forall(_ == "foo"))
 
-    val dfWithCorrectAssetIds = retryWhile[DataFrame](
-      spark.sql("select * from destinationEvent where assetIds = array(2091657868296883)"),
-      rows => rows.count < 1000)
-    assert(dfWithCorrectAssetIds.count == 1000)
+    val dfWithCorrectAssetIds = retryWhile[Array[Row]](
+      spark.sql("select * from destinationEvent where assetIds = array(2091657868296883)").collect,
+      rows => rows.length < 1000)
+    assert(dfWithCorrectAssetIds.length == 1000)
+  }
+
+  it should "allow inserts in savemode" taggedAs WriteTest in {
+    val source = "spark-savemode-insert-test"
+
+    // Cleanup events
+    cleanupEvents(source)
+    val eventDescriptionsReturned = retryWhile[Array[Row]](eventDescriptions(source),
+      rows => rows.nonEmpty)
+    assert(eventDescriptionsReturned.isEmpty)
+
+    // Test inserts
+    spark.sql(s"""
+                 |select "foo" as description,
+                 |startTime,
+                 |endTime,
+                 |type,
+                 |subtype,
+                 |array(8031965690878131) as assetIds,
+                 |bigint(0) as id,
+                 |metadata,
+                 |"$source" as source,
+                 |sourceId,
+                 |createdTime,
+                 |lastUpdatedTime
+                 |from sourceEvent
+                 |limit 100
+     """.stripMargin)
+      .write
+      .format("com.cognite.spark.datasource")
+      .option("apiKey", writeApiKey)
+      .option("type", "events")
+      .save
+
+    val dfWithSourceInsertTest = retryWhile[Array[Row]](
+      spark.sql(s"select * from destinationEvent where source = '$source'").collect,
+      df => df.length < 100
+    )
+    assert(dfWithSourceInsertTest.length == 100)
+
+    // Trying to insert existing rows should throw a CdpApiException
+    spark.sparkContext.setLogLevel("OFF") // Removing expected Spark executor Errors from the console
+    val e = intercept[SparkException] {
+      spark.sql(
+        s"""
+           |select "foo" as description,
+           |startTime,
+           |endTime,
+           |type,
+           |subtype,
+           |array(8031965690878131) as assetIds,
+           |bigint(0) as id,
+           |metadata,
+           |"$source" as source,
+           |sourceId,
+           |createdTime,
+           |lastUpdatedTime
+           |from sourceEvent
+           |limit 100
+     """.stripMargin)
+        .write
+        .format("com.cognite.spark.datasource")
+        .option("apiKey", writeApiKey)
+        .option("type", "events")
+        .save
+    }
+    e.getCause shouldBe a[CdpApiException]
+    val cdpApiException = e.getCause.asInstanceOf[CdpApiException]
+    assert(cdpApiException.code == 409)
+    spark.sparkContext.setLogLevel("WARN")
+  }
+
+  it should "allow updates in savemode" taggedAs WriteTest in {
+    val source = "spark-savemode-updates-test"
+
+    // Cleanup old events
+    cleanupEvents(source)
+    val dfWithUpdatesAsSource = retryWhile[Array[Row]](
+      spark.sql(s"select * from destinationEvent where source = '$source'")collect,
+      df => df.length > 0)
+    assert(dfWithUpdatesAsSource.length == 0)
+
+    // Insert some test data
+    spark.sql(s"""
+             |select "bar" as description,
+             |startTime,
+             |endTime,
+             |type,
+             |subtype,
+             |null as assetIds,
+             |bigint(0) as id,
+             |map("foo", null, "bar", "test") as metadata,
+             |"$source" as source,
+             |sourceId,
+             |createdTime,
+             |lastUpdatedTime
+             |from sourceEvent
+             |limit 100
+     """.stripMargin)
+      .select(destinationDf.columns.map(col): _*)
+      .write
+      .insertInto("destinationEvent")
+
+    // Update the data
+    spark.sql(
+      s"""
+         |select "bar" as description,
+         |startTime,
+         |endTime,
+         |type,
+         |subtype,
+         |assetIds,
+         |id,
+         |metadata,
+         |source,
+         |sourceId,
+         |createdTime,
+         |lastUpdatedTime
+         |from destinationEvent
+         |where source = '$source'
+      """.stripMargin)
+      .select(destinationDf.columns.map(col): _*)
+      .write
+      .option("onconflict", "update")
+      .insertInto("destinationEvent")
+
+    // Check if update worked
+    val descriptionsAfterUpdate = retryWhile[Array[Row]](eventDescriptions(source),
+      rows => rows.length < 100)
+    assert(descriptionsAfterUpdate.length == 100)
+    assert(descriptionsAfterUpdate.map(_.getString(0)).forall(_ == "bar"))
+
+    // Trying to update non-existing ids should throw a 400 CdpApiException
+    spark.sparkContext.setLogLevel("OFF") // Removing expected Spark executor Errors from the console
+    val e = intercept[SparkException] {
+    // Update the data
+    spark.sql(
+      s"""
+         |select "bar" as description,
+         |startTime,
+         |endTime,
+         |type,
+         |subtype,
+         |assetIds,
+         |bigint(1) as id,
+         |metadata,
+         |source,
+         |sourceId,
+         |createdTime,
+         |lastUpdatedTime
+         |from destinationEvent
+         |where source = '$source'
+         |limit 1
+        """.stripMargin)
+      .write
+      .format("com.cognite.spark.datasource")
+      .option("apiKey", writeApiKey)
+      .option("type", "events")
+      .option("onconflict", "update")
+      .save
+      }
+      e.getCause shouldBe a[CdpApiException]
+      val cdpApiException = e.getCause.asInstanceOf[CdpApiException]
+      assert(cdpApiException.code == 400)
+      spark.sparkContext.setLogLevel("WARN")
   }
 
   def cleanupEvents(source: String): Unit = {

--- a/src/test/scala/com/cognite/spark/datasource/StringDataPointsRelationTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/StringDataPointsRelationTest.scala
@@ -127,6 +127,7 @@ class StringDataPointsRelationTest extends FlatSpec with Matchers with SparkTest
       .load()
     destinationDf.createTempView("destinationStringDatapoints")
 
+    spark.sparkContext.setLogLevel("OFF") // Removing expected Spark executor Errors from the console
     val e = intercept[SparkException] {
       spark.sql(s"""
                    |select "timeseries_does_not_exist" as name,
@@ -140,5 +141,6 @@ class StringDataPointsRelationTest extends FlatSpec with Matchers with SparkTest
     e.getCause shouldBe a[CdpApiException]
     val cdpApiException = e.getCause.asInstanceOf[CdpApiException]
     assert(cdpApiException.code == 404)
+    spark.sparkContext.setLogLevel("WARN")
   }
 }

--- a/src/test/scala/com/cognite/spark/datasource/TimeSeriesUpsertTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/TimeSeriesUpsertTest.scala
@@ -1,35 +1,36 @@
 package com.cognite.spark.datasource
 
 import org.apache.spark.sql.{DataFrame, Row}
-import org.scalatest.FlatSpec
+import org.scalatest.{FlatSpec, Matchers}
 import org.apache.spark.sql.functions.col
 import com.softwaremill.sttp._
+import org.apache.spark.SparkException
 
-class TimeSeriesUpsertTest extends FlatSpec with SparkTest {
+class TimeSeriesUpsertTest extends FlatSpec with Matchers with SparkTest {
   val readApiKey = System.getenv("TEST_API_KEY_READ")
   val writeApiKey = System.getenv("TEST_API_KEY_WRITE")
+  val sourceDf = spark.read
+    .format("com.cognite.spark.datasource")
+    .option("apiKey", writeApiKey)
+    .option("type", "timeseries")
+    .load()
+  sourceDf.createOrReplaceTempView("sourceTimeSeries")
 
   it should "successfully both update and insert time series" taggedAs WriteTest in {
     val initialDescription = "'post testing'"
     val updatedDescription = "'upsert testing'"
-
-    val sourceDf = spark.read
-      .format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
-      .option("type", "timeseries")
-      .load()
-    sourceDf.createOrReplaceTempView("sourceTimeSeries")
+    val testUnit = "test data"
 
     // Clean up any old test data
     val namesDf =
-      spark.sql(s"""select name from sourceTimeSeries where unit = 'test data'""")
+      spark.sql(s"""select name from sourceTimeSeries where unit = '$testUnit'""")
     val namesList = namesDf.rdd.map(r => r.getAs[String](0)).collect().toList
     cleanupTimeSeries(namesList)
 
-    val testTimeSeriesAfterCleanup = retryWhile[DataFrame](
-      spark.sql(s"""select * from sourceTimeSeries where unit = 'test data'"""),
-      df => df.count > 0)
-    assert(testTimeSeriesAfterCleanup.count == 0)
+    val testTimeSeriesAfterCleanup = retryWhile[Array[Row]](
+      spark.sql(s"""select * from sourceTimeSeries where unit = 'test data'""").collect,
+      df => df.length > 0)
+    assert(testTimeSeriesAfterCleanup.length == 0)
 
     // Insert new time series test data
     spark
@@ -53,10 +54,10 @@ class TimeSeriesUpsertTest extends FlatSpec with SparkTest {
       .insertInto("sourceTimeSeries")
 
     // Check if post worked
-    val initialDescriptionsAfterPost = retryWhile[DataFrame](
-      spark.sql(s"""select * from sourceTimeSeries where description = $initialDescription"""),
-      df => df.count < 5)
-    assert(initialDescriptionsAfterPost.count == 5)
+    val initialDescriptionsAfterPost = retryWhile[Array[Row]](
+      spark.sql(s"""select * from sourceTimeSeries where description = $initialDescription""").collect,
+      df => df.length < 5)
+    assert(initialDescriptionsAfterPost.length == 5)
 
     // Upsert time series data
     spark
@@ -80,17 +81,203 @@ class TimeSeriesUpsertTest extends FlatSpec with SparkTest {
       .insertInto("sourceTimeSeries")
 
     // Check if upsert worked
-    val updatedDescriptionsAfterUpsert = retryWhile[DataFrame](
-      spark.sql(s"""select * from sourceTimeSeries where description = $updatedDescription"""),
-      df => df.count < 5)
-    assert(updatedDescriptionsAfterUpsert.count == 5)
+    val updatedDescriptionsAfterUpsert = retryWhile[Array[Row]](
+      spark.sql(s"""select * from sourceTimeSeries where description = $updatedDescription""").collect,
+      df => df.length < 5)
+    assert(updatedDescriptionsAfterUpsert.length == 5)
 
-    val initialDescriptionsAfterUpsert = retryWhile[DataFrame](
-      spark.sql(s"""select * from sourceTimeSeries where description = $initialDescription"""),
-      df => df.count > 0)
-    assert(initialDescriptionsAfterUpsert.count == 0)
+    val initialDescriptionsAfterUpsert = retryWhile[Array[Row]](
+      spark.sql(s"""select * from sourceTimeSeries where description = $initialDescription""").collect,
+      df => df.length > 0)
+    assert(initialDescriptionsAfterUpsert.length == 0)
   }
 
+  it should "support abort in savemode" taggedAs WriteTest in {
+    val insertDescription = "spark-insert-test"
+    val saveModeUnit = "spark-savemode-test"
+
+    // Clean up any old test data
+    val namesDf =
+      spark.sql(s"""select name from sourceTimeSeries where unit = '$saveModeUnit'""")
+    val namesList = namesDf.rdd.map(r => r.getAs[String](0)).collect().toList
+    cleanupTimeSeries(namesList)
+
+    // Insert new time series test data
+    spark.sql(
+      s"""
+         |select '$insertDescription' as description,
+         |isString,
+         |concat('TEST_', name) as name,
+         |metadata,
+         |'$saveModeUnit' as unit,
+         |NULL as assetId,
+         |isStep,
+         |cast(array() as array<long>) as securityCategories,
+         |createdTime,
+         |lastUpdatedTime
+         |from sourceTimeSeries
+         |where unit = 'publicdata'
+     """.stripMargin)
+      .write
+      .format("com.cognite.spark.datasource")
+      .option("apiKey", writeApiKey)
+      .option("type", "timeseries")
+      .save
+
+    val dfWithDescriptionInsertTest = retryWhile[Array[Row]](
+      spark.sql(s"select * from sourceTimeSeries where description = '$insertDescription'").collect,
+      df => df.length < 5
+    )
+    assert(dfWithDescriptionInsertTest.length == 5)
+
+    // Trying to insert existing rows should throw a CdpApiException
+    spark.sparkContext.setLogLevel("OFF") // Removing expected Spark executor Errors from the console
+    val insertError = intercept[SparkException] {
+      spark.sql(
+        s"""
+           |select description,
+           |isString,
+           |name,
+           |metadata,
+           |unit,
+           |assetId,
+           |isStep,
+           |securityCategories,
+           |createdTime,
+           |lastUpdatedTime
+           |from sourceTimeSeries
+           |where unit = '$saveModeUnit'
+     """.stripMargin)
+        .write
+        .format("com.cognite.spark.datasource")
+        .option("apiKey", writeApiKey)
+        .option("type", "timeseries")
+        .save
+    }
+    insertError.getCause shouldBe a[CdpApiException]
+    val insertCdpApiException = insertError.getCause.asInstanceOf[CdpApiException]
+    assert(insertCdpApiException.code == 400)
+    spark.sparkContext.setLogLevel("WARN")
+  }
+
+  it should "support update in savemode" taggedAs WriteTest in {
+    val updateDescription = "spark-update-test"
+    val saveModeUnit = "spark-savemode-test"
+    // Update data with a new description
+    spark.sql(
+      s"""
+         |select '$updateDescription' as description,
+         |isString,
+         |name,
+         |metadata,
+         |unit,
+         |assetId,
+         |isStep,
+         |securityCategories,
+         |id,
+         |createdTime,
+         |lastUpdatedTime
+         |from sourceTimeSeries
+         |where unit = '$saveModeUnit'
+     """.stripMargin)
+      .write
+      .format("com.cognite.spark.datasource")
+      .option("apiKey", writeApiKey)
+      .option("type", "timeseries")
+      .option("onconflict", "update")
+      .save
+
+    val dfWithDescriptionUpdateTest = retryWhile[Array[Row]](
+      spark.sql(s"select * from sourceTimeSeries where description = '$updateDescription'").collect,
+      df => df.length < 5
+    )
+    assert(dfWithDescriptionUpdateTest.length == 5)
+
+    // Trying to update nonexisting Time Series should throw a CdpApiException
+    spark.sparkContext.setLogLevel("OFF") // Removing expected Spark executor Errors from the console
+    val updateError = intercept[SparkException] {
+      spark.sql(s"""
+                   |select '$updateDescription' as description,
+                   |isString,
+                   |name,
+                   |metadata,
+                   |unit,
+                   |assetId,
+                   |isStep,
+                   |securityCategories,
+                   |id+5 as id,
+                   |createdTime,
+                   |lastUpdatedTime
+                   |from sourceTimeSeries
+                   |where unit = '$saveModeUnit'
+     """.stripMargin)
+        .write
+        .format("com.cognite.spark.datasource")
+        .option("apiKey", writeApiKey)
+        .option("type", "timeseries")
+        .option("onconflict", "update")
+        .save
+    }
+    updateError.getCause shouldBe a[CdpApiException]
+    val updateCdpApiException = updateError.getCause.asInstanceOf[CdpApiException]
+    assert(updateCdpApiException.code == 400)
+    spark.sparkContext.setLogLevel("WARN")
+
+  }
+  it should "support upsert in savemode" taggedAs WriteTest in {
+    val upsertDescription = "spark-upsert-test"
+    val saveModeUnit = "spark-savemode-test"
+    // Test upserts
+    val existingTimeSeriesDf =
+      spark.sql(s"""
+              |select '$upsertDescription' as description,
+              |isString,
+              |name,
+              |metadata,
+              |unit,
+              |assetId,
+              |isStep,
+              |securityCategories,
+              |id,
+              |createdTime,
+              |lastUpdatedTime
+              |from sourceTimeSeries
+              |where unit = '$saveModeUnit'
+     """.stripMargin)
+
+  val nonExistingTimeSeriesDf =
+    spark.sql(s"""
+             |select '$upsertDescription' as description,
+             |isString,
+             |concat('UPSERTS_', name) as name,
+             |metadata,
+             |unit,
+             |assetId,
+             |isStep,
+             |securityCategories,
+             |id + 10,
+             |createdTime,
+             |lastUpdatedTime
+             |from sourceTimeSeries
+             |where unit = '$saveModeUnit'
+     """.stripMargin)
+
+
+    existingTimeSeriesDf.union(nonExistingTimeSeriesDf)
+      .write
+      .format("com.cognite.spark.datasource")
+      .option("apiKey", writeApiKey)
+      .option("type", "timeseries")
+      .option("onconflict", "upsert")
+      .save
+
+    val dfWithDescriptionUpsertTest = retryWhile[Array[Row]](
+      spark.sql(s"select * from sourceTimeSeries where description = '$upsertDescription'").collect,
+      df => df.length < 10
+    )
+    assert(dfWithDescriptionUpsertTest.length == 10)
+
+  }
   def cleanupTimeSeries(names: List[String]): Unit = {
     val project = getProject(writeApiKey, Constants.DefaultMaxRetries, Constants.DefaultBaseUrl)
 

--- a/src/test/scala/com/cognite/spark/datasource/URLTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/URLTest.scala
@@ -8,7 +8,7 @@ class URLTest extends FunSuite with SparkTest with CdpConnector {
 
   test("verify path encoding of base url") {
     val dataPointsRelation = new NumericDataPointsRelation(RelationConfig("", "statøil", Some(100), None, 1, 10,
-      collectMetrics = false, "","https://api.cognitedata.com"), 1, None)(spark.sqlContext)
+      collectMetrics = false, "","https://api.cognitedata.com", OnConflict.ABORT), 1, None)(spark.sqlContext)
     assert("https://api.cognitedata.com/api/0.5/projects/stat%C3%B8il/timeseries/data"
       == dataPointsRelation.baseDataPointsUrl("statøil").toString)
   }


### PR DESCRIPTION
Work in progress, based on Emil's work in #142 and #117.

Implemented three different save modes: write, upsert and update, provided as .option("savemode", "upsert"). Could help users avoid making errors, what do you think?

Declaring EventsInsertion inside EventsRelation is temporary, we should probably extract common methods in a superclass or similar.