### PR TITLE
[DT-1218] Add padding range to datapoints query

### DIFF
--- a/src/main/scala/cognite/spark/v1/NumericDataPointsRdd.scala
+++ b/src/main/scala/cognite/spark/v1/NumericDataPointsRdd.scala
@@ -93,13 +93,10 @@ case class NumericDataPointsRdd(
       case _ =>
         countStart match {
           case Some(start) =>
+            val end = start.plus(granularity.amount, granularity.unit)
             val lastRange =
-              DataPointsRange(
-                id,
-                start,
-                start.plus(granularity.amount, granularity.unit),
-                Some(countSum))
-            lastRange +: ranges
+              DataPointsRange(id, start, end, Some(countSum))
+            lastRange +: DataPointsRange(id, end, end.plus(granularity.amount, granularity.unit), None) +: ranges
           case _ => ranges
         }
     }


### PR DESCRIPTION
Since aggregates are not returned unless there are enough datapoints to
fill the range, we now add an additional range at the end when reading
datapoints without aggregates.