### PR TITLE
Fix unclosed quote in error message

### DIFF
--- a/src/main/scala/com/cognite/spark/datasource/DefaultSource.scala
+++ b/src/main/scala/com/cognite/spark/datasource/DefaultSource.scala
@@ -189,7 +189,7 @@ class DefaultSource
         new TimeSeriesRelation(config)(sqlContext)
       case "assets" =>
         new AssetsRelation(config)(sqlContext)
-      case _ => sys.error(s"Resource type '$resourceType does not support save()")
+      case _ => sys.error(s"Resource type $resourceType does not support save()")
     }
 
     data.foreachPartition((rows: Iterator[Row]) => {


### PR DESCRIPTION
Fix it by removing it, since it turns into "Resource type &apos;assets does not support save()" in Databricks output and we don't really need it.