### PR TITLE
Remove metadata keys with null values

### DIFF
--- a/src/main/scala/com/cognite/spark/datasource/TimeSeriesRelation.scala
+++ b/src/main/scala/com/cognite/spark/datasource/TimeSeriesRelation.scala
@@ -123,13 +123,19 @@ class TimeSeriesRelation(config: RelationConfig)(val sqlContext: SQLContext)
   }
 
   override def upsert(rows: Seq[Row]): IO[Unit] = {
-    val timeSeriesItems = rows.map(r => fromRow[TimeSeriesItem](r))
+    val timeSeriesItems = rows.map { r =>
+      val timeSeriesItem = fromRow[TimeSeriesItem](r)
+      timeSeriesItem.copy(metadata = filterMetadata(timeSeriesItem.metadata))
+    }
     updateOrPostTimeSeries(timeSeriesItems)
   }
 
   override def update(rows: Seq[Row]): IO[Unit] = {
     val updateTimeSeriesBaseItems =
-      rows.map(r => fromRow[UpdateTimeSeriesBase](r))
+      rows.map { r =>
+        val timeSeriesItem = fromRow[UpdateTimeSeriesBase](r)
+        timeSeriesItem.copy(metadata = filterMetadata(timeSeriesItem.metadata))
+      }
 
     // Time series must have an id when using update
     if (updateTimeSeriesBaseItems.exists(_.id.isEmpty)) {

--- a/src/test/scala/com/cognite/spark/datasource/EventsRelationTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/EventsRelationTest.scala
@@ -365,7 +365,7 @@ class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
                  |subtype,
                  |array(2091657868296883) as assetIds,
                  |bigint(0) as id,
-                 |metadata,
+                 |map("some", null, "metadata", "test") as metadata,
                  |"$source" as source,
                  |sourceId,
                  |createdTime,
@@ -407,7 +407,7 @@ class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
                  |subtype,
                  |array(8031965690878131) as assetIds,
                  |bigint(0) as id,
-                 |metadata,
+                 |map("foo", null, "bar", "test") as metadata,
                  |"$source" as source,
                  |sourceId,
                  |createdTime,
@@ -439,7 +439,7 @@ class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
            |subtype,
            |array(8031965690878131) as assetIds,
            |bigint(0) as id,
-           |metadata,
+           |map("foo", null, "bar", "test") as metadata,
            |"$source" as source,
            |sourceId,
            |createdTime,
@@ -459,7 +459,7 @@ class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
     spark.sparkContext.setLogLevel("WARN")
   }
 
-  it should "allow partial updates in savemode" taggedAs WriteTest ignore {
+  it should "allow partial updates in savemode" taggedAs WriteTest in {
     val source = "spark-savemode-updates-test"
 
     // Cleanup old events
@@ -473,7 +473,7 @@ class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
     spark
       .sql(s"""
              |select "foo" as description,
-             |startTime,
+             |1384601200000 as startTime,
              |endTime,
              |type,
              |subtype,

--- a/src/test/scala/com/cognite/spark/datasource/TimeSeriesRelationTest.scala
+++ b/src/test/scala/com/cognite/spark/datasource/TimeSeriesRelationTest.scala
@@ -34,7 +34,7 @@ class TimeSeriesRelationTest extends FlatSpec with Matchers with SparkTest {
          |select '$initialDescription' as description,
          |concat('TEST', name) as name,
          |isString,
-         |metadata,
+         |map("foo", null, "bar", "test", "some more", "test data", "nullValue", null) as metadata,
          |'$testUnit' as unit,
          |'' as assetId,
          |isStep,
@@ -65,7 +65,7 @@ class TimeSeriesRelationTest extends FlatSpec with Matchers with SparkTest {
                 |select '$updatedDescription' as description,
                 |name,
                 |isString,
-                |metadata,
+                |map("foo", null, "bar", "test") as metadata,
                 |'test data' as unit,
                 |'' as assetId,
                 |isStep,
@@ -115,7 +115,7 @@ class TimeSeriesRelationTest extends FlatSpec with Matchers with SparkTest {
          |select '$insertDescription' as description,
          |isString,
          |concat('TEST_', name) as name,
-         |metadata,
+         |map("foo", null, "bar", "test") as metadata,
          |'$saveModeUnit' as unit,
          |NULL as assetId,
          |isStep,
@@ -145,7 +145,7 @@ class TimeSeriesRelationTest extends FlatSpec with Matchers with SparkTest {
            |select description,
            |isString,
            |name,
-           |metadata,
+           |map("foo", null) as metadata,
            |unit,
            |assetId,
            |isStep,
@@ -178,6 +178,7 @@ class TimeSeriesRelationTest extends FlatSpec with Matchers with SparkTest {
           .sql(s"""
            |select '$updateDescription' as description,
            |id,
+           |map("foo", null, "bar", "test") as metadata,
            |name
            |from sourceTimeSeries
            |where unit = '$saveModeUnit'
@@ -254,7 +255,7 @@ class TimeSeriesRelationTest extends FlatSpec with Matchers with SparkTest {
              |select '$upsertDescription' as description,
              |isString,
              |concat('UPSERTS_', name) as name,
-             |metadata,
+             |map("foo", null, "bar", "test") as metadata,
              |unit,
              |assetId,
              |isStep,


### PR DESCRIPTION
This was already done for insertInto, but is now done for all ways of
writing to CDF.