### PR TITLE
Save mode for numeric and string datapoints

### DIFF
--- a/src/main/scala/cognite/spark/v1/AssetsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/AssetsRelation.scala
@@ -15,7 +15,8 @@ import io.scalaland.chimney.dsl._
 
 class AssetsRelation(config: RelationConfig)(val sqlContext: SQLContext)
     extends SdkV1Relation[Asset, Long](config, "assets")
-    with InsertableRelation {
+    with InsertableRelation
+    with WritableRelation {
   import CdpConnector._
 
   override def getStreams(filters: Array[Filter])(

--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -180,7 +180,6 @@ class DefaultSource
       data: DataFrame): BaseRelation = {
     val config = parseRelationConfig(parameters, sqlContext)
     val resourceType = parameters.getOrElse("type", sys.error("Resource type must be specified"))
-
     val relation = resourceType match {
       case "events" =>
         new EventsRelation(config)(sqlContext)
@@ -189,6 +188,10 @@ class DefaultSource
         new TimeSeriesRelation(config, useLegacyName)(sqlContext)
       case "assets" =>
         new AssetsRelation(config)(sqlContext)
+      case "datapoints" =>
+        new NumericDataPointsRelationV1(config)(sqlContext)
+      case "stringdatapoints" =>
+        new StringDataPointsRelationV1(config)(sqlContext)
       case _ => sys.error(s"Resource type $resourceType does not support save()")
     }
 

--- a/src/main/scala/cognite/spark/v1/EventsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/EventsRelation.scala
@@ -14,7 +14,8 @@ import io.scalaland.chimney.dsl._
 
 class EventsRelation(config: RelationConfig)(val sqlContext: SQLContext)
     extends SdkV1Relation[Event, Long](config, "events")
-    with InsertableRelation {
+    with InsertableRelation
+    with WritableRelation {
   import CdpConnector._
 
   override def getStreams(filters: Array[Filter])(

--- a/src/main/scala/cognite/spark/v1/NumericDataPointsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/NumericDataPointsRelation.scala
@@ -102,9 +102,21 @@ object Granularity {
 }
 
 class NumericDataPointsRelationV1(config: RelationConfig)(sqlContext: SQLContext)
-    extends DataPointsRelationV1[DataPointsItem](config)(sqlContext) {
+    extends DataPointsRelationV1[DataPointsItem](config)(sqlContext)
+    with WritableRelation {
 
   import PushdownUtilities.filtersToTimestampLimits
+
+  override def insert(rows: Seq[Row]): IO[Unit] =
+    throw new RuntimeException("Insert not supported for datapoints. Use upsert instead.")
+
+  override def upsert(rows: Seq[Row]): IO[Unit] = insertSeqOfRows(rows)
+
+  override def update(rows: Seq[Row]): IO[Unit] =
+    throw new RuntimeException("Update not supported for datapoints. Use upsert instead.")
+
+  override def delete(rows: Seq[Row]): IO[Unit] =
+    throw new RuntimeException("Delete not supported for datapoints.")
 
   override def schema: StructType =
     StructType(

--- a/src/main/scala/cognite/spark/v1/SdkV1Relation.scala
+++ b/src/main/scala/cognite/spark/v1/SdkV1Relation.scala
@@ -88,20 +88,11 @@ abstract class SdkV1Relation[A <: Product, I](config: RelationConfig, shortName:
       val rowOfAllFields = toRow(item)
       Row.fromSeq(indicesOfRequiredFields.map(idx => rowOfAllFields.get(idx)))
     }
+}
 
-  def insert(rows: Seq[Row]): IO[Unit] =
-    throw new IllegalArgumentException(
-      s"""$shortName does not support the "onconflict" option "abort".""")
-
-  def upsert(rows: Seq[Row]): IO[Unit] =
-    throw new IllegalArgumentException(
-      s"""$shortName does not support the "onconflict" option "upsert".""")
-
-  def update(rows: Seq[Row]): IO[Unit] =
-    throw new IllegalArgumentException(
-      s"""$shortName does not support the "onconflict" option "update".""")
-
-  def delete(rows: Seq[Row]): IO[Unit] =
-    throw new IllegalArgumentException(
-      s"""$shortName does not support the "onconflict" option "delete".""")
+trait WritableRelation {
+  def insert(rows: Seq[Row]): IO[Unit]
+  def upsert(rows: Seq[Row]): IO[Unit]
+  def update(rows: Seq[Row]): IO[Unit]
+  def delete(rows: Seq[Row]): IO[Unit]
 }

--- a/src/main/scala/cognite/spark/v1/StringDataPointsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/StringDataPointsRelation.scala
@@ -35,7 +35,19 @@ case class StringDataPointsFilter(
 )
 
 class StringDataPointsRelationV1(config: RelationConfig)(override val sqlContext: SQLContext)
-    extends DataPointsRelationV1[StringDataPointsItem](config)(sqlContext) {
+    extends DataPointsRelationV1[StringDataPointsItem](config)(sqlContext)
+    with WritableRelation {
+
+  override def insert(rows: Seq[Row]): IO[Unit] =
+    throw new RuntimeException("Insert not supported for stringdatapoints. Please use upsert instead.")
+
+  override def upsert(rows: Seq[Row]): IO[Unit] = insertSeqOfRows(rows)
+
+  override def update(rows: Seq[Row]): IO[Unit] =
+    throw new RuntimeException("Update not supported for stringdatapoints. Please use upsert instead.")
+
+  override def delete(rows: Seq[Row]): IO[Unit] =
+    throw new RuntimeException("Delete not supported for stringdatapoints.")
 
   def toRow(a: StringDataPointsItem): Row = asRow(a)
 

--- a/src/main/scala/cognite/spark/v1/TimeSeriesRelation.scala
+++ b/src/main/scala/cognite/spark/v1/TimeSeriesRelation.scala
@@ -20,6 +20,7 @@ import io.scalaland.chimney.dsl._
 
 class TimeSeriesRelation(config: RelationConfig, useLegacyName: Boolean)(val sqlContext: SQLContext)
     extends SdkV1Relation[TimeSeries, Long](config, "timeseries")
+    with WritableRelation
     with InsertableRelation {
   import CdpConnector._
 


### PR DESCRIPTION
-- datapoints and stringdatapoints only support upserts (deleted the part about deletes bc we are not sure how it will look in jetfire for now)