### PR TITLE
Check for null id on update

### DIFF
--- a/src/main/scala/com/cognite/spark/datasource/EventsRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/EventsRelation.scala
@@ -104,6 +104,11 @@ class EventsRelation(config: RelationConfig)(@transient val sqlContext: SQLConte
   override def update(rows: Seq[Row]): IO[Unit] = {
     val updateEventItems = rows.map(r => UpdateEventItem(fromRow[EventItem](r)))
 
+    // Events must have an id when using update
+    if (updateEventItems.exists(_.id.isEmpty)) {
+      throw new IllegalArgumentException("Events must have an id when using update")
+    }
+
     post(config, uri"${baseEventsURL(config.project)}/update", updateEventItems)
   }
 

--- a/src/test/scala/com/cognite/spark/datasource/FilesRelationTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/FilesRelationTest.scala
@@ -9,7 +9,8 @@ class FilesRelationTest extends FlatSpec with Matchers with SparkTest {
   private val writeApiKey = System.getenv("TEST_API_KEY_WRITE")
 
   "FilesRelation" should "read files" taggedAs ReadTest in {
-    val df = spark.read.format("com.cognite.spark.datasource")
+    val df = spark.read
+      .format("com.cognite.spark.datasource")
       .option("apiKey", readApiKey)
       .option("type", "files")
       .load()
@@ -20,7 +21,8 @@ class FilesRelationTest extends FlatSpec with Matchers with SparkTest {
   }
 
   it should "respect the limit option" taggedAs ReadTest in {
-    val df = spark.read.format("com.cognite.spark.datasource")
+    val df = spark.read
+      .format("com.cognite.spark.datasource")
       .option("apiKey", readApiKey)
       .option("type", "files")
       .option("limit", "5")
@@ -30,7 +32,8 @@ class FilesRelationTest extends FlatSpec with Matchers with SparkTest {
   }
 
   it should "use cursors when necessary" taggedAs ReadTest in {
-    val df = spark.read.format("com.cognite.spark.datasource")
+    val df = spark.read
+      .format("com.cognite.spark.datasource")
       .option("apiKey", readApiKey)
       .option("type", "files")
       .option("batchSize", "2")
@@ -44,14 +47,15 @@ class FilesRelationTest extends FlatSpec with Matchers with SparkTest {
     val firstDirectoryName = "test directory"
     val secondDirectoryName = "dummy directory"
 
-
-    val df = spark.read.format("com.cognite.spark.datasource")
+    val df = spark.read
+      .format("com.cognite.spark.datasource")
       .option("apiKey", writeApiKey)
       .option("type", "files")
       .load()
     df.createOrReplaceTempView("filesSource")
 
-    spark.sql(s"""
+    spark
+      .sql(s"""
                  |select id,
                  |fileName,
                  |'$firstDirectoryName' as directory,
@@ -76,7 +80,8 @@ class FilesRelationTest extends FlatSpec with Matchers with SparkTest {
       rows => rows.length < 10)
     assert(dfWithTestDirectory.length == 10)
 
-    spark.sql(s"""
+    spark
+      .sql(s"""
                  |select id,
                  |fileName,
                  |'$secondDirectoryName' as directory,
@@ -99,7 +104,7 @@ class FilesRelationTest extends FlatSpec with Matchers with SparkTest {
     val dfWithUpdatedSource = retryWhile[Array[Row]](
       spark.sql(s"select * from filesSource where directory = '$secondDirectoryName'").collect,
       rows => rows.length < 10)
-    assert(dfWithUpdatedSource.length== 10)
+    assert(dfWithUpdatedSource.length == 10)
 
     val emptyDfWithTestDirectory = retryWhile[Array[Row]](
       spark.sql(s"select * from filesSource where directory = '$firstDirectoryName'").collect,


### PR DESCRIPTION
Make sure we don't send values with null ids to the API on update.
Instead check and throw an IllegalArgumentException if we receive
any null ids on update. Previously we only checked this on assets, but now we also check on timeSeries and events.