### PR TITLE
[DT-1424] Only infer schema on a small subset of the table

### DIFF
--- a/src/test/scala/cognite/spark/v1/RawTableRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/RawTableRelationTest.scala
@@ -236,7 +236,7 @@ class RawTableRelationTest extends FlatSpec with Matchers with SparkTest {
 
     val numRowsReadDuringSchemaInferance =
       getNumberOfRowsRead(metricsPrefix, s"raw.$database.$table.rows")
-    numRowsReadDuringSchemaInferance should be(inferSchemaLimit * partitions)
+    numRowsReadDuringSchemaInferance should be(inferSchemaLimit)
   }
 
   "lastUpdatedTime" should "insert data without error" taggedAs (WriteTest) in {


### PR DESCRIPTION
Before we ended up reading 200 (numPartitions) * 10000 (defaultInferenceLimit) just to infer schema. This PR sets num partitions to 1 during schema inference.

I don't think we've a good way of testing this unfortunately. 