### PR TITLE
Add support for partial updates

### DIFF
--- a/macro/src/main/scala/SparkSchemaHelper.scala
+++ b/macro/src/main/scala/SparkSchemaHelper.scala
@@ -39,7 +39,7 @@ class SparkSchemaHelperImpl(val c: Context) {
         innerType
       }
 
-      val column = q"Option($r.getAs[$rowType]($name))"
+      val column = q"scala.util.Try(Option($r.getAs[$rowType]($name))).toOption.flatten"
       val (baseExpr, isOuterOption) = if (param.typeSignature <:< typeOf[Option[_]]) {
         (column, true)
       } else {

--- a/src/main/scala/com/cognite/spark/datasource/CdpConnector.scala
+++ b/src/main/scala/com/cognite/spark/datasource/CdpConnector.scala
@@ -9,7 +9,7 @@ import com.softwaremill.sttp._
 import com.softwaremill.sttp.circe._
 import io.circe.generic.auto._
 import io.circe.parser.decode
-import io.circe.{Decoder, Encoder}
+import io.circe.{Decoder, Encoder, Printer}
 
 import scala.concurrent.{ExecutionContext, TimeoutException}
 import scala.concurrent.duration._
@@ -28,6 +28,7 @@ case class CdpApiException(url: Uri, code: Int, message: String)
 
 trait CdpConnector {
   import CdpConnector._
+  implicit val customPrinter: Printer = Printer.noSpaces.copy(dropNullValues = true)
 
   def getProject(auth: Auth, maxRetries: Int, baseUrl: String): String = {
     val loginStatusUrl = uri"$baseUrl/login/status"

--- a/src/main/scala/com/cognite/spark/datasource/CdpRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/CdpRelation.scala
@@ -18,6 +18,7 @@ object Setter {
       case _ => Some(new Setter(set.get, false))
     }
 }
+case class NonNullableSetter[A](set: A)
 
 abstract class CdpRelation[T: DerivedDecoder: TypeTag: ClassTag](
     config: RelationConfig,

--- a/src/main/scala/com/cognite/spark/datasource/DefaultSource.scala
+++ b/src/main/scala/com/cognite/spark/datasource/DefaultSource.scala
@@ -141,11 +141,7 @@ class DefaultSource
           inferSchemaLimit,
           collectSchemaInferenceMetrics)(sqlContext)
       case "assets" =>
-        val assetsPath = parameters.get("assetsPath")
-        if (assetsPath.isDefined && !AssetsRelation.isValidAssetsPath(assetsPath.get)) {
-          sys.error("Invalid assets path: " + assetsPath.get)
-        }
-        new AssetsRelation(config, assetsPath)(sqlContext)
+        new AssetsRelation(config)(sqlContext)
       case "events" =>
         new EventsRelation(config)(sqlContext)
       case "files" =>
@@ -191,6 +187,8 @@ class DefaultSource
         new EventsRelation(config)(sqlContext) //.EventsInsertion(config)
       case "timeseries" =>
         new TimeSeriesRelation(config)(sqlContext)
+      case "assets" =>
+        new AssetsRelation(config)(sqlContext)
       case _ => sys.error(s"Resource type '$resourceType does not support save()")
     }
 

--- a/src/main/scala/com/cognite/spark/datasource/EventsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/EventsRelation.scala
@@ -102,8 +102,7 @@ class EventsRelation(config: RelationConfig)(@transient val sqlContext: SQLConte
   override def upsert(rows: Seq[Row]): IO[Unit] = postEvents(rows)
 
   override def update(rows: Seq[Row]): IO[Unit] = {
-    val eventItems = rows.map(r => fromRow[EventItem](r))
-    val updateEventItems = eventItems.map(e => UpdateEventItem(e))
+    val updateEventItems = rows.map(r => UpdateEventItem(fromRow[EventItem](r)))
 
     post(
       config.auth,

--- a/src/main/scripts/Pipfile
+++ b/src/main/scripts/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+cognite-sdk = "*"
+
+[requires]
+python_version = "3.5"

--- a/src/main/scripts/Pipfile.lock
+++ b/src/main/scripts/Pipfile.lock
@@ -1,0 +1,174 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "72ec23a4aebb56ca36000e2a58313a884698804730db7414c4d98717827c79b3"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.5"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+            ],
+            "version": "==2019.3.9"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "cognite-logger": {
+            "hashes": [
+                "sha256:d81e13887b598afe9992cf233cad74629df4a6d287b5cff04b5f2630909ff9fb"
+            ],
+            "version": "==0.4.0"
+        },
+        "cognite-sdk": {
+            "hashes": [
+                "sha256:03af7fba9dddd99f92955fc8468bc9aa7b3109817c4b9cf616bc773ee9c4e990",
+                "sha256:77e1d08773f38b19bc870c01510165892ec35f6aa3032e73ab4f3c37a42fe97e"
+            ],
+            "index": "pypi",
+            "version": "==0.13.3"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:0e2eed77804b2a6a88741f8fcac02c5499bba3953ec9c71e8b217fad4912c56c",
+                "sha256:1c666f04553ef70fda54adf097dbae7080645435fc273e2397f26bbf1d127bbb",
+                "sha256:1f46532afa7b2903bfb1b79becca2954c0a04389d19e03dc73f06b039048ac40",
+                "sha256:315fa1b1dfc16ae0f03f8fd1c55f23fd15368710f641d570236f3d78af55e340",
+                "sha256:3d5fcea4f5ed40c3280791d54da3ad2ecf896f4c87c877b113576b8280c59441",
+                "sha256:48241759b99d60aba63b0e590332c600fc4b46ad597c9b0a53f350b871ef0634",
+                "sha256:4b4f2924b36d857cf302aec369caac61e43500c17eeef0d7baacad1084c0ee84",
+                "sha256:54fe3b7ed9e7eb928bbc4318f954d133851865f062fa4bbb02ef8940bc67b5d2",
+                "sha256:5a8f021c70e6206c317974c93eaaf9bc2b56295b6b1cacccf88846e44a1f33fc",
+                "sha256:754a6be26d938e6ca91942804eb209307b73f806a1721176278a6038869a1686",
+                "sha256:771147e654e8b95eea1293174a94f34e2e77d5729ad44aefb62fbf8a79747a15",
+                "sha256:78a6f89da87eeb48014ec652a65c4ffde370c036d780a995edaeb121d3625621",
+                "sha256:7fde5c2a3a682a9e101e61d97696687ebdba47637611378b4127fe7e47fdf2bf",
+                "sha256:80d99399c97f646e873dd8ce87c38cfdbb668956bbc39bc1e6cac4b515bba2a0",
+                "sha256:88a72c1e45a0ae24d1f249a529d9f71fe82e6fa6a3fd61414b829396ec585900",
+                "sha256:a4f4460877a16ac73302a9c077ca545498d9fe64e6a81398d8e1a67e4695e3df",
+                "sha256:a61255a765b3ac73ee4b110b28fccfbf758c985677f526c2b4b39c48cc4b509d",
+                "sha256:ab4896a8c910b9a04c0142871d8800c76c8a2e5ff44763513e1dd9d9631ce897",
+                "sha256:abbd6b1c2ef6199f4b7ca9f818eb6b31f17b73a6110aadc4e4298c3f00fab24e",
+                "sha256:b16d88da290334e33ea992c56492326ea3b06233a00a1855414360b77ca72f26",
+                "sha256:b78a1defedb0e8f6ae1eb55fa6ac74ab42acc4569c3a2eacc2a407ee5d42ebcb",
+                "sha256:cfef82c43b8b29ca436560d51b2251d5117818a8d1fb74a8384a83c096745dad",
+                "sha256:d160e57731fcdec2beda807ebcabf39823c47e9409485b5a3a1db3a8c6ce763e"
+            ],
+            "version": "==1.16.3"
+        },
+        "pandas": {
+            "hashes": [
+                "sha256:071e42b89b57baa17031af8c6b6bbd2e9a5c68c595bc6bf9adabd7a9ed125d3b",
+                "sha256:17450e25ae69e2e6b303817bdf26b2cd57f69595d8550a77c308be0cd0fd58fa",
+                "sha256:17916d818592c9ec891cbef2e90f98cc85e0f1e89ed0924c9b5220dc3209c846",
+                "sha256:2538f099ab0e9f9c9d09bbcd94b47fd889bad06dc7ae96b1ed583f1dc1a7a822",
+                "sha256:366f30710172cb45a6b4f43b66c220653b1ea50303fbbd94e50571637ffb9167",
+                "sha256:42e5ad741a0d09232efbc7fc648226ed93306551772fc8aecc6dce9f0e676794",
+                "sha256:4e718e7f395ba5bfe8b6f6aaf2ff1c65a09bb77a36af6394621434e7cc813204",
+                "sha256:4f919f409c433577a501e023943e582c57355d50a724c589e78bc1d551a535a2",
+                "sha256:4fe0d7e6438212e839fc5010c78b822664f1a824c0d263fd858f44131d9166e2",
+                "sha256:5149a6db3e74f23dc3f5a216c2c9ae2e12920aa2d4a5b77e44e5b804a5f93248",
+                "sha256:627594338d6dd995cfc0bacd8e654cd9e1252d2a7c959449228df6740d737eb8",
+                "sha256:83c702615052f2a0a7fb1dd289726e29ec87a27272d775cb77affe749cca28f8",
+                "sha256:8c872f7fdf3018b7891e1e3e86c55b190e6c5cee70cab771e8f246c855001296",
+                "sha256:90f116086063934afd51e61a802a943826d2aac572b2f7d55caaac51c13db5b5",
+                "sha256:a3352bacac12e1fc646213b998bce586f965c9d431773d9e91db27c7c48a1f7d",
+                "sha256:bcdd06007cca02d51350f96debe51331dec429ac8f93930a43eb8fb5639e3eb5",
+                "sha256:c1bd07ebc15285535f61ddd8c0c75d0d6293e80e1ee6d9a8d73f3f36954342d0",
+                "sha256:c9a4b7c55115eb278c19aa14b34fcf5920c8fe7797a09b7b053ddd6195ea89b3",
+                "sha256:cc8fc0c7a8d5951dc738f1c1447f71c43734244453616f32b8aa0ef6013a5dfb",
+                "sha256:d7b460bc316064540ce0c41c1438c416a40746fd8a4fb2999668bf18f3c4acf1"
+            ],
+            "version": "==0.24.2"
+        },
+        "protobuf": {
+            "hashes": [
+                "sha256:21e395d7959551e759d604940a115c51c6347d90a475c9baf471a1a86b5604a9",
+                "sha256:57e05e16955aee9e6a0389fcbd58d8289dd2420e47df1a1096b3a232c26eb2dd",
+                "sha256:67819e8e48a74c68d87f25cad9f40edfe2faf278cdba5ca73173211b9213b8c9",
+                "sha256:75da7d43a2c8a13b0bc7238ab3c8ae217cbfd5979d33b01e98e1f78defb2d060",
+                "sha256:78e08371e236f193ce947712c072542ff19d0043ab5318c2ea46bbc2aaebdca6",
+                "sha256:7ee5b595db5abb0096e8c4755e69c20dfad38b2d0bcc9bc7bafc652d2496b471",
+                "sha256:86260ecfe7a66c0e9d82d2c61f86a14aa974d340d159b829b26f35f710f615db",
+                "sha256:92c77db4bd33ea4ee5f15152a835273f2338a5246b2cbb84bab5d0d7f6e9ba94",
+                "sha256:9c7b90943e0e188394b4f068926a759e3b4f63738190d1ab3d500d53b9ce7614",
+                "sha256:a77f217ea50b2542bae5b318f7acee50d9fc8c95dd6d3656eaeff646f7cab5ee",
+                "sha256:ad589ed1d1f83db22df867b10e01fe445516a5a4d7cfa37fe3590a5f6cfc508b",
+                "sha256:b06a794901bf573f4b2af87e6139e5cd36ac7c91ac85d7ae3fe5b5f6fc317513",
+                "sha256:bd8592cc5f8b4371d0bad92543370d4658dc41a5ccaaf105597eb5524c616291",
+                "sha256:be48e5a6248a928ec43adf2bea037073e5da692c0b3c10b34f9904793bd63138",
+                "sha256:cc5eb13f5ccc4b1b642cc147c2cdd121a34278b341c7a4d79e91182fff425836",
+                "sha256:cd3b0e0ad69b74ee55e7c321f52a98effed2b4f4cc9a10f3683d869de00590d5",
+                "sha256:d6e88c4920660aa75c0c2c4b53407aef5efd9a6e0ca7d2fc84d79aba2ccbda3a",
+                "sha256:ec3c49b6d247152e19110c3a53d9bb4cf917747882017f70796460728b02722e"
+            ],
+            "version": "==3.7.1"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+            ],
+            "version": "==2.8.0"
+        },
+        "python-json-logger": {
+            "hashes": [
+                "sha256:30999d1d742ecf6645991a2ce9273188505e98b713ad63be06aabff47dd1b3c4",
+                "sha256:8205cfe7061715de5cd1b37e3565d5b97d0ac13b30ff3ee612554abb6093d640"
+            ],
+            "version": "==0.1.8"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:303879e36b721603cc54604edcac9d20401bdbe31e1e4fdee5b9f98d5d31dfda",
+                "sha256:d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141"
+            ],
+            "version": "==2019.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
+                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+            ],
+            "version": "==2.21.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
+                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
+            ],
+            "version": "==1.24.3"
+        }
+    },
+    "develop": {}
+}

--- a/src/test/scala/com/cognite/spark/datasource/AssetsRelationTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/AssetsRelationTest.scala
@@ -3,13 +3,15 @@ package com.cognite.spark.datasource
 import com.softwaremill.sttp._
 import org.apache.spark.sql.{Row}
 import org.scalatest.{FlatSpec, Matchers}
+import org.apache.spark.sql.functions.col
 
 class AssetsRelationTest extends FlatSpec with Matchers with SparkTest {
   val readApiKey = ApiKeyAuth(System.getenv("TEST_API_KEY_READ"))
   val writeApiKey = ApiKeyAuth(System.getenv("TEST_API_KEY_WRITE"))
 
   it should "read assets" taggedAs ReadTest in {
-    val df = spark.read.format("com.cognite.spark.datasource")
+    val df = spark.read
+      .format("com.cognite.spark.datasource")
       .option("apiKey", readApiKey.apiKey)
       .option("type", "assets")
       .option("limit", "1000")
@@ -17,13 +19,15 @@ class AssetsRelationTest extends FlatSpec with Matchers with SparkTest {
       .load()
 
     df.createTempView("assets")
-    val res = spark.sql("select * from assets")
+    val res = spark
+      .sql("select * from assets")
       .collect()
     assert(res.length == 1000)
   }
 
   it should "read assets with a small batchSize" taggedAs ReadTest in {
-    val df = spark.read.format("com.cognite.spark.datasource")
+    val df = spark.read
+      .format("com.cognite.spark.datasource")
       .option("apiKey", readApiKey.apiKey)
       .option("type", "assets")
       .option("batchSize", "1")
@@ -36,7 +40,8 @@ class AssetsRelationTest extends FlatSpec with Matchers with SparkTest {
 
   it should "be possible to create assets" taggedAs WriteTest in {
     val assetsTestSource = "assets-relation-test-create"
-    val df = spark.read.format("com.cognite.spark.datasource")
+    val df = spark.read
+      .format("com.cognite.spark.datasource")
       .option("apiKey", writeApiKey.apiKey)
       .option("type", "assets")
       .load()
@@ -45,8 +50,8 @@ class AssetsRelationTest extends FlatSpec with Matchers with SparkTest {
     retryWhile[Array[Row]](
       spark.sql(s"select * from assets where source = '$assetsTestSource'").collect,
       rows => rows.length > 0)
-    spark.sql(
-      s"""
+    spark
+      .sql(s"""
         |select null as id,
         |null as path,
         |null as depth,
@@ -68,12 +73,14 @@ class AssetsRelationTest extends FlatSpec with Matchers with SparkTest {
 
   it should "be possible to copy assets from one tenant to another" taggedAs WriteTest in {
     val assetsTestSource = "assets-relation-test-copy"
-    val sourceDf = spark.read.format("com.cognite.spark.datasource")
+    val sourceDf = spark.read
+      .format("com.cognite.spark.datasource")
       .option("apiKey", readApiKey.apiKey)
       .option("type", "assets")
       .load()
     sourceDf.createOrReplaceTempView("source_assets")
-    val df = spark.read.format("com.cognite.spark.datasource")
+    val df = spark.read
+      .format("com.cognite.spark.datasource")
       .option("apiKey", writeApiKey.apiKey)
       .option("type", "assets")
       .load()
@@ -82,8 +89,8 @@ class AssetsRelationTest extends FlatSpec with Matchers with SparkTest {
     retryWhile[Array[Row]](
       spark.sql(s"select * from assets where source = '$assetsTestSource'").collect,
       rows => rows.length > 0)
-    spark.sql(
-      s"""
+    spark
+      .sql(s"""
          |select id,
          |path,
          |depth,
@@ -102,6 +109,103 @@ class AssetsRelationTest extends FlatSpec with Matchers with SparkTest {
     retryWhile[Array[Row]](
       spark.sql(s"select * from assets where source = '$assetsTestSource'").collect,
       rows => rows.length < 1)
+    retryWhile[Array[Row]](
+      spark.sql(s"select * from assets where source = '$assetsTestSource'").collect,
+      rows => rows.length < 1)
+  }
+
+  it should "allow partial updates" taggedAs WriteTest in {
+    val sourceDf = spark.read
+      .format("com.cognite.spark.datasource")
+      .option("apiKey", writeApiKey.apiKey)
+      .option("type", "assets")
+      .load()
+      .where("name = 'upsertTestThree'")
+    sourceDf.createTempView("update")
+    val wdf = spark.sql("""
+        |select 'upsertTestThree' as name, id from update
+      """.stripMargin)
+
+    wdf.write
+      .format("com.cognite.spark.datasource")
+      .option("apiKey", writeApiKey.apiKey)
+      .option("type", "assets")
+      .option("onconflict", "update")
+      .save()
+  }
+
+  it should "support some more partial updates" taggedAs WriteTest in {
+    val source = "spark-assets-test"
+
+    val sourceDf = spark.read
+      .format("com.cognite.spark.datasource")
+      .option("apiKey", readApiKey.apiKey)
+      .option("type", "assets")
+      .load()
+    sourceDf.createTempView("sourceAssets")
+
+    val destinationDf = spark.read
+      .format("com.cognite.spark.datasource")
+      .option("apiKey", writeApiKey.apiKey)
+      .option("type", "assets")
+      .load()
+    destinationDf.createTempView("destinationAssets")
+
+    // Cleanup assets
+    cleanupAssets(source)
+    val oldAssetsFromTestDf = retryWhile[Array[Row]](
+      spark.sql(s"select * from destinationAssets where source = '$source'").collect,
+      df => df.length > 0)
+    assert(oldAssetsFromTestDf.length == 0)
+
+    // Post new events
+    spark
+      .sql(s"""
+                 |select id,
+                 |path,
+                 |depth,
+                 |name,
+                 |null as parentId,
+                 |description,
+                 |metadata,
+                 |"$source" as source,
+                 |sourceId,
+                 |createdTime,
+                 |lastUpdatedTime
+                 |from sourceAssets
+                 |limit 100
+     """.stripMargin)
+      .select(destinationDf.columns.map(col): _*)
+      .write
+      .insertInto("destinationAssets")
+
+    // Check if post worked
+    val assetsFromTestDf = retryWhile[Array[Row]](
+      spark.sql(s"select * from destinationAssets where source = '$source'").collect,
+      df => df.length < 100)
+    assert(assetsFromTestDf.length == 100)
+
+    val description = "spark-testing-description"
+
+    // Update assets
+    spark
+      .sql(s"""
+                 |select '$description' as description,
+                 |id from destinationAssets
+                 |where source = '$source'
+     """.stripMargin)
+      .write
+      .format("com.cognite.spark.datasource")
+      .option("apiKey", writeApiKey.apiKey)
+      .option("type", "assets")
+      .option("onconflict", "update")
+      .save()
+
+    // Check if update worked
+    val assetsWithNewNameDf = retryWhile[Array[Row]](
+      spark.sql(s"select * from destinationAssets where description = '$description'").collect,
+      df => df.length < 100)
+    assert(assetsFromTestDf.length == 100)
   }
 
   def cleanupAssets(source: String): Unit = {
@@ -116,7 +220,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with SparkTest {
       limit = None,
       maxRetries = 10)
 
-    val assetIdsChunks = assets.flatMap(_.id).grouped(1000)
+    val assetIdsChunks = assets.map(_.id).grouped(1000)
     val AssetIdNotFound = "^(Asset ids not found).+".r
     for (assetIds <- assetIdsChunks) {
       try {

--- a/src/test/scala/com/cognite/spark/datasource/DataPointsRelationTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/DataPointsRelationTest.scala
@@ -135,7 +135,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with SparkTest {
       .option("type", "datapoints")
       .load()
       .where(s"timestamp >= 1520035200000 and timestamp <= 1571616000000 and aggregation = 'avg' and granularity = '60d' and name = $valhallTimeSeries")
-    assert(df2.count() == 7)
+    assert(df2.count() == 8)
     val df3 = spark.read.format("com.cognite.spark.datasource")
       .option("apiKey", readApiKey)
       .option("type", "datapoints")

--- a/src/test/scala/com/cognite/spark/datasource/TimeSeriesUpsertTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/TimeSeriesUpsertTest.scala
@@ -122,7 +122,7 @@ class TimeSeriesUpsertTest extends FlatSpec with Matchers with SparkTest {
       .format("com.cognite.spark.datasource")
       .option("apiKey", writeApiKey.apiKey)
       .option("type", "timeseries")
-      .save
+      .save()
 
     val dfWithDescriptionInsertTest = retryWhile[Array[Row]](
       spark.sql(s"select * from sourceTimeSeries where description = '$insertDescription'").collect,
@@ -152,7 +152,7 @@ class TimeSeriesUpsertTest extends FlatSpec with Matchers with SparkTest {
         .format("com.cognite.spark.datasource")
         .option("apiKey", writeApiKey.apiKey)
         .option("type", "timeseries")
-        .save
+        .save()
     }
     insertError.getCause shouldBe a[CdpApiException]
     val insertCdpApiException = insertError.getCause.asInstanceOf[CdpApiException]
@@ -160,23 +160,15 @@ class TimeSeriesUpsertTest extends FlatSpec with Matchers with SparkTest {
     spark.sparkContext.setLogLevel("WARN")
   }
 
-  it should "support update in savemode" taggedAs WriteTest in {
+  it should "support partial update in savemode" taggedAs WriteTest in {
     val updateDescription = "spark-update-test"
     val saveModeUnit = "spark-savemode-test"
     // Update data with a new description
     spark.sql(
       s"""
          |select '$updateDescription' as description,
-         |isString,
-         |name,
-         |metadata,
-         |unit,
-         |assetId,
-         |isStep,
-         |securityCategories,
          |id,
-         |createdTime,
-         |lastUpdatedTime
+         |name
          |from sourceTimeSeries
          |where unit = '$saveModeUnit'
      """.stripMargin)
@@ -185,7 +177,7 @@ class TimeSeriesUpsertTest extends FlatSpec with Matchers with SparkTest {
       .option("apiKey", writeApiKey.apiKey)
       .option("type", "timeseries")
       .option("onconflict", "update")
-      .save
+      .save()
 
     val dfWithDescriptionUpdateTest = retryWhile[Array[Row]](
       spark.sql(s"select * from sourceTimeSeries where description = '$updateDescription'").collect,
@@ -216,7 +208,7 @@ class TimeSeriesUpsertTest extends FlatSpec with Matchers with SparkTest {
         .option("apiKey", writeApiKey.apiKey)
         .option("type", "timeseries")
         .option("onconflict", "update")
-        .save
+        .save()
     }
     updateError.getCause shouldBe a[CdpApiException]
     val updateCdpApiException = updateError.getCause.asInstanceOf[CdpApiException]
@@ -269,7 +261,7 @@ class TimeSeriesUpsertTest extends FlatSpec with Matchers with SparkTest {
       .option("apiKey", writeApiKey.apiKey)
       .option("type", "timeseries")
       .option("onconflict", "upsert")
-      .save
+      .save()
 
     val dfWithDescriptionUpsertTest = retryWhile[Array[Row]](
       spark.sql(s"select * from sourceTimeSeries where description = '$upsertDescription'").collect,


### PR DESCRIPTION
@Tapped I couldn't make `val column = q"${typeOf[Try[_]]}(Option($r.getAs[$rowType]($name))).toOption.flatten"` work, so importing Try everywhere.

```
/cdp-spark-datasource/src/main/scala/com/cognite/spark/datasource/TimeSeriesRelation.scala:
121:53: scala.util.Try[_$5] does not take parameters
val timeSeriesItem = fromRow[TimeSeriesItem](r)
                                     ^
```