### PR TITLE
[DT-1115] Fix bug in push down implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,12 +361,13 @@ To **skip the read/write tests in assembly**, add `test in assembly := {}` to bu
 
 ## Run the project locally with spark-shell
 
-Download the jar-file and place it under SPARK_HOME/jars.
+To download the spark data source, simply add the maven coordinates for the package using the
+`--packages` flag.
 
-Get an API-key for the Open Industrial Data project at https://openindustrialdata.com and run the following commands (replace <release> with the release you'd like, for example 1.0.0-rc1):
+Get an API-key for the Open Industrial Data project at https://openindustrialdata.com and run the following commands (replace <release> with the release you'd like, for example 1.2.0):
 
 ``` cmd
-$> spark-shell --packages com.cognite.spark.datasource:cdp-spark-datasource_2.11:<latest-release>
+$> spark-shell --packages com.cognite.spark.datasource:cdf-spark-datasource_2.11:<latest-release>
 scala> val apiKey="secret-key-you-have"
 scala> val df = spark.sqlContext.read.format("cognite.spark.v1")
   .option("apiKey", apiKey)
@@ -380,3 +381,6 @@ df: org.apache.spark.sql.DataFrame = [name: string, parentId: bigint ... 3 more 
 scala> df.count
 res0: Long = 1000
 ```
+
+Note that if you're on an older version than `1.1.0` you'll need to use the old name,
+`cdp-spark-datasource`.

--- a/src/main/scala/cognite/spark/v1/EventsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/EventsRelation.scala
@@ -31,7 +31,12 @@ class EventsRelation(config: RelationConfig)(val sqlContext: SQLContext)
         "minStartTime",
         "maxStartTime",
         "minEndTime",
-        "maxEndTime")
+        "maxEndTime",
+        "minCreatedTime",
+        "maxCreatedTime",
+        "minLastUpdatedTime",
+        "maxLastUpdatedTime"
+      )
     val pushdownFilterExpression = toPushdownFilterExpression(filters)
     val shouldGetAllRows = shouldGetAll(pushdownFilterExpression, fieldNames)
     val filtersAsMaps = pushdownToParameters(pushdownFilterExpression)
@@ -60,7 +65,9 @@ class EventsRelation(config: RelationConfig)(val sqlContext: SQLContext)
       subtype = m.get("subtype"),
       startTime = timeRangeFromMinAndMax(m.get("minStartTime"), m.get("maxStartTime")),
       endTime = timeRangeFromMinAndMax(m.get("minEndTime"), m.get("maxEndTime")),
-      assetIds = m.get("assetIds").map(assetIdsFromWrappedArray)
+      assetIds = m.get("assetIds").map(assetIdsFromWrappedArray),
+      createdTime = timeRangeFromMinAndMax(m.get("minCreatedTime"), m.get("maxCreatedTime")),
+      lastUpdatedTime = timeRangeFromMinAndMax(m.get("minLastUpdatedTime"), m.get("maxLastUpdatedTime"))
     )
 
   override def insert(rows: Seq[Row]): IO[Unit] = {

--- a/src/main/scala/cognite/spark/v1/PushdownUtilities.scala
+++ b/src/main/scala/cognite/spark/v1/PushdownUtilities.scala
@@ -83,7 +83,7 @@ object PushdownUtilities {
       fieldsWithPushdownFilter: Seq[String]): Boolean =
     pushdownExpression match {
       case PushdownAnd(left, right) =>
-        shouldGetAll(left, fieldsWithPushdownFilter) || shouldGetAll(right, fieldsWithPushdownFilter)
+        shouldGetAll(left, fieldsWithPushdownFilter) && shouldGetAll(right, fieldsWithPushdownFilter)
       case PushdownFilter(field, _) => !fieldsWithPushdownFilter.contains(field)
       case PushdownFilters(filters) =>
         filters


### PR DESCRIPTION
Push down filters were not applied when filtering on a push down column *and* a not push down column. Also sneaking in the pushdown filters on `createdTime` and `lastUpdatedTime` for Events, and an update to the Readme.md.