### PR TITLE
Fix tests failing because of eventual consistency

### DIFF
--- a/src/test/scala/com/cognite/spark/datasource/AssetsRelationTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/AssetsRelationTest.scala
@@ -1,11 +1,8 @@
 package com.cognite.spark.datasource
 
-import java.util.regex.Pattern
-
 import com.softwaremill.sttp._
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.{Row}
 import org.scalatest.{FlatSpec, Matchers}
-import cats.implicits._
 
 class AssetsRelationTest extends FlatSpec with Matchers with SparkTest {
   val readApiKey = ApiKeyAuth(System.getenv("TEST_API_KEY_READ"))
@@ -45,9 +42,9 @@ class AssetsRelationTest extends FlatSpec with Matchers with SparkTest {
       .load()
     df.createOrReplaceTempView("assets")
     cleanupAssets(assetsTestSource)
-    retryWhile[DataFrame](
-      spark.sql(s"select * from assets where source = '$assetsTestSource'"),
-      rows => rows.count > 0)
+    retryWhile[Array[Row]](
+      spark.sql(s"select * from assets where source = '$assetsTestSource'").collect,
+      rows => rows.length > 0)
     spark.sql(
       s"""
         |select null as id,
@@ -64,9 +61,9 @@ class AssetsRelationTest extends FlatSpec with Matchers with SparkTest {
       """.stripMargin)
       .write
       .insertInto("assets")
-    retryWhile[DataFrame](
-      spark.sql(s"select * from assets where source = '$assetsTestSource'"),
-      rows => rows.count < 1)
+    retryWhile[Array[Row]](
+      spark.sql(s"select * from assets where source = '$assetsTestSource'").collect,
+      rows => rows.length < 1)
   }
 
   it should "be possible to copy assets from one tenant to another" taggedAs WriteTest in {
@@ -82,9 +79,9 @@ class AssetsRelationTest extends FlatSpec with Matchers with SparkTest {
       .load()
     df.createOrReplaceTempView("assets")
     cleanupAssets(assetsTestSource)
-    retryWhile[DataFrame](
-      spark.sql(s"select * from assets where source = '$assetsTestSource'"),
-      rows => rows.count > 0)
+    retryWhile[Array[Row]](
+      spark.sql(s"select * from assets where source = '$assetsTestSource'").collect,
+      rows => rows.length > 0)
     spark.sql(
       s"""
          |select id,
@@ -102,9 +99,9 @@ class AssetsRelationTest extends FlatSpec with Matchers with SparkTest {
       """.stripMargin)
       .write
       .insertInto("assets")
-    retryWhile[DataFrame](
-      spark.sql(s"select * from assets where source = '$assetsTestSource'"),
-      rows => rows.count < 1)
+    retryWhile[Array[Row]](
+      spark.sql(s"select * from assets where source = '$assetsTestSource'").collect,
+      rows => rows.length < 1)
   }
 
   def cleanupAssets(source: String): Unit = {

--- a/src/test/scala/com/cognite/spark/datasource/FilesRelationTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/FilesRelationTest.scala
@@ -1,6 +1,6 @@
 package com.cognite.spark.datasource
 
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions.col
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -71,10 +71,10 @@ class FilesRelationTest extends FlatSpec with Matchers with SparkTest {
       .write
       .insertInto("filesSource")
 
-    val dfWithTestDirectory = retryWhile[DataFrame](
-      spark.sql(s"select * from filesSource where directory = '$firstDirectoryName'"),
-      rows => rows.count < 10)
-    assert(dfWithTestDirectory.count == 10)
+    val dfWithTestDirectory = retryWhile[Array[Row]](
+      spark.sql(s"select * from filesSource where directory = '$firstDirectoryName'").collect,
+      rows => rows.length < 10)
+    assert(dfWithTestDirectory.length == 10)
 
     spark.sql(s"""
                  |select id,
@@ -96,15 +96,15 @@ class FilesRelationTest extends FlatSpec with Matchers with SparkTest {
       .write
       .insertInto("filesSource")
 
-    val dfWithUpdatedSource = retryWhile[DataFrame](
-      spark.sql(s"select * from filesSource where directory = '$secondDirectoryName'"),
-      rows => rows.count < 10)
-    assert(dfWithUpdatedSource.count == 10)
+    val dfWithUpdatedSource = retryWhile[Array[Row]](
+      spark.sql(s"select * from filesSource where directory = '$secondDirectoryName'").collect,
+      rows => rows.length < 10)
+    assert(dfWithUpdatedSource.length== 10)
 
-    val emptyDfWithTestDirectory = retryWhile[DataFrame](
-      spark.sql(s"select * from filesSource where directory = '$firstDirectoryName'"),
-      rows => rows.count > 0)
-    assert(emptyDfWithTestDirectory.count == 0)
+    val emptyDfWithTestDirectory = retryWhile[Array[Row]](
+      spark.sql(s"select * from filesSource where directory = '$firstDirectoryName'").collect,
+      rows => rows.length > 0)
+    assert(emptyDfWithTestDirectory.length == 0)
 
   }
 }


### PR DESCRIPTION
This fixes the failing test from FilesRelation, and uses collect in AssetsRelationTest for consistency. We should also find a way to fix TimeSeriesRelationTest, which has two main problems:

- should successfully both update and insert time series
This test times out sometimes
- should support abort in savemode
This sometimes fails because it doesn't always get a conflict on inserting existing rows due to EC.

Any other tests we know of that fail? The `does not throw exception` should be fixed everywhere we use the pattern, and since we'll add more of it once we implement savemode for other resource types it will be an even bigger problem soon.