### PR TITLE
Avoid global execution context

### DIFF
--- a/src/main/scala/cognite/spark/v1/AssetsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/AssetsRelation.scala
@@ -11,14 +11,12 @@ import PushdownUtilities._
 import com.cognite.sdk.scala.common.CdpApiException
 import fs2.Stream
 
-import scala.concurrent.ExecutionContext
 import io.scalaland.chimney.dsl._
 
 class AssetsRelation(config: RelationConfig)(val sqlContext: SQLContext)
     extends SdkV1Relation[Asset, Long](config, "assets")
     with InsertableRelation {
-  @transient implicit lazy val contextShift: ContextShift[IO] =
-    IO.contextShift(ExecutionContext.global)
+  import CdpConnector._
 
   override def getStreams(filters: Array[Filter])(
       client: GenericClient[IO, Nothing],

--- a/src/main/scala/cognite/spark/v1/DataPointsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/DataPointsRelation.scala
@@ -2,11 +2,10 @@ package cognite.spark.v1
 
 import java.time.Instant
 
-import cats.effect.{ContextShift, IO}
+import cats.effect.IO
 import cats.implicits._
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 
-import scala.concurrent.ExecutionContext
 import com.cognite.sdk.scala.v1.GenericClient
 import com.cognite.sdk.scala.common.Auth
 import com.softwaremill.sttp.SttpBackend
@@ -32,8 +31,7 @@ abstract class DataPointsRelationV1[A](config: RelationConfig)(override val sqlC
     with PrunedFilteredScan
     with Serializable
     with InsertableRelation {
-  @transient implicit lazy val contextShift: ContextShift[IO] =
-    IO.contextShift(ExecutionContext.global)
+  import CdpConnector._
   @transient lazy implicit val retryingSttpBackend: SttpBackend[IO, Nothing] =
     CdpConnector.retryingSttpBackend(config.maxRetries)
   implicit val auth: Auth = config.auth

--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -1,13 +1,10 @@
 package cognite.spark.v1
 
-import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import com.cognite.sdk.scala.common.{ApiKeyAuth, Auth, BearerTokenAuth}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row, SQLContext, SaveMode}
-
-import scala.concurrent.ExecutionContext
 
 case class RelationConfig(
     auth: Auth,
@@ -196,7 +193,7 @@ class DefaultSource
     }
 
     data.foreachPartition((rows: Iterator[Row]) => {
-      implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+      import CdpConnector._
       val batches = rows.grouped(Constants.DefaultBatchSize).toVector
 
       config.onConflict match {

--- a/src/main/scala/cognite/spark/v1/EventsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/EventsRelation.scala
@@ -1,6 +1,6 @@
 package cognite.spark.v1
 
-import cats.effect.{ContextShift, IO}
+import cats.effect.IO
 import cats.implicits._
 import com.cognite.sdk.scala.v1.{Event, EventCreate, EventUpdate, EventsFilter, GenericClient}
 import cognite.spark.v1.SparkSchemaHelper.{asRow, fromRow, structType}
@@ -12,13 +12,10 @@ import PushdownUtilities._
 import fs2.Stream
 import io.scalaland.chimney.dsl._
 
-import scala.concurrent.ExecutionContext
-
 class EventsRelation(config: RelationConfig)(val sqlContext: SQLContext)
     extends SdkV1Relation[Event, Long](config, "events")
     with InsertableRelation {
-  @transient implicit lazy val contextShift: ContextShift[IO] =
-    IO.contextShift(ExecutionContext.global)
+  import CdpConnector._
 
   override def getStreams(filters: Array[Filter])(
       client: GenericClient[IO, Nothing],

--- a/src/main/scala/cognite/spark/v1/NumericDataPointsRdd.scala
+++ b/src/main/scala/cognite/spark/v1/NumericDataPointsRdd.scala
@@ -368,7 +368,7 @@ case class NumericDataPointsRdd(
     val bucket = _split.asInstanceOf[Bucket]
 
     bucket.ranges.toVector
-      .flatTraverse {
+      .parFlatTraverse {
         case r: DataPointsRange =>
           queryById(r.id, r.start, r.end, 100000)
             .map(queryResponse => queryResponse.flatMap(_.datapoints))


### PR DESCRIPTION
Spark uses the global execution context for a lot of things, and depleting it gives some horrendous error messages and breaks the reporting of the original exception back to the driver.

So don't use it.