### PR TITLE
Reduce default maximum timestamp

### DIFF
--- a/src/main/scala/cognite/spark/v1/Constants.scala
+++ b/src/main/scala/cognite/spark/v1/Constants.scala
@@ -18,4 +18,5 @@ object Constants {
   val MetadataValuePostMaxLength = 512
   val MaxConcurrentRequests = 1000
   val SparkDatasourceVersion = s"${BuildInfo.organization}-${BuildInfo.version}"
+  val millisSinceEpochIn2100 = 4102448400000L
 }

--- a/src/main/scala/cognite/spark/v1/PushdownUtilities.scala
+++ b/src/main/scala/cognite/spark/v1/PushdownUtilities.scala
@@ -109,7 +109,7 @@ object PushdownUtilities {
         .getOrElse(Instant.ofEpochMilli(0)),
       Try(timestampLimits.filter(_.isInstanceOf[Max]).min).toOption
         .map(_.value)
-        .getOrElse(Instant.ofEpochMilli(Long.MaxValue))
+        .getOrElse(Instant.ofEpochMilli(Constants.millisSinceEpochIn2100)) // Year 2100 should be sufficient
     )
   }
 

--- a/src/test/scala/cognite/spark/v1/DataPointsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/DataPointsRelationTest.scala
@@ -144,9 +144,10 @@ class DataPointsRelationTest extends FlatSpec with Matchers with SparkTest {
       .option("apiKey", readApiKey)
       .option("type", "datapoints")
       .option("partitions", "1")
+      .option("limit", "10")
       .load()
       .where(
-        s"timestamp >= to_timestamp(1509490000) and timestamp <= to_timestamp(1510358400) and aggregation = 'min' and granularity = '1d' and id = $valhallTimeSeriesId")
+        s"aggregation = 'min' and granularity = '1d' and id = $valhallTimeSeriesId")
 
     assert(df1.count() == 10)
     val df1Partitions = spark.read


### PR DESCRIPTION
The default for the upper timestamp filter on datapoints was too high,
this is now reduced to year 2100.