### PR TITLE
Fix bug of same metric registered multiple times

### DIFF
--- a/src/main/scala/com/cognite/spark/datasource/AssetsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/AssetsRelation.scala
@@ -11,6 +11,7 @@ import org.apache.spark.sql.sources.InsertableRelation
 import org.apache.spark.sql.types.{DataTypes, StructType}
 import org.apache.spark.sql.{Row, SQLContext}
 import com.cognite.spark.datasource.SparkSchemaHelper._
+import org.apache.spark.datasource.MetricsSource
 
 import scala.concurrent.ExecutionContext
 
@@ -47,7 +48,8 @@ class AssetsRelation(config: RelationConfig, assetPath: Option[String])(val sqlC
     extends CdpRelation[AssetsItem](config, "assets")
     with InsertableRelation
     with CdpConnector {
-  @transient lazy private val assetsCreated = metricsSource.getOrCreateCounter(s"assets.created")
+  @transient lazy private val assetsCreated =
+    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"assets.created")
 
   override def insert(df: org.apache.spark.sql.DataFrame, overwrite: scala.Boolean): scala.Unit =
     df.foreachPartition(rows => {

--- a/src/main/scala/com/cognite/spark/datasource/CdpRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/CdpRelation.scala
@@ -1,9 +1,9 @@
 package com.cognite.spark.datasource
-import org.apache.spark.datasource.MetricsSource
 import org.apache.spark.sql.sources.{BaseRelation, TableScan}
 import io.circe.generic.auto._
 import io.circe.generic.decoding.DerivedDecoder
 import com.softwaremill.sttp.Uri
+import org.apache.spark.datasource.MetricsSource
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Row, SQLContext}
 
@@ -25,8 +25,8 @@ abstract class CdpRelation[T: DerivedDecoder: TypeTag: ClassTag](
     extends BaseRelation
     with TableScan
     with Serializable {
-  @transient lazy val metricsSource = new MetricsSource(config.metricsPrefix)
-  @transient lazy private val itemsRead = metricsSource.getOrCreateCounter(s"$shortName.read")
+  @transient lazy private val itemsRead =
+    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"$shortName.read")
 
   val sqlContext: SQLContext
 

--- a/src/main/scala/com/cognite/spark/datasource/DataPointsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/DataPointsRelation.scala
@@ -14,7 +14,6 @@ import com.softwaremill.sttp.circe._
 import scala.concurrent.ExecutionContext
 import scala.util.Try
 import com.cognite.data.api.v2.DataPoints._
-import org.apache.spark.datasource.MetricsSource
 
 sealed case class DataPointsDataItems[A](items: Seq[A])
 
@@ -70,8 +69,6 @@ abstract class DataPointsRelation(
     with Serializable {
   import CdpConnector._
   @transient lazy private val maxRetries = config.maxRetries
-
-  @transient val metricsSource = new MetricsSource(config.metricsPrefix)
 
   val datapointsCreated: Counter
   val datapointsRead: Counter

--- a/src/main/scala/com/cognite/spark/datasource/EventsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/EventsRelation.scala
@@ -9,6 +9,7 @@ import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import io.circe.parser.decode
 import com.softwaremill.sttp._
 import SparkSchemaHelper._
+import org.apache.spark.datasource.MetricsSource
 import org.apache.spark.rdd.RDD
 
 import scala.concurrent.ExecutionContext
@@ -87,8 +88,10 @@ class EventsRelation(config: RelationConfig)(@transient val sqlContext: SQLConte
     with InsertableRelation
     with PrunedFilteredScan
     with CdpConnector {
-  @transient lazy private val eventsCreated = metricsSource.getOrCreateCounter(s"events.created")
-  @transient lazy private val eventsRead = metricsSource.getOrCreateCounter(s"events.read")
+  @transient lazy private val eventsCreated =
+    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"events.created")
+  @transient lazy private val eventsRead =
+    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"events.read")
 
   override def insert(data: DataFrame, overwrite: Boolean): Unit =
     data.foreachPartition(rows => {

--- a/src/main/scala/com/cognite/spark/datasource/MetricsSource.scala
+++ b/src/main/scala/com/cognite/spark/datasource/MetricsSource.scala
@@ -3,37 +3,28 @@ package org.apache.spark.datasource
 import scala.collection.JavaConverters._
 import java.util.concurrent.ConcurrentHashMap
 
+import cats.Eval
 import com.codahale.metrics._
 import org.apache.spark._
 
-class MetricsSource(val metricNamespace: String) {
-
-  class LazyWrapper[T](wrapped: => T) {
-    lazy val value = wrapped
-  }
-
-  private def wrap[T](value: => T): LazyWrapper[T] =
-    new LazyWrapper[T](value)
-
-  private def unwrap[T](lazyWrapper: LazyWrapper[T]): T =
-    lazyWrapper.value
-
+class MetricsSource {
+  // Add metricNamespace to differentiate with spark system metrics.
   // Keeps track of all the Metric instances that are being published
-  val metricsMap = new ConcurrentHashMap[String, LazyWrapper[Metric]]().asScala
+  val metricsMap = new ConcurrentHashMap[String, Eval[Metric]]().asScala
 
-  def getOrElseUpdate(metricName: String, metric: => Metric): Metric = {
-    val wrapped = wrap(metric)
-    metricsMap.putIfAbsent(metricName, wrapped) match {
+  def getOrElseUpdate(metricNamespace: String, metricName: String, metric: => Metric): Metric = {
+    val wrapped = Eval.later(metric)
+    metricsMap.putIfAbsent(s"${metricNamespace}.${metricName}", wrapped) match {
       case Some(wrappedMetric) => wrappedMetric.value
       case None => {
-        registerMetricSource(metricName, wrapped.value)
+        registerMetricSource(metricNamespace, metricName, wrapped.value)
         wrapped.value
       }
     }
   }
 
-  def getOrCreateCounter(metricName: String): Counter =
-    getOrElseUpdate(metricName, new Counter).asInstanceOf[Counter]
+  def getOrCreateCounter(metricNamespace: String, metricName: String): Counter =
+    getOrElseUpdate(metricNamespace, metricName, new Counter).asInstanceOf[Counter]
 
   /**
     * Register a [[Metric]] with Spark's [[org.apache.spark.metrics.MetricsSystem]].
@@ -45,11 +36,11 @@ class MetricsSource(val metricNamespace: String) {
     * @param metricName name of the Metric
     * @param metric [[Metric]] instance to be published
     */
-  def registerMetricSource(metricName: String, metric: Metric): Unit = {
+  def registerMetricSource(metricNamespace: String, metricName: String, metric: Metric): Unit = {
     val env = SparkEnv.get
     env.metricsSystem.registerSource(
       new Source {
-        override val sourceName = s"$metricNamespace"
+        override val sourceName = s"${metricNamespace}"
         override def metricRegistry: MetricRegistry = {
           val metrics = new MetricRegistry
           metrics.register(metricName, metric)
@@ -59,3 +50,6 @@ class MetricsSource(val metricNamespace: String) {
     )
   }
 }
+
+// Singleton to make sure each metric is only registered once.
+object MetricsSource extends MetricsSource

--- a/src/main/scala/com/cognite/spark/datasource/NumericDataPointsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/NumericDataPointsRelation.scala
@@ -9,6 +9,7 @@ import com.cognite.data.api.v2.DataPoints.{
   NumericTimeseriesData
 }
 import com.softwaremill.sttp._
+import org.apache.spark.datasource.MetricsSource
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
@@ -27,9 +28,10 @@ class NumericDataPointsRelation(
     numPartitions: Int,
     suppliedSchema: Option[StructType])(override val sqlContext: SQLContext)
     extends DataPointsRelation(config, numPartitions, suppliedSchema)(sqlContext) {
-  @transient override val datapointsCreated =
-    metricsSource.getOrCreateCounter(s"datapoints.created")
-  @transient override val datapointsRead = metricsSource.getOrCreateCounter(s"datapoints.read")
+  @transient lazy override val datapointsCreated =
+    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"datapoints.created")
+  @transient lazy override val datapointsRead =
+    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"datapoints.read")
 
   override def schema: StructType =
     suppliedSchema.getOrElse(

--- a/src/main/scala/com/cognite/spark/datasource/RawTableRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/RawTableRelation.scala
@@ -53,11 +53,10 @@ class RawTableRelation(
 
   // TODO: check if we need to sanitize the database and table names, or if they are reasonably named
 
-  @transient lazy private val metricsSource = new MetricsSource(config.metricsPrefix)
   @transient lazy private val rowsCreated =
-    metricsSource.getOrCreateCounter(s"raw.$database.$table.rows.created")
+    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"raw.$database.$table.rows.created")
   @transient lazy private val rowsRead =
-    metricsSource.getOrCreateCounter(s"raw.$database.$table.rows.read")
+    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"raw.$database.$table.rows.read")
 
   override val schema: StructType = userSchema.getOrElse {
     if (inferSchema) {

--- a/src/main/scala/com/cognite/spark/datasource/StringDataPointsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/StringDataPointsRelation.scala
@@ -4,6 +4,7 @@ import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import com.cognite.data.api.v2.DataPoints._
 import com.softwaremill.sttp._
+import org.apache.spark.datasource.MetricsSource
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types._
@@ -16,10 +17,10 @@ class StringDataPointsRelation(
     numPartitions: Int,
     suppliedSchema: Option[StructType])(override val sqlContext: SQLContext)
     extends DataPointsRelation(config, numPartitions, suppliedSchema)(sqlContext) {
-  @transient override val datapointsCreated =
-    metricsSource.getOrCreateCounter(s"stringdatapoints.created")
-  @transient override val datapointsRead =
-    metricsSource.getOrCreateCounter(s"stringdatapoints.read")
+  @transient lazy override val datapointsCreated =
+    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"stringdatapoints.created")
+  @transient lazy override val datapointsRead =
+    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"stringdatapoints.read")
 
   private val batchSize = config.batchSize.getOrElse(Constants.DefaultDataPointsBatchSize)
   override def schema: StructType =

--- a/src/main/scala/com/cognite/spark/datasource/TimeSeriesRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/TimeSeriesRelation.scala
@@ -9,6 +9,7 @@ import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.{DataTypes, StructType}
 import org.apache.spark.sql.{Row, SQLContext}
 import SparkSchemaHelper._
+import org.apache.spark.datasource.MetricsSource
 
 import scala.concurrent.ExecutionContext
 
@@ -74,7 +75,7 @@ class TimeSeriesRelation(config: RelationConfig)(val sqlContext: SQLContext)
     with CdpConnector {
 
   @transient lazy private val timeSeriesCreated =
-    metricsSource.getOrCreateCounter(s"timeseries.created")
+    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"timeseries.created")
 
   override def insert(df: org.apache.spark.sql.DataFrame, overwrite: scala.Boolean): scala.Unit =
     df.foreachPartition(rows => {


### PR DESCRIPTION
Previously when Jetfire was using the new metrics in cdp-spark-datasource, we get errors about registering metrics that already exist, possibly due to Spark creating multiple instances of <DataType>Relation classes (and thus multiple instances of MetricSource)for read and for write.

This fix makes MetricSources a global singleton, so all metrics of all jobs are put into one hashmap. They are later removed when job is finished. This should be thread-safe.