### PR TITLE
Support ignoreUnknownIds for asset and event deletes

### DIFF
--- a/src/main/scala/cognite/spark/v1/AssetsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/AssetsRelation.scala
@@ -67,8 +67,8 @@ class AssetsRelation(config: RelationConfig)(val sqlContext: SQLContext)
   }
 
   override def delete(rows: Seq[Row]): IO[Unit] = {
-    val ids = rows.map(r => fromRow[DeleteItem](r).id)
-    client.assets.deleteByIds(ids)
+    val deletes = rows.map(r => fromRow[DeleteItem](r))
+    deleteWithIgnoreUnknownIds(client.assets, deletes, config.ignoreUnknownIds)
   }
 
   override def upsert(rows: Seq[Row]): IO[Unit] = getFromRowAndCreate(rows)

--- a/src/main/scala/cognite/spark/v1/EventsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/EventsRelation.scala
@@ -87,8 +87,8 @@ class EventsRelation(config: RelationConfig)(val sqlContext: SQLContext)
   }
 
   override def delete(rows: Seq[Row]): IO[Unit] = {
-    val ids = rows.map(r => fromRow[DeleteItem](r).id)
-    client.events.deleteByIds(ids)
+    val deletes = rows.map(r => fromRow[DeleteItem](r))
+    deleteWithIgnoreUnknownIds(client.events, deletes, config.ignoreUnknownIds)
   }
 
   override def upsert(rows: Seq[Row]): IO[Unit] = getFromRowAndCreate(rows)

--- a/src/main/scala/cognite/spark/v1/SdkV1Relation.scala
+++ b/src/main/scala/cognite/spark/v1/SdkV1Relation.scala
@@ -139,6 +139,13 @@ abstract class SdkV1Relation[A <: Product, I](config: RelationConfig, shortName:
     (create, update).parMapN((_, _) => ())
   }
 
+  def deleteWithIgnoreUnknownIds(
+      resource: DeleteByIdsWithIgnoreUnknownIds[IO, Long],
+      deletes: Seq[DeleteItem],
+      ignoreUnknownIds: Boolean = true): IO[Unit] = {
+    val ids = deletes.map(_.id)
+    resource.deleteByIds(ids, ignoreUnknownIds)
+  }
 }
 
 trait WritableRelation {

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -81,7 +81,8 @@ trait SparkTest extends CdpConnector {
       Constants.DefaultBaseUrl,
       OnConflict.ABORT,
       spark.sparkContext.applicationId,
-      Constants.DefaultParallelismPerPartition
+      Constants.DefaultParallelismPerPartition,
+      true
     )
 
   def getNumberOfRowsRead(metricsPrefix: String, resourceType: String): Long =


### PR DESCRIPTION
- support ignoreUnknownIds when doing delete
- user can specify `true as ignoreUnknownIds` in delete queries to not error out when encountering unknown ids
- `false as ignoreUnknownIds` or not specifying any value for ignoreUnknownIds will error out when encountering unknown ids