### PR TITLE
Remove trailing comma

### DIFF
--- a/src/test/scala/cognite/spark/v1/AssetHierarchyBuilderTest.scala
+++ b/src/test/scala/cognite/spark/v1/AssetHierarchyBuilderTest.scala
@@ -374,7 +374,7 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
       AssetCreate("cycleZero", None, None, Some(testName),Some("cycleZero"), None, Some("cycleThree")),
       AssetCreate("cycleOne", None, None, Some(testName),Some("cycleOne"), None, Some("cycleZero")),
       AssetCreate("cycleTwo", None, None, Some(testName),Some("cycleTwo"), None, Some("cycleOne")),
-      AssetCreate("cycleThree", None, None, Some(testName),Some("cycleThree"), None, Some("cycleTwo")),
+      AssetCreate("cycleThree", None, None, Some(testName),Some("cycleThree"), None, Some("cycleTwo"))
     )
 
     spark.sparkContext.parallelize(assetTree).toDF().write


### PR DESCRIPTION
We only compile/test on Scala 2.12 for PR builds, so we didn't catch
this change that was not compatible with Scala 2.11.