### PR TITLE
Add bearer token support

### DIFF
--- a/src/main/scala/com/cognite/spark/datasource/AssetsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/AssetsRelation.scala
@@ -59,7 +59,7 @@ class AssetsRelation(config: RelationConfig, assetPath: Option[String])(val sqlC
       val assetItem = fromRow[PostAssetsItem](r)
       assetItem.copy(metadata = filterMetadata(assetItem.metadata))
     }
-    post(config.apiKey, baseAssetsURL(config.project), assetItems, config.maxRetries)
+    post(config.auth, baseAssetsURL(config.project), assetItems, config.maxRetries)
       .map(item => {
         if (config.collectMetrics) {
           assetsCreated.inc(rows.length)

--- a/src/main/scala/com/cognite/spark/datasource/CdpRdd.scala
+++ b/src/main/scala/com/cognite/spark/datasource/CdpRdd.scala
@@ -33,7 +33,7 @@ case class CdpRdd[A: DerivedDecoder](
     val split = _split.asInstanceOf[CdpRddPartition]
     val cdpRows =
       get[A](
-        config.apiKey,
+        config.auth,
         getSinglePartitionBaseUri,
         config.batchSize.getOrElse(Constants.DefaultBatchSize),
         split.size,

--- a/src/main/scala/com/cognite/spark/datasource/CursorsCursorIterator.scala
+++ b/src/main/scala/com/cognite/spark/datasource/CursorsCursorIterator.scala
@@ -8,7 +8,7 @@ case class CursorsCursorIterator(url: Uri, config: RelationConfig)
     extends Iterator[(Option[String], Option[Int])]
     with CdpConnector {
   private val cursors = {
-    val cursors = get[String](config.apiKey, url, 100, None, config.maxRetries).toSeq
+    val cursors = get[String](config.auth, url, 100, None, config.maxRetries).toSeq
     mutable.Queue(cursors: _*)
   }
 

--- a/src/main/scala/com/cognite/spark/datasource/DataPointsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/DataPointsRelation.scala
@@ -14,6 +14,7 @@ import com.softwaremill.sttp.circe._
 import scala.concurrent.ExecutionContext
 import scala.util.Try
 import com.cognite.data.api.v2.DataPoints._
+import com.cognite.spark.datasource.Auth._
 
 sealed case class DataPointsDataItems[A](items: Seq[A])
 
@@ -116,7 +117,7 @@ abstract class DataPointsRelation(
       uri"${config.baseUrl}/api/0.5/projects/${config.project}/timeseries/latest/$timeSeriesName"
     val getLatest = sttp
       .header("Accept", "application/json")
-      .header("api-key", config.apiKey)
+      .auth(config.auth)
       .response(asJson[LatestDataPoint])
       .get(url)
       .send()
@@ -131,7 +132,7 @@ abstract class DataPointsRelation(
 
   private def getFirstDataPointTimestamp(timeSeriesName: String): Long =
     getJson[DataItemsWithCursor[DataPointsTimestampItem]](
-      config.apiKey,
+      config.auth,
       uri"${baseDataPointsUrl(config.project)}/$timeSeriesName"
         .param("limit", "1")
         .param("start", "0"),
@@ -171,7 +172,7 @@ abstract class DataPointsRelation(
     val url = uri"${baseDataPointsUrl(config.project)}"
     val postDataPoints = sttp
       .header("Accept", "application/json")
-      .header("api-key", config.apiKey)
+      .auth(config.auth)
       .parseResponseIf(_ => true)
       .contentType("application/protobuf")
       .body(data.toByteArray)

--- a/src/main/scala/com/cognite/spark/datasource/FilesRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/FilesRelation.scala
@@ -70,7 +70,7 @@ class FilesRelation(config: RelationConfig)(val sqlContext: SQLContext)
     val updateFileItems = fileItems.map(f => UpdateFileItem(f))
 
     post(
-      config.apiKey,
+      config.auth,
       uri"$listUrl/update",
       updateFileItems,
       config.maxRetries

--- a/src/main/scala/com/cognite/spark/datasource/NextCursorIterator.scala
+++ b/src/main/scala/com/cognite/spark/datasource/NextCursorIterator.scala
@@ -27,7 +27,7 @@ case class NextCursorIterator[A: DerivedDecoder](url: Uri, config: RelationConfi
     val urlWithLimit = url.param("limit", thisBatchSize.toString)
     val getUrl = nextCursor.fold(urlWithLimit)(urlWithLimit.param("cursor", _))
     val dataWithCursor =
-      getJson[CdpConnector.DataItemsWithCursor[A]](config.apiKey, getUrl, config.maxRetries)
+      getJson[CdpConnector.DataItemsWithCursor[A]](config.auth, getUrl, config.maxRetries)
         .unsafeRunSync()
         .data
     nextCursor = dataWithCursor.nextCursor

--- a/src/main/scala/com/cognite/spark/datasource/NumericDataPointsRdd.scala
+++ b/src/main/scala/com/cognite/spark/datasource/NumericDataPointsRdd.scala
@@ -33,7 +33,7 @@ class NumericDataPointsRdd(
           .param("aggregates", s"${aggregationFilter.aggregation}")
           .param("granularity", s"${g.amount.getOrElse("")}${g.unit}")
         getJson[CdpConnector.DataItemsWithCursor[DataPointsItem]](
-          config.apiKey,
+          config.auth,
           uriWithAggregation,
           config.maxRetries)
           .unsafeRunSync()
@@ -46,7 +46,7 @@ class NumericDataPointsRdd(
                 getAggregationValue(dataPoint, aggregationFilter))
             }))
       case None =>
-        getProtobuf[Seq[NumericDatapoint]](config.apiKey, uri, parseResult, config.maxRetries)
+        getProtobuf[Seq[NumericDatapoint]](config.auth, uri, parseResult, config.maxRetries)
           .unsafeRunSync()
     }
     if (dataPoints.lastOption.fold(true)(_.timestamp < start)) {

--- a/src/main/scala/com/cognite/spark/datasource/RawTableRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/RawTableRelation.scala
@@ -121,7 +121,7 @@ class RawTableRelation(
 
     val url = uri"${baseRawTableURL(config.project, database, table)}/create"
 
-    post(config.apiKey, url, items, maxRetries)
+    post(config.auth, url, items, maxRetries)
       .flatTap { _ =>
         IO {
           if (config.collectMetrics) {

--- a/src/main/scala/com/cognite/spark/datasource/StringDataPointsRdd.scala
+++ b/src/main/scala/com/cognite/spark/datasource/StringDataPointsRdd.scala
@@ -19,7 +19,7 @@ class StringDataPointsRdd(
 
   override def getDataPointRows(uri: Uri, start: Long): (Seq[Row], Option[Long]) = {
     val dataPoints =
-      getProtobuf[Seq[StringDatapoint]](config.apiKey, uri, parseResult, config.maxRetries)
+      getProtobuf[Seq[StringDatapoint]](config.auth, uri, parseResult, config.maxRetries)
         .unsafeRunSync()
     if (dataPoints.lastOption.fold(true)(_.timestamp < start)) {
       (Seq.empty, None)

--- a/src/main/scala/com/cognite/spark/datasource/cdpAuth.scala
+++ b/src/main/scala/com/cognite/spark/datasource/cdpAuth.scala
@@ -1,0 +1,23 @@
+package com.cognite.spark.datasource
+import com.softwaremill.sttp.RequestT
+
+sealed trait Auth {
+  def auth[U[_], T, S](r: RequestT[U, T, S]): RequestT[U, T, S]
+}
+
+object Auth {
+  implicit class AuthSttpExtension[U[_], T, +S](val r: RequestT[U, T, S]) {
+    def auth(auth: Auth): RequestT[U, T, S] =
+      auth.auth(r)
+  }
+}
+
+case class ApiKeyAuth(apiKey: String) extends Auth {
+  def auth[U[_], T, S](r: RequestT[U, T, S]): RequestT[U, T, S] =
+    r.header("api-key", apiKey)
+}
+
+case class BearerTokenAuth(bearerToken: String) extends Auth {
+  def auth[U[_], T, S](r: RequestT[U, T, S]): RequestT[U, T, S] =
+    r.header("Authorization", s"Bearer $bearerToken")
+}

--- a/src/test/scala/com/cognite/spark/datasource/AssetsRelationTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/AssetsRelationTest.scala
@@ -8,12 +8,12 @@ import org.scalatest.{FlatSpec, Matchers}
 import cats.implicits._
 
 class AssetsRelationTest extends FlatSpec with Matchers with SparkTest {
-  val readApiKey = System.getenv("TEST_API_KEY_READ")
-  val writeApiKey = System.getenv("TEST_API_KEY_WRITE")
+  val readApiKey = ApiKeyAuth(System.getenv("TEST_API_KEY_READ"))
+  val writeApiKey = ApiKeyAuth(System.getenv("TEST_API_KEY_WRITE"))
 
   it should "read assets" taggedAs ReadTest in {
     val df = spark.read.format("com.cognite.spark.datasource")
-      .option("apiKey", readApiKey)
+      .option("apiKey", readApiKey.apiKey)
       .option("type", "assets")
       .option("limit", "1000")
       .option("partitions", "1")
@@ -27,7 +27,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with SparkTest {
 
   it should "read assets with a small batchSize" taggedAs ReadTest in {
     val df = spark.read.format("com.cognite.spark.datasource")
-      .option("apiKey", readApiKey)
+      .option("apiKey", readApiKey.apiKey)
       .option("type", "assets")
       .option("batchSize", "1")
       .option("limit", "10")
@@ -40,7 +40,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with SparkTest {
   it should "be possible to create assets" taggedAs WriteTest in {
     val assetsTestSource = "assets-relation-test-create"
     val df = spark.read.format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
+      .option("apiKey", writeApiKey.apiKey)
       .option("type", "assets")
       .load()
     df.createOrReplaceTempView("assets")
@@ -72,12 +72,12 @@ class AssetsRelationTest extends FlatSpec with Matchers with SparkTest {
   it should "be possible to copy assets from one tenant to another" taggedAs WriteTest in {
     val assetsTestSource = "assets-relation-test-copy"
     val sourceDf = spark.read.format("com.cognite.spark.datasource")
-      .option("apiKey", readApiKey)
+      .option("apiKey", readApiKey.apiKey)
       .option("type", "assets")
       .load()
     sourceDf.createOrReplaceTempView("source_assets")
     val df = spark.read.format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
+      .option("apiKey", writeApiKey.apiKey)
       .option("type", "assets")
       .load()
     df.createOrReplaceTempView("assets")

--- a/src/test/scala/com/cognite/spark/datasource/EventsRelationTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/EventsRelationTest.scala
@@ -6,12 +6,12 @@ import org.apache.spark.SparkException
 import org.scalatest.{FlatSpec, Matchers}
 
 class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
-  val readApiKey = System.getenv("TEST_API_KEY_READ")
-  val writeApiKey = System.getenv("TEST_API_KEY_WRITE")
+  val readApiKey = ApiKeyAuth(System.getenv("TEST_API_KEY_READ"))
+  val writeApiKey = ApiKeyAuth(System.getenv("TEST_API_KEY_WRITE"))
 
   "EventsRelation" should "allow simple reads" taggedAs ReadTest in {
     val df = spark.read.format("com.cognite.spark.datasource")
-      .option("apiKey", readApiKey)
+      .option("apiKey", readApiKey.apiKey)
       .option("type", "events")
       .option("batchSize", "500")
       .option("limit", "1000")
@@ -26,7 +26,7 @@ class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
 
   it should "apply a single pushdown filter" taggedAs WriteTest in {
     val df = spark.read.format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
+      .option("apiKey", writeApiKey.apiKey)
       .option("type", "events")
       .load()
       .where(s"type = 'alert'")
@@ -35,7 +35,7 @@ class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
 
   it should "apply multiple pushdown filters" taggedAs WriteTest in {
     val df = spark.read.format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
+      .option("apiKey", writeApiKey.apiKey)
       .option("type", "events")
       .load()
       .where(s"type = 'maintenance' and subtype = 'new'")
@@ -44,7 +44,7 @@ class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
 
   it should "handle or conditions" taggedAs WriteTest in {
     val df = spark.read.format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
+      .option("apiKey", writeApiKey.apiKey)
       .option("type", "events")
       .load()
       .where(s"type = 'maintenance' or type = 'upgrade'")
@@ -53,7 +53,7 @@ class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
 
   it should "handle in() conditions" taggedAs WriteTest in {
     val df = spark.read.format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
+      .option("apiKey", writeApiKey.apiKey)
       .option("type", "events")
       .load()
       .where(s"type in('alert','replacement')")
@@ -62,7 +62,7 @@ class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
 
   it should "handle and, or and in() in one query" taggedAs WriteTest in {
     val df = spark.read.format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
+      .option("apiKey", writeApiKey.apiKey)
       .option("type", "events")
       .load()
       .where(s"(type = 'maintenance' or type = 'upgrade') and subtype in('manual', 'automatic')")
@@ -74,13 +74,13 @@ class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
     .collect()
 
   val destinationDf: DataFrame = spark.read.format("com.cognite.spark.datasource")
-    .option("apiKey", writeApiKey)
+    .option("apiKey", writeApiKey.apiKey)
     .option("type", "events")
     .load()
   destinationDf.createOrReplaceTempView("destinationEvent")
 
   val sourceDf: DataFrame = spark.read.format("com.cognite.spark.datasource")
-    .option("apiKey", readApiKey)
+    .option("apiKey", readApiKey.apiKey)
     .option("type", "events")
     .option("limit", "1000")
     .option("partitions", "1")
@@ -219,7 +219,7 @@ class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
      """.stripMargin)
       .write
       .format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
+      .option("apiKey", writeApiKey.apiKey)
       .option("type", "events")
       .save
 
@@ -251,7 +251,7 @@ class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
      """.stripMargin)
         .write
         .format("com.cognite.spark.datasource")
-        .option("apiKey", writeApiKey)
+        .option("apiKey", writeApiKey.apiKey)
         .option("type", "events")
         .save
     }
@@ -345,7 +345,7 @@ class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
         """.stripMargin)
       .write
       .format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
+      .option("apiKey", writeApiKey.apiKey)
       .option("type", "events")
       .option("onconflict", "update")
       .save

--- a/src/test/scala/com/cognite/spark/datasource/SparkTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/SparkTest.scala
@@ -19,15 +19,15 @@ trait SparkTest extends CdpConnector {
     .config("spark.app.id", this.getClass.getName + math.floor(math.random * 1000).toLong.toString)
     .getOrCreate()
 
-  def getThreeDModelIdAndRevisionId(apiKey: String): (String, String) = {
-    val project = getProject(apiKey, 10, Constants.DefaultBaseUrl)
+  def getThreeDModelIdAndRevisionId(auth: Auth): (String, String) = {
+    val project = getProject(auth, 10, Constants.DefaultBaseUrl)
 
     val modelUrl = uri"https://api.cognitedata.com/api/0.6/projects/$project/3d/models"
-    val models = getJson[Data[Items[ModelItem]]](apiKey, modelUrl, 10).unsafeRunSync()
+    val models = getJson[Data[Items[ModelItem]]](auth, modelUrl, 10).unsafeRunSync()
     val modelId = models.data.items.head.id.toString
 
     val revisionsUrl = uri"https://api.cognitedata.com/api/0.6/projects/$project/3d/models/$modelId/revisions"
-    val revisions = getJson[Data[Items[ModelRevisionItem]]](apiKey, revisionsUrl, 10).unsafeRunSync()
+    val revisions = getJson[Data[Items[ModelRevisionItem]]](auth, revisionsUrl, 10).unsafeRunSync()
     val revisionId = revisions.data.items.head.id.toString
 
     (modelId, revisionId)

--- a/src/test/scala/com/cognite/spark/datasource/ThreeDModelRevisionMappingsRelationTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/ThreeDModelRevisionMappingsRelationTest.scala
@@ -3,13 +3,13 @@ package com.cognite.spark.datasource
 import org.scalatest.FlatSpec
 
 class ThreeDModelRevisionMappingsRelationTest extends FlatSpec with SparkTest {
-  private val writeApiKey = System.getenv("TEST_API_KEY_WRITE")
+  private val writeApiKey = ApiKeyAuth(System.getenv("TEST_API_KEY_WRITE"))
 
   "ThreeDModelRevisionsRelationTest" should "pass a smoke test" taggedAs WriteTest in {
     val (modelId, revisionId) = getThreeDModelIdAndRevisionId(writeApiKey)
 
     val df = spark.read.format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
+      .option("apiKey", writeApiKey.apiKey)
       .option("type", "3dmodelrevisionmappings")
       .option("modelid", modelId)
       .option("revisionid", revisionId)

--- a/src/test/scala/com/cognite/spark/datasource/ThreeDModelRevisionNodesRelationTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/ThreeDModelRevisionNodesRelationTest.scala
@@ -3,13 +3,13 @@ package com.cognite.spark.datasource
 import org.scalatest.FlatSpec
 
 class ThreeDModelRevisionNodesRelationTest extends FlatSpec with SparkTest  {
-  private val writeApiKey = System.getenv("TEST_API_KEY_WRITE")
+  private val writeApiKey = ApiKeyAuth(System.getenv("TEST_API_KEY_WRITE"))
 
   "ThreeDModelRevisionNodesRelationTest" should "pass a smoke test" taggedAs WriteTest in {
     val (modelId, revisionId) = getThreeDModelIdAndRevisionId(writeApiKey)
 
     val df = spark.read.format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
+      .option("apiKey", writeApiKey.apiKey)
       .option("type", "3dmodelrevisionnodes")
       .option("modelid", modelId)
       .option("revisionid", revisionId)

--- a/src/test/scala/com/cognite/spark/datasource/ThreeDModelRevisionSectorsRelationTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/ThreeDModelRevisionSectorsRelationTest.scala
@@ -3,13 +3,13 @@ package com.cognite.spark.datasource
 import org.scalatest.FlatSpec
 
 class ThreeDModelRevisionSectorsRelationTest extends FlatSpec with SparkTest {
-  private val writeApiKey = System.getenv("TEST_API_KEY_WRITE")
+  private val writeApiKey = ApiKeyAuth(System.getenv("TEST_API_KEY_WRITE"))
 
   "ThreeDModelRevisionSectorsRelationTest" should "pass a smoke test" taggedAs WriteTest in {
     val (modelId, revisionId) = getThreeDModelIdAndRevisionId(writeApiKey)
 
     val df = spark.read.format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
+      .option("apiKey", writeApiKey.apiKey)
       .option("type", "3dmodelrevisionsectors")
       .option("modelid", modelId)
       .option("revisionid", revisionId)

--- a/src/test/scala/com/cognite/spark/datasource/ThreeDModelRevisionsRelationTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/ThreeDModelRevisionsRelationTest.scala
@@ -3,13 +3,13 @@ package com.cognite.spark.datasource
 import org.scalatest.FlatSpec
 
 class ThreeDModelRevisionsRelationTest extends FlatSpec with SparkTest  {
-  private val writeApiKey = System.getenv("TEST_API_KEY_WRITE")
+  private val writeApiKey = ApiKeyAuth(System.getenv("TEST_API_KEY_WRITE"))
 
   "ThreeDModelRevisionsRelationTest" should "pass a smoke test" taggedAs WriteTest in {
     val (modelId, _) = getThreeDModelIdAndRevisionId(writeApiKey)
 
     val df = spark.read.format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
+      .option("apiKey", writeApiKey.apiKey)
       .option("type", "3dmodelrevisions")
       .option("modelid", modelId)
       .load()

--- a/src/test/scala/com/cognite/spark/datasource/TimeSeriesUpsertTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/TimeSeriesUpsertTest.scala
@@ -7,11 +7,11 @@ import com.softwaremill.sttp._
 import org.apache.spark.SparkException
 
 class TimeSeriesUpsertTest extends FlatSpec with Matchers with SparkTest {
-  val readApiKey = System.getenv("TEST_API_KEY_READ")
-  val writeApiKey = System.getenv("TEST_API_KEY_WRITE")
+  val readApiKey = ApiKeyAuth(System.getenv("TEST_API_KEY_READ"))
+  val writeApiKey = ApiKeyAuth(System.getenv("TEST_API_KEY_WRITE"))
   val sourceDf = spark.read
     .format("com.cognite.spark.datasource")
-    .option("apiKey", writeApiKey)
+    .option("apiKey", writeApiKey.apiKey)
     .option("type", "timeseries")
     .load()
   sourceDf.createOrReplaceTempView("sourceTimeSeries")
@@ -120,7 +120,7 @@ class TimeSeriesUpsertTest extends FlatSpec with Matchers with SparkTest {
      """.stripMargin)
       .write
       .format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
+      .option("apiKey", writeApiKey.apiKey)
       .option("type", "timeseries")
       .save
 
@@ -150,7 +150,7 @@ class TimeSeriesUpsertTest extends FlatSpec with Matchers with SparkTest {
      """.stripMargin)
         .write
         .format("com.cognite.spark.datasource")
-        .option("apiKey", writeApiKey)
+        .option("apiKey", writeApiKey.apiKey)
         .option("type", "timeseries")
         .save
     }
@@ -182,7 +182,7 @@ class TimeSeriesUpsertTest extends FlatSpec with Matchers with SparkTest {
      """.stripMargin)
       .write
       .format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
+      .option("apiKey", writeApiKey.apiKey)
       .option("type", "timeseries")
       .option("onconflict", "update")
       .save
@@ -213,7 +213,7 @@ class TimeSeriesUpsertTest extends FlatSpec with Matchers with SparkTest {
      """.stripMargin)
         .write
         .format("com.cognite.spark.datasource")
-        .option("apiKey", writeApiKey)
+        .option("apiKey", writeApiKey.apiKey)
         .option("type", "timeseries")
         .option("onconflict", "update")
         .save
@@ -266,7 +266,7 @@ class TimeSeriesUpsertTest extends FlatSpec with Matchers with SparkTest {
     existingTimeSeriesDf.union(nonExistingTimeSeriesDf)
       .write
       .format("com.cognite.spark.datasource")
-      .option("apiKey", writeApiKey)
+      .option("apiKey", writeApiKey.apiKey)
       .option("type", "timeseries")
       .option("onconflict", "upsert")
       .save
@@ -283,7 +283,7 @@ class TimeSeriesUpsertTest extends FlatSpec with Matchers with SparkTest {
 
     for (name <- names) {
       delete(
-        writeApiKey,
+        writeApiKey.apiKey,
         uri"${Constants.DefaultBaseUrl}/api/0.5/projects/$project/timeseries/$name",
         maxRetries = 5
       ).unsafeRunSync()

--- a/src/test/scala/com/cognite/spark/datasource/URLTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/URLTest.scala
@@ -7,14 +7,14 @@ class URLTest extends FunSuite with SparkTest with CdpConnector {
   val readApiKey = System.getenv("TEST_API_KEY_READ")
 
   test("verify path encoding of base url") {
-    val dataPointsRelation = new NumericDataPointsRelation(RelationConfig("", "statøil", Some(100), None, 1, 10,
+    val dataPointsRelation = new NumericDataPointsRelation(RelationConfig(ApiKeyAuth(""), "statøil", Some(100), None, 1, 10,
       collectMetrics = false, "","https://api.cognitedata.com", OnConflict.ABORT), 1, None)(spark.sqlContext)
     assert("https://api.cognitedata.com/api/0.5/projects/stat%C3%B8il/timeseries/data"
       == dataPointsRelation.baseDataPointsUrl("statøil").toString)
   }
 
   test("verify that correct project is retrieved from TEST_API_KEY"){
-    val project = getProject(readApiKey, Constants.DefaultMaxRetries, Constants.DefaultBaseUrl)
+    val project = getProject(ApiKeyAuth(readApiKey), Constants.DefaultMaxRetries, Constants.DefaultBaseUrl)
     assert(project == "publicdata")
   }
 }


### PR DESCRIPTION
This makes it possible to use the spark datasource in cituations where
an api-key is unavailable, but instead a bearer token is.