### PR TITLE
Fix flaky tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,17 +47,25 @@ podTemplate(label: label,
                     sh('mkdir -p /root/.sbt/gpg && cp /sbt-credentials/pubring.asc /sbt-credentials/secring.asc /root/.sbt/gpg/')
                 }
                 stage('Run tests') {
-                    sh('sbt -Dsbt.log.noformat=true scalastyle scalafmtCheck coverage +test coverageReport')
+                    def test = "test"
+                    if (env.BRANCH_NAME == 'master') {
+                        test = "+test"
+                    }
+                    sh("sbt -Dsbt.log.noformat=true scalastyle scalafmtCheck coverage $test coverageReport")
                 }
                 stage("Upload report to codecov.io") {
                     sh('bash </codecov-script/upload-report.sh')
                 }
                 stage('Build JAR file') {
+                    def libPackage = "library/package"
+                    if (env.BRANCH_NAME == 'master') {
+                        libPackage = "+library/package"
+                    }
                     sh('sbt -Dsbt.log.noformat=true'
-                       + ' "set test in library := {}"'
-                       + ' "set compile/skip := true"'
-                       + ' "set macroSub/skip := true"'
-                       + ' +library/package')
+                        + ' "set test in library := {}"'
+                        + ' "set compile/skip := true"'
+                        + ' "set macroSub/skip := true"'
+                        + " $libPackage")
                 }
                 if (env.BRANCH_NAME == 'master') {
                     stage('Deploy') {

--- a/src/main/scala/cognite/spark/v1/EventsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/EventsRelation.scala
@@ -53,7 +53,6 @@ class EventsRelation(config: RelationConfig)(val sqlContext: SQLContext)
     // the same RDD partition
     streamsPerFilter.transpose
       .map(s => s.reduce(_.merge(_)))
-
   }
 
   def eventsFilterFromMap(m: Map[String, String]): EventsFilter =

--- a/src/main/scala/cognite/spark/v1/PushdownUtilities.scala
+++ b/src/main/scala/cognite/spark/v1/PushdownUtilities.scala
@@ -119,11 +119,11 @@ object PushdownUtilities {
       case _ => {
         val minimumTimeAsInstant =
           minTime
-            .map(java.sql.Timestamp.valueOf(_).toInstant.plusMillis(1))
+            .map(java.sql.Timestamp.valueOf(_).toInstant)
             .getOrElse(java.time.Instant.ofEpochMilli(0)) //API does not accept values < 0
         val maximumTimeAsInstant =
           maxTime
-            .map(java.sql.Timestamp.valueOf(_).toInstant.minusMillis(1))
+            .map(java.sql.Timestamp.valueOf(_).toInstant)
             .getOrElse(java.time.Instant.ofEpochMilli(Long.MaxValue))
         Some(TimeRange(minimumTimeAsInstant, maximumTimeAsInstant))
       }

--- a/src/test/scala/cognite/spark/v1/AssetsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/AssetsRelationTest.scala
@@ -1,6 +1,5 @@
 package cognite.spark.v1
 
-import com.cognite.sdk.scala.common.ApiKeyAuth
 import org.apache.spark.sql.Row
 import org.apache.spark.SparkException
 import org.apache.spark.sql.functions._

--- a/src/test/scala/cognite/spark/v1/DataPointsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/DataPointsRelationTest.scala
@@ -2,7 +2,7 @@ package cognite.spark.v1
 
 import com.cognite.sdk.scala.common.CdpApiException
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.types.{BooleanType, DoubleType, LongType, StringType, StructField, TimestampType}
+import org.apache.spark.sql.types.{DoubleType, LongType, StringType, StructField, TimestampType}
 import org.scalatest.{FlatSpec, Matchers}
 import org.apache.spark.SparkException
 import org.apache.spark.sql.Row

--- a/src/test/scala/cognite/spark/v1/SdkV1RddTest.scala
+++ b/src/test/scala/cognite/spark/v1/SdkV1RddTest.scala
@@ -1,7 +1,7 @@
 package cognite.spark.v1
 
 import cats.effect.IO
-import com.cognite.sdk.scala.common.{ApiKeyAuth, CdpApiException}
+import com.cognite.sdk.scala.common.CdpApiException
 import com.cognite.sdk.scala.v1.GenericClient
 import fs2.Stream
 import org.apache.spark.TaskContext

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -2,9 +2,6 @@ package cognite.spark.v1
 
 import java.io.IOException
 
-import cats.effect.IO
-import com.softwaremill.sttp._
-import io.circe.generic.auto._
 import com.codahale.metrics.Counter
 import com.cognite.sdk.scala.common.{ApiKeyAuth, Auth}
 import org.apache.spark.sql.SparkSession

--- a/src/test/scala/cognite/spark/v1/StringDataPointsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/StringDataPointsRelationTest.scala
@@ -2,7 +2,7 @@ package cognite.spark.v1
 
 import com.cognite.sdk.scala.common.CdpApiException
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.types.{BooleanType, LongType, StringType, StructField, TimestampType}
+import org.apache.spark.sql.types.{LongType, StringType, StructField, TimestampType}
 import org.scalatest.{FlatSpec, Matchers}
 
 class StringDataPointsRelationTest extends FlatSpec with Matchers with SparkTest {

--- a/src/test/scala/cognite/spark/v1/ThreeDModelRevisionMappingsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/ThreeDModelRevisionMappingsRelationTest.scala
@@ -1,10 +1,9 @@
 package cognite.spark.v1
 
-import com.cognite.sdk.scala.common.ApiKeyAuth
 import org.scalatest.FlatSpec
 
 class ThreeDModelRevisionMappingsRelationTest extends FlatSpec with SparkTest {
-  "ThreeDModelRevisionsRelationTest" should "pass a smoke test" taggedAs WriteTest ignore {
+  "ThreeDModelRevisionsRelationTest" should "pass a smoke test" taggedAs WriteTest in {
     val model = writeClient.threeDModels.list().compile.toList.head
     val revision = writeClient.threeDRevisions(model.id).list().compile.toList.head
 

--- a/src/test/scala/cognite/spark/v1/ThreeDModelRevisionNodesRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/ThreeDModelRevisionNodesRelationTest.scala
@@ -1,6 +1,5 @@
 package cognite.spark.v1
 
-import com.cognite.sdk.scala.common.ApiKeyAuth
 import org.scalatest.FlatSpec
 
 class ThreeDModelRevisionNodesRelationTest extends FlatSpec with SparkTest  {

--- a/src/test/scala/cognite/spark/v1/ThreeDModelRevisionsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/ThreeDModelRevisionsRelationTest.scala
@@ -1,6 +1,5 @@
 package cognite.spark.v1
 
-import com.cognite.sdk.scala.common.ApiKeyAuth
 import org.scalatest.FlatSpec
 
 class ThreeDModelRevisionsRelationTest extends FlatSpec with SparkTest  {

--- a/src/test/scala/cognite/spark/v1/URLTest.scala
+++ b/src/test/scala/cognite/spark/v1/URLTest.scala
@@ -1,6 +1,5 @@
 package cognite.spark.v1
 
-import com.cognite.sdk.scala.common.ApiKeyAuth
 import org.scalatest.FlatSpec
 
 class URLTest extends FlatSpec with SparkTest {


### PR DESCRIPTION
Having all tests write and delete data based on the same unit turned out to be a bad idea, since this increases the number of operations that happen on the same data. This PR decouples the tests, which should fix a lot of the flaky behavior we're seeing now.