### PR TITLE
[DT-1371][DT-1373] Asset Hierarchy generalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ i.e there's a match on `externalId` and there's a change to one of the other fie
 There's also an option to delete assets from CDF that are not referenced in the input data.
 
 ### Requirements
-- The root is denoted by setting its `parentExternalId` to the empty string `""`.
+- Root assets are denoted by setting their `parentExternalId` to the empty string `""`.
 - The input data must not have loops, to ensure all asset hierarchies are fully connected.
 - `externalId` can not be the empty string `""`.
 

--- a/README.md
+++ b/README.md
@@ -160,9 +160,7 @@ There's also an option to delete assets from CDF that are not referenced in the 
 |    Option                  | Default | Description |
 | -------------------------- | --------|------------------------------------------------------------------------------------------------------------------ |
 | `deleteMissingAssets`      | `false` | Whether or not you would like assets under the root to be deleted if they're not present in the input data.       |
-| `ignoreDisconnectedAssets` | `false` | This will ignore assets that are not connected to root, as opposed to throwing an error and stopping the program. |
-| `allowMultipleRoots`       | `true`  | Whether it's allowed to ingest more than one (sub)tree. |
-| `allowSubtreeIngestion`    | `true`  | Whether ingestion of trees without a root node is allowed. Otherwise, an error is raised or the items are ignored when `ignoreDisconnectedAssets` is set |
+| `subtrees` | `ingest` | Controls what should happen with subtrees without a root node in the input data. `ingest` says they will be processed and loaded into CDF, `ignore` will ignore all of them and `error` will stop the execution and raise an error (nothing will be ingested). |
 | `batchSize`                | 1000    | The number of assets to write per API call.                                                                       |
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -145,15 +145,14 @@ Note: The asset hierarchy builder is currently in beta, and has not been suffici
 on production data.
 
 The `.option("type", "assethierarchy")` lets you write new asset hierarchies, or update existing ones,
-using the Spark Data Source. It currently supports writing a single root asset and any number of children.
-The asset hierarchy builder can ingest entire hierarchies, as long as all nodes are connected to the root asset
+using the Spark Data Source.
+The asset hierarchy builder can ingest entire hierarchies of nodes connected
 through the `externalId`/`parentExternalId` relationship. If input contains an update to data that already exists,
 i.e there's a match on `externalId` and there's a change to one of the other fields, the asset will be updated.
 There's also an option to delete assets from CDF that are not referenced in the input data.
 
 ### Requirements
-- The source data must contain a single root, denoted by setting its `parentExternalId` to the empty string `""`.
-- All assets, except root, must be connected to another asset in the input data by `parentExternalId`.
+- The root is denoted by setting its `parentExternalId` to the empty string `""`.
 - The input data must not have loops, to ensure all asset hierarchies are fully connected.
 - `externalId` can not be the empty string `""`.
 
@@ -162,6 +161,8 @@ There's also an option to delete assets from CDF that are not referenced in the 
 | -------------------------- | --------|------------------------------------------------------------------------------------------------------------------ |
 | `deleteMissingAssets`      | `false` | Whether or not you would like assets under the root to be deleted if they're not present in the input data.       |
 | `ignoreDisconnectedAssets` | `false` | This will ignore assets that are not connected to root, as opposed to throwing an error and stopping the program. |
+| `allowMultipleRoots`       | `true`  | Whether it's allowed to ingest more than one (sub)tree. |
+| `allowSubtreeIngestion`    | `true`  | Whether ingestion of trees without a root node is allowed. Otherwise, an error is raised or the items are ignored when `ignoreDisconnectedAssets` is set |
 | `batchSize`                | 1000    | The number of assets to write per API call.                                                                       |
 
 ### Example

--- a/src/main/scala/cognite/spark/v1/AssetHierarchyBuilder.scala
+++ b/src/main/scala/cognite/spark/v1/AssetHierarchyBuilder.scala
@@ -1,12 +1,16 @@
 package cognite.spark.v1
 
 import cats.effect.IO
+import cats.effect.syntax._
 import cats.implicits._
+import cats.syntax._
 import cognite.spark.v1.SparkSchemaHelper.{fromRow, structType}
-import com.cognite.sdk.scala.common.SetValue
+import com.cognite.sdk.scala.common.{CdpApiException, SetNull, SetValue}
 import com.cognite.sdk.scala.v1.{Asset, AssetCreate, AssetUpdate, AssetsFilter, CogniteExternalId}
 import org.apache.spark.sql.types.{DataTypes, StructType}
 import org.apache.spark.sql.{DataFrame, SQLContext}
+
+import scala.collection.mutable
 
 final case class AssetsIngestSchema(
     externalId: String,
@@ -41,14 +45,25 @@ object AssetsIngestSchema {
     )
 }
 
-final case class MultipleRootsException(message: String = "Tree has more than one root.")
-    extends Exception(message)
+private case class AssetSubtree(
+    // node that contains all the `nodes`
+    // might be just a pseudo-root
+    root: AssetsIngestSchema,
+    nodes: Array[AssetsIngestSchema]
+)
+
+final case class MultipleRootsException(roots: Seq[String])
+    extends Exception(s"Tree has more than one root: ${roots.mkString(", ")}")
 final case class NoRootException(
     message: String = """Tree has no root. Set parentExternalId to "" for the root Asset.""")
     extends Exception(message)
 final case class InvalidTreeException(message: String = s"The tree is has an invalid structure.")
     extends Exception(message)
+final case class NonUniqueAssetId(id: String)
+    extends Exception(s"Asset tree contains asset '$id' multiple times.")
 final case class EmptyExternalIdException(message: String = s"ExternalId cannot be an empty String.")
+    extends Exception(message)
+final case class CdfDoesNotSupportException(message: String)
     extends Exception(message)
 
 class AssetHierarchyBuilder(config: RelationConfig)(val sqlContext: SQLContext)
@@ -56,28 +71,75 @@ class AssetHierarchyBuilder(config: RelationConfig)(val sqlContext: SQLContext)
 
   import CdpConnector.cdpConnectorContextShift
 
-  def build(df: DataFrame): IO[Unit] = {
-    val deleteMissingAssets = config.deleteMissingAssets
-    val ignoreDisconnectedAssets = config.ignoreDisconnectedAssets
-    val batchSize = config.batchSize.getOrElse(Constants.DefaultBatchSize)
+  val batchSize = config.batchSize.getOrElse(Constants.DefaultBatchSize)
 
+  val deleteMissingAssets = config.deleteMissingAssets
+  val ignoreDisconnectedAssets = config.ignoreDisconnectedAssets
+  val allowMultipleRoots = true // TODO
+  val allowSubtreeIngestion = true // TODO
+
+  def build(df: DataFrame): IO[Unit] = {
     val sourceTree = df.collect.map(r => fromRow[AssetsIngestSchema](r))
 
-    val (root, children) = validateAndOrderInput(sourceTree, ignoreDisconnectedAssets)
+    val subtrees = validateAndOrderInput(sourceTree).toVector
+
+    val subtrees2 =
+      if (allowSubtreeIngestion) {
+        subtrees
+      } else if (ignoreDisconnectedAssets) {
+        // only take trees with proper roots
+        subtrees.filter(t => t.root.parentExternalId.isEmpty)
+      } else {
+        val nonRoots = subtrees.filter(t => t.root.parentExternalId.nonEmpty)
+        if (nonRoots.nonEmpty) {
+          throw InvalidTreeException(
+            s"These subtrees are not connected to any root: ${nonRoots.map(_.root.externalId).mkString(", ")}."
+              + " Did you meant to set option ignoreDisconnectedAssets or allowSubtreeIngestion to true?"
+          )
+        }
+        subtrees
+      }
+
+    if (subtrees.nonEmpty && subtrees2.isEmpty){
+      // in case all nodes are dropped due to ignoreDisconnectedAssets
+      throw NoRootException()
+      // we can allow empty source data set, that won't really happen by accident
+    }
+
+    if (!allowMultipleRoots && subtrees2.size > 1) {
+      throw MultipleRootsException(subtrees2.map(_.root.externalId))
+    }
 
     for {
-      rootAndChildren <- getCdfRootAndTree(CogniteExternalId(root.externalId))
-      (cdfRoot, cdfChildren) = (rootAndChildren._1, rootAndChildren._2)
+      _ <- validateSubtreeRoots(subtrees2.map(_.root))
+      _ <- subtrees2.map(t => buildSubtree(t.root, t.nodes)).sequence_ // TODO: parallel?
+    } yield ()
+  }
+
+
+  def validateSubtreeRoots(roots: Seq[AssetsIngestSchema]): IO[Unit] = {
+    // check that all parentExternalId exist
+    val ids = roots.map(_.parentExternalId).filter(_.nonEmpty)
+    if (ids.isEmpty) {
+      IO.unit
+    } else {
+      // The API calls throws exception when any of the ids does not exist
+      client.assets.retrieveByExternalIds(ids) *> IO.unit
+    }
+  }
+
+  def buildSubtree(root: AssetsIngestSchema, children: Array[AssetsIngestSchema]): IO[Unit] =
+    for {
+      cdfRoot <- fetchCdfRoot(root.externalId)
       _ <- upsertRoot(root, cdfRoot)
-      (toDelete, toInsert, toUpdate) = nodesToDeleteInsertUpdate(root, children, cdfChildren)
+      cdfSubtree <- fetchCdfSubtree(root)
+      (toDelete, toInsert, toUpdate) = nodesToDeleteInsertUpdate(root, children, cdfSubtree)
       _ <- insert(toInsert, batchSize)
       _ <- update(toUpdate, batchSize)
       _ <- delete(toDelete, deleteMissingAssets, batchSize)
     } yield ()
-  }
 
-  def insert(toInsert: Seq[AssetsIngestSchema], batchSize: Int): IO[Unit] =
-    if (toInsert.nonEmpty) {
+  def insert(toInsert: Seq[AssetsIngestSchema], batchSize: Int): IO[Unit] = {
       val assetCreatesToInsert = toInsert.map(AssetsIngestSchema.toAssetCreate)
       // Traverse batches in order to ensure writing parents first
       assetCreatesToInsert
@@ -85,8 +147,6 @@ class AssetHierarchyBuilder(config: RelationConfig)(val sqlContext: SQLContext)
         .toList
         .traverse(client.assets.create)
         .flatTap(x => incMetrics(itemsCreated, x.map(_.size).sum)) *> IO.unit
-    } else {
-      IO.unit
     }
 
   def delete(toDelete: Seq[Asset], deleteMissingAssets: Boolean, batchSize: Int): IO[Unit] =
@@ -118,71 +178,116 @@ class AssetHierarchyBuilder(config: RelationConfig)(val sqlContext: SQLContext)
       IO.unit
     }
 
-  def getCdfRootAndTree(sourceRootExternalId: CogniteExternalId): IO[(Option[Asset], List[Asset])] = {
-    val cdfTree = client.assets
-      .filter(AssetsFilter(rootIds = Some(Seq(sourceRootExternalId))))
-      .compile
-      .toList
+  def fetchCdfRoot(sourceRootExternalId: String): IO[Option[Asset]] =
+    client.assets.retrieveByExternalId(sourceRootExternalId)
+      .map(Some(_).asInstanceOf[Option[Asset]])
+      .handleError {
+        case e: CdpApiException if e.code == 400 && e.missing.isDefined => None.asInstanceOf[Option[Asset]]
+      }
 
-    for {
-      tree <- cdfTree
-      root = tree.find(_.externalId.contains(sourceRootExternalId.externalId))
-    } yield (root, tree)
-  }
+  def fetchCdfSubtree(root: AssetsIngestSchema): IO[List[Asset]] =
+    if (root.parentExternalId.isEmpty) {
+      // proper root
+      client.assets
+        .filter(AssetsFilter(rootIds = Some(Seq(CogniteExternalId(root.externalId)))))
+        .compile
+        .toList
+    } else {
+      // This API will error out if the subtree contains more than 100,000 items
+      // If that's a problem, we'll have to workaround by downloading it's entire hierarchy
+      // (or convince the API team to lift that limitation)
+      client.assets
+        .filter(AssetsFilter(assetSubtreeIds = Some(Seq(CogniteExternalId(root.externalId)))))
+        .compile
+        .toList
+    }
 
   def upsertRoot(
       root: AssetsIngestSchema,
       sourceRoot: Option[Asset]
-  ): IO[Unit] =
+  ): IO[Unit] = {
+    val parentId = if (root.parentExternalId.isEmpty) {
+      None
+    } else {
+      Some(root.parentExternalId)
+    }
+
+    // TODO: don't do the update when nothing is changed (waiting for )
     sourceRoot match {
       case None =>
         client.assets
-          .create(Seq(AssetsIngestSchema.toAssetCreate(root).copy(parentExternalId = None)))
-          .flatTap(x => incMetrics(itemsCreated, x.size)) *> IO.unit
-      case Some(asset) =>
-        if (isMostlyEqual(root, asset)) {
-          IO.unit
-        } else {
+          .create(Seq(AssetsIngestSchema.toAssetCreate(root).copy(parentExternalId = parentId)))
+          .flatTap(x => incMetrics(itemsCreated, x.size))
+          .map(x => x.head)
+      case Some(asset) => {
+          val parentIdUpdate = (parentId, asset.parentId) match {
+            case (None, Some(oldParent)) =>
+              throw CdfDoesNotSupportException(
+                s"Can not make root from asset '${}' which is already inside asset '${oldParent}."
+                + " You might need to remove the asset and insert it again.")
+            case (None, None) => None
+            case (Some(newParent), _) => Some(SetValue(newParent))
+          }
           client.assets
             .updateByExternalId(
               Seq(
                 root.externalId -> AssetsIngestSchema
                   .toAssetUpdate(root)
-                  .copy(parentExternalId = None)).toMap)
-            .flatTap(x => incMetrics(itemsUpdated, x.size)) *> IO.unit
-        }
+                  .copy(parentExternalId = parentIdUpdate)).toMap)
+            .flatTap(x => incMetrics(itemsUpdated, x.size))
+            .map(x => x.head)
+      }
     }
+  }
 
   def nodesToDeleteInsertUpdate(
       root: AssetsIngestSchema,
       children: Seq[AssetsIngestSchema],
       cdfTree: Seq[Asset]): (Seq[Asset], Seq[AssetsIngestSchema], Seq[AssetsIngestSchema]) = {
-    // Insert assets that are not present in CDF
-    val toInsert = children.filter(a => !cdfTree.map(_.externalId.get).contains(a.externalId))
-
+    val newIds = (Seq(root) ++ children).map(_.externalId).toSet
     // Keep assets that are in both source and CDF, delete those only in CDF
-    val (toKeep, toDelete) =
-      cdfTree.partition(a => (Seq(root) ++ children).map(_.externalId).contains(a.externalId.get))
+    val toDelete =
+      cdfTree.filter(a => !a.externalId.exists(newIds.contains))
 
+    val cdfTreeMap = cdfTree.flatMap(a => a.externalId.map((_, a))).toMap
+    // Insert assets that are not present in CDF
+    val toInsert = children.filter(a => !cdfTreeMap.contains(a.externalId))
+
+    val cdfTreeIdMap = cdfTree.map(a => (a.id, a)).toMap
     // Filter out assets that would not be changed in an update
-    val toUpdate = children.filter(a => needsUpdate(a, toKeep))
+    val toUpdate = children.filter(a => needsUpdate(a, cdfTreeMap, cdfTreeIdMap))
 
     (toDelete, toInsert, toUpdate)
   }
 
-  def needsUpdate(child: AssetsIngestSchema, cdfTree: Seq[Asset]): Boolean = {
+  def needsUpdate(child: AssetsIngestSchema, cdfTreeByExternalId: Map[String, Asset], cdfTreeById: Map[Long, Asset]): Boolean = {
     // Find the matching asset in CDF
-    val cdfAsset = cdfTree.find(a => a.externalId.contains(child.externalId))
+    val cdfAsset = cdfTreeByExternalId.get(child.externalId)
     cdfAsset match {
+      case Some(asset) if asset.parentId.isEmpty =>
+        // it's root and should not be -> update
+        true
       case Some(asset) =>
         // Find the parent asset in CDF to be able to get the externalId of the parent
-        cdfTree.find(a => asset.parentId.contains(a.id)) match {
+        cdfTreeById.get(asset.parentId.get) match {
           case Some(parentAsset) =>
             !isMostlyEqual(child, asset) || !parentAsset.externalId.contains(child.parentExternalId)
           case None =>
-            false
+            // this should not happen, except for races
+            // in that case just do the update, just to be sure
+            true
         }
-      case None => false
+      case None => false // this one will be inserted
+    }
+  }
+
+  def validateSourceTree(source: Array[AssetsIngestSchema]): Unit = {
+    val emptyExternalIds = source.filter(_.externalId == "")
+    if (emptyExternalIds.nonEmpty) {
+      throw EmptyExternalIdException(
+        s"""Found empty externalId for children with names: ${emptyExternalIds
+          .map(_.name)
+          .mkString(", ")}""")
     }
   }
 
@@ -190,26 +295,43 @@ class AssetHierarchyBuilder(config: RelationConfig)(val sqlContext: SQLContext)
     child.description == asset.description &&
       child.metadata == asset.metadata &&
       child.name == asset.name &&
-      child.source == asset.source
+      child.source == asset.source &&
+      child.dataSetId == asset.dataSetId
 
-  def validateAndOrderInput(
-      tree: Array[AssetsIngestSchema],
-      ignoreDisconnectedAssets: Boolean): (AssetsIngestSchema, Seq[AssetsIngestSchema]) = {
-    val (root, children) = splitIntoRootAndChildren(tree)
-
-    (root, getValidatedTree(root, children, ignoreDisconnectedAssets))
+  def buildAssetMap(source: Array[AssetsIngestSchema]): mutable.HashMap[String, AssetsIngestSchema] = {
+    val map = mutable.HashMap[String, AssetsIngestSchema]()
+    for (x <- source) {
+      if (map.contains(x.externalId)) {
+        throw NonUniqueAssetId(x.externalId)
+      }
+      map(x.externalId) = x
+    }
+    map
   }
 
-  def splitIntoRootAndChildren(
-      tree: Array[AssetsIngestSchema]): (AssetsIngestSchema, Array[AssetsIngestSchema]) = {
-    val (maybeRoots, children) = tree.partition(_.parentExternalId == "")
-
-    val root = maybeRoots match {
-      case Array(singleRoot) => singleRoot
-      case Array() => throw NoRootException()
-      case Array(_, _*) => throw MultipleRootsException()
-    }
-    (root, children)
+  private def validateAndOrderInput(tree: Array[AssetsIngestSchema]): Vector[AssetSubtree] = {
+    validateSourceTree(tree)
+    val assetMap = buildAssetMap(tree)
+    def getRoot(tree: AssetsIngestSchema, path: Set[String] = Set()): AssetsIngestSchema =
+      if (path contains tree.externalId) {
+        throw InvalidTreeException(s"The asset tree contains a cycle: ${path.mkString(", ")}")
+      } else {
+        assetMap
+          .get(tree.parentExternalId)
+          .map(getRoot(_, path + tree.externalId))
+          .getOrElse(tree)
+      }
+    //    val roots = tree.filter(a => a.parentExternalId.isEmpty || !assetMap.contains(a.parentExternalId))
+//    val rootBuckets = Map(roots.map(r => r -> mutable.ArrayBuffer()): _*)
+    tree
+      .groupBy(getRoot(_))
+      .map({
+        case (root, items) => {
+          assert(items.contains(root))
+          AssetSubtree(root, orderChildren(root.externalId, items.filter(_ != root)))
+        }
+      })
+      .toVector
   }
 
   def getValidatedTree(
@@ -217,13 +339,6 @@ class AssetHierarchyBuilder(config: RelationConfig)(val sqlContext: SQLContext)
       children: Array[AssetsIngestSchema],
       ignoreDisconnectedAssets: Boolean): Seq[AssetsIngestSchema] = {
     val visited = Seq[AssetsIngestSchema]()
-    val emptyExternalIds = children.filter(_.externalId == "")
-    if (emptyExternalIds.nonEmpty) {
-      throw EmptyExternalIdException(
-        s"""Found empty externalId for children with names: ${emptyExternalIds
-          .map(_.name)
-          .mkString(", ")}""")
-    }
     val insertableTree = iterateChildren(children, Array(root.externalId), visited)
     val insertableTreeExternalIds = insertableTree.map(_.externalId)
 
@@ -252,6 +367,9 @@ class AssetHierarchyBuilder(config: RelationConfig)(val sqlContext: SQLContext)
       iterateChildren(currentChildren, nextChildren.map(_.externalId), visited ++ nextChildren)
     }
   }
+
+  def orderChildren(rootId: String, nodes: Array[AssetsIngestSchema]): Array[AssetsIngestSchema] =
+    iterateChildren(nodes, Array(rootId), Seq()).toArray
 
   override def schema: StructType = structType[AssetsIngestSchema]
 }

--- a/src/main/scala/cognite/spark/v1/AssetHierarchyBuilder.scala
+++ b/src/main/scala/cognite/spark/v1/AssetHierarchyBuilder.scala
@@ -334,8 +334,7 @@ class AssetHierarchyBuilder(config: RelationConfig)(val sqlContext: SQLContext)
           .map(getRoot(_, path + tree.externalId))
           .getOrElse(tree)
       }
-    //    val roots = tree.filter(a => a.parentExternalId.isEmpty || !assetMap.contains(a.parentExternalId))
-//    val rootBuckets = Map(roots.map(r => r -> mutable.ArrayBuffer()): _*)
+
     tree
       .groupBy(getRoot(_))
       .map({

--- a/src/main/scala/cognite/spark/v1/AssetHierarchyBuilder.scala
+++ b/src/main/scala/cognite/spark/v1/AssetHierarchyBuilder.scala
@@ -87,7 +87,9 @@ class AssetHierarchyBuilder(config: RelationConfig)(val sqlContext: SQLContext)
   def build(df: DataFrame): IO[Unit] = {
     val sourceTree = df.collect.map(r => fromRow[AssetsIngestSchema](r))
 
-    val subtrees = validateAndOrderInput(sourceTree).toVector
+    val subtrees =
+      validateAndOrderInput(sourceTree)
+        .sortBy(_.root.externalId) // make potential errors deterministic
 
     val subtrees2 =
       if (allowSubtreeIngestion) {

--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -25,6 +25,8 @@ case class RelationConfig(
     ignoreUnknownIds: Boolean,
     deleteMissingAssets: Boolean,
     ignoreDisconnectedAssets: Boolean,
+    allowSubtreeIngestion: Boolean,
+    allowMultipleRoots: Boolean,
     legacyNameSource: LegacyNameSource.Value
 )
 
@@ -59,6 +61,91 @@ class DefaultSource
 
   override def createRelation(sqlContext: SQLContext, parameters: Map[String, String]): BaseRelation =
     createRelation(sqlContext, parameters, null) // scalastyle:off null
+
+  private def toBoolean(
+      parameters: Map[String, String],
+      parameterName: String,
+      defaultValue: Boolean = false): Boolean =
+    parameters.get(parameterName) match {
+      case Some(string) =>
+        if (string.equalsIgnoreCase("true")) {
+          true
+        } else if (string.equalsIgnoreCase("false")) {
+          false
+        } else {
+          sys.error("$parameterName must be 'true' or 'false'")
+        }
+      case None => defaultValue
+    }
+
+  private def toPositiveInt(parameters: Map[String, String], parameterName: String): Option[Int] =
+    parameters.get(parameterName).map { intString =>
+      val intValue = intString.toInt
+      if (intValue <= 0) {
+        sys.error(s"$parameterName must be greater than 0")
+      }
+      intValue
+    }
+
+  private def parseSaveMode(parameters: Map[String, String]) = {
+    val onConflictName = parameters.getOrElse("onconflict", "ABORT")
+    OnConflict
+      .withNameOpt(onConflictName.toUpperCase())
+      .getOrElse(throw new IllegalArgumentException(
+        s"$onConflictName is not a valid onConflict option. Please choose one of the following options instead: ${OnConflict.values
+          .mkString(", ")}"))
+  }
+
+  def parseRelationConfig(parameters: Map[String, String], sqlContext: SQLContext): RelationConfig = {
+    val maxRetries = toPositiveInt(parameters, "maxRetries")
+      .getOrElse(Constants.DefaultMaxRetries)
+    val baseUrl = parameters.getOrElse("baseUrl", Constants.DefaultBaseUrl)
+    val bearerToken = parameters
+      .get("bearerToken")
+      .map(bearerToken => BearerTokenAuth(bearerToken))
+    val apiKey = parameters
+      .get("apiKey")
+      .map(apiKey => ApiKeyAuth(apiKey))
+    val auth = apiKey
+      .orElse(bearerToken)
+      .getOrElse(sys.error("Either apiKey or bearerToken is required."))
+    val projectName = parameters
+      .getOrElse("project", DefaultSource.getProjectFromAuth(auth, maxRetries, baseUrl))
+    val batchSize = toPositiveInt(parameters, "batchSize")
+    val limitPerPartition = toPositiveInt(parameters, "limitPerPartition")
+    val partitions = toPositiveInt(parameters, "partitions")
+      .getOrElse(Constants.DefaultPartitions)
+    val metricsPrefix = parameters.get("metricsPrefix") match {
+      case Some(prefix) => s"$prefix"
+      case None => ""
+    }
+    val collectMetrics = toBoolean(parameters, "collectMetrics")
+    val saveMode = parseSaveMode(parameters)
+    val parallelismPerPartition = {
+      toPositiveInt(parameters, "parallelismPerPartition").getOrElse(
+        Constants.DefaultParallelismPerPartition)
+    }
+    RelationConfig(
+      auth,
+      projectName,
+      batchSize,
+      limitPerPartition,
+      partitions,
+      maxRetries,
+      collectMetrics,
+      metricsPrefix,
+      baseUrl,
+      saveMode,
+      sqlContext.sparkContext.applicationId,
+      parallelismPerPartition,
+      ignoreUnknownIds = toBoolean(parameters, "ignoreUnknownIds", true),
+      deleteMissingAssets = toBoolean(parameters, "deleteMissingAssets", false),
+      ignoreDisconnectedAssets = toBoolean(parameters, "ignoreDisconnectedAssets", false),
+      allowSubtreeIngestion = toBoolean(parameters, "allowSubtreeIngestion", true),
+      allowMultipleRoots = toBoolean(parameters, "allowMultipleRoots", true),
+      legacyNameSource = LegacyNameSource.fromSparkOption(parameters.get("useLegacyName"))
+    )
+  }
 
   // scalastyle:off cyclomatic.complexity method.length
   override def createRelation(

--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -2,6 +2,7 @@ package cognite.spark.v1
 
 import cats.effect.IO
 import cats.implicits._
+import cognite.spark.v1.OnConflict.values
 import com.cognite.sdk.scala.common.{ApiKeyAuth, Auth, BearerTokenAuth}
 import com.cognite.sdk.scala.v1.GenericClient
 import com.softwaremill.sttp.SttpBackend
@@ -24,9 +25,7 @@ case class RelationConfig(
     parallelismPerPartition: Int,
     ignoreUnknownIds: Boolean,
     deleteMissingAssets: Boolean,
-    ignoreDisconnectedAssets: Boolean,
-    allowSubtreeIngestion: Boolean,
-    allowMultipleRoots: Boolean,
+    subtrees: AssetSubtreeOption.AssetSubtreeOption,
     legacyNameSource: LegacyNameSource.Value
 )
 
@@ -50,6 +49,13 @@ object LegacyNameSource extends Enumeration {
     }
 }
 
+object AssetSubtreeOption extends Enumeration {
+  type AssetSubtreeOption = Value
+  val Ingest, Ignore, Error = Value
+
+  def withNameOpt(s: String): Option[Value] = values.find(_.toString.toLowerCase == s.toLowerCase)
+}
+
 class DefaultSource
     extends RelationProvider
     with CreatableRelationProvider
@@ -61,91 +67,6 @@ class DefaultSource
 
   override def createRelation(sqlContext: SQLContext, parameters: Map[String, String]): BaseRelation =
     createRelation(sqlContext, parameters, null) // scalastyle:off null
-
-  private def toBoolean(
-      parameters: Map[String, String],
-      parameterName: String,
-      defaultValue: Boolean = false): Boolean =
-    parameters.get(parameterName) match {
-      case Some(string) =>
-        if (string.equalsIgnoreCase("true")) {
-          true
-        } else if (string.equalsIgnoreCase("false")) {
-          false
-        } else {
-          sys.error("$parameterName must be 'true' or 'false'")
-        }
-      case None => defaultValue
-    }
-
-  private def toPositiveInt(parameters: Map[String, String], parameterName: String): Option[Int] =
-    parameters.get(parameterName).map { intString =>
-      val intValue = intString.toInt
-      if (intValue <= 0) {
-        sys.error(s"$parameterName must be greater than 0")
-      }
-      intValue
-    }
-
-  private def parseSaveMode(parameters: Map[String, String]) = {
-    val onConflictName = parameters.getOrElse("onconflict", "ABORT")
-    OnConflict
-      .withNameOpt(onConflictName.toUpperCase())
-      .getOrElse(throw new IllegalArgumentException(
-        s"$onConflictName is not a valid onConflict option. Please choose one of the following options instead: ${OnConflict.values
-          .mkString(", ")}"))
-  }
-
-  def parseRelationConfig(parameters: Map[String, String], sqlContext: SQLContext): RelationConfig = {
-    val maxRetries = toPositiveInt(parameters, "maxRetries")
-      .getOrElse(Constants.DefaultMaxRetries)
-    val baseUrl = parameters.getOrElse("baseUrl", Constants.DefaultBaseUrl)
-    val bearerToken = parameters
-      .get("bearerToken")
-      .map(bearerToken => BearerTokenAuth(bearerToken))
-    val apiKey = parameters
-      .get("apiKey")
-      .map(apiKey => ApiKeyAuth(apiKey))
-    val auth = apiKey
-      .orElse(bearerToken)
-      .getOrElse(sys.error("Either apiKey or bearerToken is required."))
-    val projectName = parameters
-      .getOrElse("project", DefaultSource.getProjectFromAuth(auth, maxRetries, baseUrl))
-    val batchSize = toPositiveInt(parameters, "batchSize")
-    val limitPerPartition = toPositiveInt(parameters, "limitPerPartition")
-    val partitions = toPositiveInt(parameters, "partitions")
-      .getOrElse(Constants.DefaultPartitions)
-    val metricsPrefix = parameters.get("metricsPrefix") match {
-      case Some(prefix) => s"$prefix"
-      case None => ""
-    }
-    val collectMetrics = toBoolean(parameters, "collectMetrics")
-    val saveMode = parseSaveMode(parameters)
-    val parallelismPerPartition = {
-      toPositiveInt(parameters, "parallelismPerPartition").getOrElse(
-        Constants.DefaultParallelismPerPartition)
-    }
-    RelationConfig(
-      auth,
-      projectName,
-      batchSize,
-      limitPerPartition,
-      partitions,
-      maxRetries,
-      collectMetrics,
-      metricsPrefix,
-      baseUrl,
-      saveMode,
-      sqlContext.sparkContext.applicationId,
-      parallelismPerPartition,
-      ignoreUnknownIds = toBoolean(parameters, "ignoreUnknownIds", true),
-      deleteMissingAssets = toBoolean(parameters, "deleteMissingAssets", false),
-      ignoreDisconnectedAssets = toBoolean(parameters, "ignoreDisconnectedAssets", false),
-      allowSubtreeIngestion = toBoolean(parameters, "allowSubtreeIngestion", true),
-      allowMultipleRoots = toBoolean(parameters, "allowMultipleRoots", true),
-      legacyNameSource = LegacyNameSource.fromSparkOption(parameters.get("useLegacyName"))
-    )
-  }
 
   // scalastyle:off cyclomatic.complexity method.length
   override def createRelation(
@@ -297,7 +218,7 @@ object DefaultSource {
           .mkString(", ")}"))
   }
 
-  def parseRelationConfig(parameters: Map[String, String], sqlContext: SQLContext): RelationConfig = {
+  def parseRelationConfig(parameters: Map[String, String], sqlContext: SQLContext): RelationConfig = { // scalastyle:off
     val maxRetries = toPositiveInt(parameters, "maxRetries")
       .getOrElse(Constants.DefaultMaxRetries)
     val baseUrl = parameters.getOrElse("baseUrl", Constants.DefaultBaseUrl)
@@ -326,9 +247,27 @@ object DefaultSource {
       toPositiveInt(parameters, "parallelismPerPartition").getOrElse(
         Constants.DefaultParallelismPerPartition)
     }
-    val ignoreUnknownIds = toBoolean(parameters, "ignoreUnknownIds", true)
-    val deleteMissingAssets = toBoolean(parameters, "deleteMissingAssets", false)
-    val ignoreDisconnectedAssets = toBoolean(parameters, "ignoreDisconnectedAssets", false)
+    // keep compatibility with ignoreDisconnectedAssets
+    val subtreesOption =
+      (parameters.get("ignoreDisconnectedAssets"), parameters.get("subtrees")) match {
+        case (None, None) => AssetSubtreeOption.Ingest
+        case (None, Some(x)) =>
+          AssetSubtreeOption
+            .withNameOpt(x)
+            .getOrElse(
+              throw new IllegalArgumentException(
+                s"`$x` is an invalid value for option subtree. You can use ingest, ignore or value."))
+        case (Some(_), None) =>
+          if (toBoolean(parameters, "ignoreDisconnectedAssets")) {
+            AssetSubtreeOption.Ignore
+          } else {
+            // error was the previous default. If somebody was explicit about ignoreDisconnectedAssets=false, then error
+            AssetSubtreeOption.Error
+          }
+        case (Some(ignoreDisconnectedAssets), Some(subtree)) =>
+          throw new IllegalArgumentException(
+            s"Can not specify both ignoreDisconnectedAssets=$ignoreDisconnectedAssets and subtree=$subtree")
+      }
     RelationConfig(
       auth,
       projectName,
@@ -342,9 +281,9 @@ object DefaultSource {
       saveMode,
       Option(sqlContext).map(_.sparkContext.applicationId).getOrElse("CDF"),
       parallelismPerPartition,
-      ignoreUnknownIds,
-      deleteMissingAssets,
-      ignoreDisconnectedAssets,
+      ignoreUnknownIds = toBoolean(parameters, "ignoreUnknownIds", true),
+      deleteMissingAssets = toBoolean(parameters, "deleteMissingAssets", false),
+      subtrees = subtreesOption,
       legacyNameSource = LegacyNameSource.fromSparkOption(parameters.get("useLegacyName"))
     )
   }

--- a/src/test/scala/cognite/spark/v1/AssetHierarchyBuilderTest.scala
+++ b/src/test/scala/cognite/spark/v1/AssetHierarchyBuilderTest.scala
@@ -1,6 +1,7 @@
 package cognite.spark.v1
 
 import cognite.spark.v1.SparkSchemaHelper.fromRow
+import com.cognite.sdk.scala.common.CdpApiException
 import com.cognite.sdk.scala.v1.AssetCreate
 import org.apache.spark.sql.Row
 import org.scalatest.{FlatSpec, Matchers}
@@ -17,71 +18,79 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
 
   val testName = "assetHierarchyTest"
 
+  private def ingest(
+      tree: Seq[AssetCreate],
+      metricsPrefix: Option[String] = None,
+      batchSize: Int = 2,
+      allowSubtreeIngestion: Boolean = true,
+      ignoreDisconnectedAssets: Boolean = false,
+      allowMultipleRoots: Boolean = true,
+      deleteMissingAssets: Boolean = false): Unit =
+      spark.sparkContext.parallelize(tree).toDF().write
+        .format("cognite.spark.v1")
+        .option("apiKey", writeApiKey)
+        .option("type", "assethierarchy")
+        .option("collectMetrics", metricsPrefix.isDefined)
+        .option("allowSubtreeIngestion", allowSubtreeIngestion)
+        .option("ignoreDisconnectedAssets", ignoreDisconnectedAssets)
+        .option("allowMultipleRoots", allowMultipleRoots)
+        .option("deleteMissingAssets", deleteMissingAssets)
+        .option("batchSize", batchSize)
+        .option("metricsPrefix", metricsPrefix.getOrElse(""))
+        .save
+
+  private def cleanDB() =
+    writeClient.assets.deleteByExternalIds(Seq("dad", "dad2", "unusedZero", "son"), true, true)
+
+
   it should "throw an error when everything is ignored" in {
     val tree = Seq(
       AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some("someNode"))
     )
     val e = intercept[Exception] {
-      spark.sparkContext.parallelize(tree).toDF().write
-        .format("cognite.spark.v1")
-        .option("apiKey", writeApiKey)
-        .option("allowSubtreeIngestion", "false")
-        .option("ignoreDisconnectedAssets", "true")
-        .option("type", "assethierarchy")
-        .save
+      ingest(tree, allowSubtreeIngestion = false, ignoreDisconnectedAssets = true)
     }
     e shouldBe an[NoRootException]
   }
 
   it should "throw an error if some nodes are disconnected from the root" in {
+    val brokenTree = Seq(
+      AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some("")),
+      AssetCreate("son", None, None, Some(testName),Some("son"), None, Some("dad")),
+      AssetCreate("daughter", None, None, Some(testName),Some("daughter"), None, Some("dad")),
+      AssetCreate("daughterSon", None, None, Some(testName),Some("daughterSon"), None, Some("daughter")),
+      AssetCreate("othertree", None, None, Some(testName),Some("other"), None, Some("otherDad"))
+    )
     val e = intercept[Exception] {
-      spark.sparkContext.parallelize(Seq(
-        AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some("")),
-        AssetCreate("son", None, None, Some(testName),Some("son"), None, Some("dad")),
-        AssetCreate("daughter", None, None, Some(testName),Some("daughter"), None, Some("dad")),
-        AssetCreate("daughterSon", None, None, Some(testName),Some("daughterSon"), None, Some("daughter")),
-        AssetCreate("othertree", None, None, Some(testName),Some("other"), None, Some("otherDad"))
-      )).toDF().write
-        .format("cognite.spark.v1")
-        .option("apiKey", writeApiKey)
-        .option("type", "assethierarchy")
-        .option("allowSubtreeIngestion", "false")
-        .save
+      ingest(brokenTree, allowSubtreeIngestion = false)
     }
     e shouldBe an[InvalidTreeException]
   }
 
   it should "throw an error if there are multiple roots" in {
+    val multiRootTree = Seq(
+      AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some("")),
+      AssetCreate("son", None, None, Some(testName),Some("son"), None, Some("")),
+      AssetCreate("daughter", None, None, Some(testName),Some("daughter"), None, Some("")),
+      AssetCreate("daughterSon", None, None, Some(testName),Some("daughterSon"), None, Some("daughter")),
+      AssetCreate("othertree", None, None, Some(testName),Some("other"), None, Some("otherDad"))
+    )
     val e = intercept[Exception] {
-      spark.sparkContext.parallelize(Seq(
-        AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some("")),
-        AssetCreate("son", None, None, Some(testName),Some("son"), None, Some("")),
-        AssetCreate("daughter", None, None, Some(testName),Some("daughter"), None, Some("")),
-        AssetCreate("daughterSon", None, None, Some(testName),Some("daughterSon"), None, Some("daughter")),
-        AssetCreate("othertree", None, None, Some(testName),Some("other"), None, Some("otherDad"))
-      )).toDF().write
-        .format("cognite.spark.v1")
-        .option("apiKey", writeApiKey)
-        .option("type", "assethierarchy")
-        .option("allowMultipleRoots", "false")
-        .save
+      ingest(multiRootTree, allowMultipleRoots = false)
     }
     e shouldBe an[MultipleRootsException]
   }
 
   it should "throw an error if there is a cycle" in {
+    val cyclicHierarchy = Seq(
+      AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some("")),
+      AssetCreate("son", None, None, Some(testName),Some("son"), None, Some("daughter")),
+      AssetCreate("daughter", None, None, Some(testName),Some("daughter"), None, Some("daughterSon")),
+      AssetCreate("daughterSon", None, None, Some(testName),Some("daughterSon"), None, Some("other")),
+      AssetCreate("othertree", None, None, Some(testName),Some("other"), None, Some("son"))
+    )
     val e = intercept[Exception] {
-      spark.sparkContext.parallelize(Seq(
-        AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some("")),
-        AssetCreate("son", None, None, Some(testName),Some("son"), None, Some("daughter")),
-        AssetCreate("daughter", None, None, Some(testName),Some("daughter"), None, Some("daughterSon")),
-        AssetCreate("daughterSon", None, None, Some(testName),Some("daughterSon"), None, Some("other")),
-        AssetCreate("othertree", None, None, Some(testName),Some("other"), None, Some("son"))
-      )).toDF().write
-        .format("cognite.spark.v1")
-        .option("apiKey", writeApiKey)
-        .option("type", "assethierarchy")
-        .save
+      ingest(cyclicHierarchy)
     }
     e shouldBe an[InvalidTreeException]
     val errorMessage = e.getMessage
@@ -93,17 +102,13 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
 
   it should "throw an error if one more externalIds are empty Strings" in {
     val e = intercept[Exception] {
-      spark.sparkContext.parallelize(Seq(
+      ingest(Seq(
         AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some("")),
         AssetCreate("son", None, None, Some(testName),Some("son"), None, Some("dad")),
         AssetCreate("daughter", None, None, Some(testName),Some(""), None, Some("dad")),
         AssetCreate("daughterSon", None, None, Some(testName),Some("daughterSon"), None, Some("daughter")),
         AssetCreate("othertree", None, None, Some(testName),Some(""), None, Some("otherDad"))
-      )).toDF().write
-        .format("cognite.spark.v1")
-        .option("apiKey", writeApiKey)
-        .option("type", "assethierarchy")
-        .save
+      ))
     }
     e shouldBe an[EmptyExternalIdException]
     val errorMessage = e.getMessage
@@ -113,23 +118,79 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
   }
 
   it should "fail reasonably when parent does not exist" in {
-    val assetTree = Seq(
+    val tree = Seq(
       AssetCreate("testNode1", None, None, Some(testName),Some("testNode1"), None, Some("nonExistentNode-jakdhdslfskgslfuwfvbnvwbqrvotfeds")),
       AssetCreate("testNode2", None, None, Some(testName),Some("testNode2"), None, Some(""))
     )
 
-    val writer = spark.sparkContext.parallelize(assetTree).toDF().write
-      .format("cognite.spark.v1")
-      .option("apiKey", writeApiKey)
-      .option("type", "assethierarchy")
-
-    val ex = intercept[Exception] { writer.save }
+    val ex = intercept[Exception] { ingest(tree) }
     ex shouldBe an[InvalidNodeReferenceException]
     ex.getMessage shouldBe "Node 'nonExistentNode-jakdhdslfskgslfuwfvbnvwbqrvotfeds' referenced from 'testNode1' does not exist."
   }
 
+  it should "fail when subtree is updated into being root" in {
+    cleanDB()
+
+    val assetTree = Seq(
+      AssetCreate("dad", None, None, Some(testName), Some("dad"), None, Some("")),
+      AssetCreate("son", None, None, Some(testName), Some("son"), None, Some("dad")),
+      AssetCreate("daughter", None, None, Some(testName), Some("daughter"), None, Some("dad")),
+      AssetCreate("daughterSon", None, None, Some(testName), Some("daughterSon"), None, Some("daughter"))
+    )
+
+    ingest(assetTree)
+
+    val ex = intercept[Exception] {
+      ingest(Seq(
+        AssetCreate("daughter", None, None, Some(testName), Some("daughter"), None, Some("")),
+      ))
+    }
+
+    ex shouldBe an[CdfDoesNotSupportException]
+    ex.getMessage should include("daughter")
+  }
+
+  // although these test basically only test what CDF does, we want
+  // * to be sure that error message is not swallowed
+  // * to be notified if this behavior changes, as then we should also support it
+  //   or (at least) fail reasonably
+  it should "fail when merging trees" in {
+    cleanDB()
+
+    ingest(Seq(
+      AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some("")),
+      AssetCreate("son", None, None, Some(testName),Some("son"), None, Some("dad")),
+      AssetCreate("dad2", None, None, Some(testName),Some("dad2"), None, Some("")),
+      AssetCreate("son2", None, None, Some(testName),Some("son2"), None, Some("dad2")),
+    ))
+
+    val ex = intercept[CdpApiException] {
+      ingest(Seq(
+        AssetCreate("dad2-updated", None, None, Some(testName),Some("dad2"), None, Some("son")),
+      ))
+    }
+    ex.getMessage should include("Changing from/to being root isn't allowed")
+  }
+
+  it should "fail when node moves between trees" in {
+    cleanDB()
+
+    ingest(Seq(
+      AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some("")),
+      AssetCreate("son", None, None, Some(testName),Some("son"), None, Some("dad")),
+      AssetCreate("dad2", None, None, Some(testName),Some("dad2"), None, Some("")),
+    ))
+
+    val ex = intercept[CdpApiException] {
+      ingest(Seq(
+        AssetCreate("son", None, None, Some(testName), Some("son"), None, Some("dad2")),
+      ))
+    }
+    ex.getMessage should include("Asset must stay within same asset hierarchy")
+  }
+
   it should "ingest an asset tree" in {
-    writeClient.assets.deleteByExternalIds(Seq("dad"), true, true)
+    cleanDB()
 
     val ds = Some(testDataSetId)
 
@@ -140,12 +201,7 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
       AssetCreate("daughterSon", None, None, Some(testName),Some("daughterSon"), None, Some("daughter"), ds)
     )
 
-    spark.sparkContext.parallelize(assetTree).toDF().write
-      .format("cognite.spark.v1")
-      .option("apiKey", writeApiKey)
-      .option("type", "assethierarchy")
-      .option("batchSize", "2")
-      .save
+    ingest(assetTree)
 
     val result = retryWhile[Array[Row]](
       spark.sql(s"select * from assets where source = '$testName' and dataSetId = $testDataSetId").collect,
@@ -160,24 +216,20 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
   }
 
   it should "ingest an asset tree, then update it" in {
-    writeClient.assets.deleteByExternalIds(Seq("dad"), true, true)
-    writeClient.assets.deleteByExternalIds(Seq("unusedZero"), true, true)
+    cleanDB()
 
     val ds = Some(testDataSetId)
 
-    spark.sparkContext.parallelize(Seq(
+    val originalTree = Seq(
       AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some("")),
       AssetCreate("son", None, None, Some(testName),Some("son"), None, Some("dad"), dataSetId = ds),
       AssetCreate("daughter", None, None, Some(testName), Some("daughter"), None, Some("dad")),
       AssetCreate("sonDaughter", None, None, Some(testName),Some("sonDaughter"), None, Some("son")),
       AssetCreate("daughterSon", None, None, Some(testName),Some("daughterSon"), None, Some("daughter")),
       AssetCreate("secondDaughterToBeDeleted", None, None, Some(testName),Some("secondDaughter"), None, Some("dad"))
-    )).toDF().write
-      .format("cognite.spark.v1")
-      .option("apiKey", writeApiKey)
-      .option("type", "assethierarchy")
-      .option("batchSize", "3")
-      .save
+    )
+
+    ingest(originalTree, batchSize = 3)
 
     retryWhile[Array[Row]](
       spark.sql(s"select * from assets where source = '$testName'").collect,
@@ -192,13 +244,7 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
       AssetCreate("daughterSon", None, None, Some(testName),Some("daughterSon"), None, Some("daughter"))
     ).map(a => a.copy(name = a.name + "Updated"))
 
-    spark.sparkContext.parallelize(updatedTree).toDF().write
-      .format("cognite.spark.v1")
-      .option("apiKey", writeApiKey)
-      .option("type", "assethierarchy")
-      .option("deleteMissingAssets", "true")
-      .option("batchSize", "2")
-      .save
+    ingest(updatedTree, deleteMissingAssets = true)
 
     val result = retryWhile[Array[Row]](
       spark.sql(s"select * from assets where source = '$testName'").collect,
@@ -214,19 +260,16 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
   }
 
   it should "move an asset to another asset that is being moved" in {
-    writeClient.assets.deleteByExternalIds(Seq("dad"), true, true)
+    cleanDB()
 
-    spark.sparkContext.parallelize(Seq(
+    val originalTree = Seq(
       AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some("")),
       AssetCreate("son", None, None, Some(testName),Some("son"), None, Some("dad")),
       AssetCreate("daughter", None, None, Some(testName), Some("daughter"), None, Some("dad")),
       AssetCreate("sonChild", None, None, Some(testName),Some("sonChild"), None, Some("son"))
-    )).toDF().write
-      .format("cognite.spark.v1")
-      .option("apiKey", writeApiKey)
-      .option("type", "assethierarchy")
-      .option("batchSize", "5")
-      .save
+    )
+
+    ingest(originalTree, batchSize = 5)
 
     retryWhile[Array[Row]](
       spark.sql(s"select * from assets where source = '$testName'").collect,
@@ -241,13 +284,7 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
       AssetCreate("daughterChildTwo", None, None, Some(testName),Some("daughterChildTwo"), None, Some("daughter"))
     ).map(a => a.copy(name = a.name + "Updated"))
 
-    spark.sparkContext.parallelize(updatedTree).toDF().write
-      .format("cognite.spark.v1")
-      .option("apiKey", writeApiKey)
-      .option("type", "assethierarchy")
-      .option("", "true")
-      .option("batchSize", "1")
-      .save
+    ingest(updatedTree, batchSize = 1)
 
     val result = retryWhile[Array[Row]](
       spark.sql(s"select * from assets where source = '$testName'").collect,
@@ -261,18 +298,15 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
   }
 
   it should "avoid deleting assets when deleteMissingAssets is false" in {
-    writeClient.assets.deleteByExternalIds(Seq("dad"), true, true)
+    cleanDB()
 
-    spark.sparkContext.parallelize(Seq(
+    val originalTree = Seq(
       AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some("")),
       AssetCreate("son", None, None, Some(testName),Some("son"), None, Some("dad")),
       AssetCreate("daughter", None, None, Some(testName), Some("daughter"), None, Some("dad"))
-    )).toDF().write
-      .format("cognite.spark.v1")
-      .option("apiKey", writeApiKey)
-      .option("type", "assethierarchy")
-      .option("batchSize", "3")
-      .save
+    )
+
+    ingest(originalTree, batchSize = 3)
 
     retryWhile[Array[Row]](
       spark.sql(s"select * from assets where source = '$testName'").collect,
@@ -284,13 +318,7 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
       AssetCreate("newSibling", None, None, Some(testName),Some("newSibling"), None, Some("dad"))
     )
 
-      spark.sparkContext.parallelize(updatedTree).toDF().write
-      .format("cognite.spark.v1")
-      .option("apiKey", writeApiKey)
-      .option("type", "assethierarchy")
-      .option("deleteMissingAssets", "false")
-      .option("batchSize", "2")
-      .save
+    ingest(updatedTree, deleteMissingAssets = false)
 
     val allNames = updatedTree.map(_.name) ++ Seq("son", "daughter")
 
@@ -305,11 +333,10 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
   }
 
   it should "allow rearranging orders and depth of assets" in {
-    writeClient.assets.deleteByExternalIds(Seq("dad"), true, true)
-    writeClient.assets.deleteByExternalIds(Seq("theGrandFather"), true, true)
+    cleanDB()
 
     val metricsPrefix = "update.assetsHierarchy.subtreeDepth"
-    spark.sparkContext.parallelize(Seq(
+    ingest(Seq(
       AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some("")),
       AssetCreate("son", None, None, Some(testName),Some("son"), None, Some("dad")),
       AssetCreate("daughter", None, None, Some(testName), Some("daughter"), None, Some("dad")),
@@ -317,12 +344,7 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
       AssetCreate("daughterDaughter", None, None, Some(testName), Some("daughterDaughter"), None, Some("daughter")),
       AssetCreate("sonSon", None, None, Some(testName), Some("sonSon"), None, Some("son")),
       AssetCreate("sonDaughter", None, None, Some(testName), Some("sonDaughter"), None, Some("son"))
-    )).toDF().write
-      .format("cognite.spark.v1")
-      .option("apiKey", writeApiKey)
-      .option("type", "assethierarchy")
-      .option("batchSize", "2")
-      .save
+    ))
 
     retryWhile[Array[Row]](
       spark.sql(s"select * from assets where source = '$testName'").collect,
@@ -337,15 +359,7 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
       AssetCreate("hen", None, None, Some(testName), Some("hen"), None, Some("dad"))
     ).map(a => a.copy(name = a.name + "Updated"))
 
-    spark.sparkContext.parallelize(updatedTree).toDF().write
-      .format("cognite.spark.v1")
-      .option("apiKey", writeApiKey)
-      .option("type", "assethierarchy")
-      .option("deleteMissingAssets", "true")
-      .option("batchSize", "3")
-      .option("collectMetrics", "true")
-      .option("metricsPrefix", metricsPrefix)
-      .save
+    ingest(updatedTree, deleteMissingAssets = true, batchSize = 3, metricsPrefix = Some(metricsPrefix))
 
     val result = retryWhile[Array[Row]](
       spark.sql(s"select * from assets where source = '$testName'").collect,
@@ -362,21 +376,16 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
   }
 
   it should "ingest an asset tree, then successfully delete a subtree" in {
-    writeClient.assets.deleteByExternalIds(Seq("dad"), true, true)
+    cleanDB()
 
-    spark.sparkContext.parallelize(Seq(
+    ingest(Seq(
       AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some("")),
       AssetCreate("son", None, None, Some(testName),Some("son"), None, Some("dad")),
       AssetCreate("daughter", None, None, Some(testName), Some("daughter"), None, Some("son")),
       AssetCreate("daughter2", None, None, Some(testName), Some("daughter2"), None, Some("daughter")),
       AssetCreate("daughter3", None, None, Some(testName), Some("daughter3"), None, Some("daughter2")),
       AssetCreate("daughter4", None, None, Some(testName), Some("daughter4"), None, Some("daughter3"))
-    )).toDF().write
-      .format("cognite.spark.v1")
-      .option("apiKey", writeApiKey)
-      .option("type", "assethierarchy")
-      .option("batchSize", "3")
-      .save
+    ))
 
     retryWhile[Array[Row]](
       spark.sql(s"select * from assets where source = '$testName'").collect,
@@ -387,13 +396,7 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
       AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some(""))
     ).map(a => a.copy(name = a.name + "Updated"))
 
-    spark.sparkContext.parallelize(updatedTree).toDF().write
-      .format("cognite.spark.v1")
-      .option("apiKey", writeApiKey)
-      .option("type", "assethierarchy")
-      .option("deleteMissingAssets", "true")
-      .option("batchSize", "1")
-      .save
+    ingest(updatedTree, deleteMissingAssets = true)
 
     val result = retryWhile[Array[Row]](
       spark.sql(s"select * from assets where source = '$testName'").collect,
@@ -417,16 +420,7 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
     )
 
     val metricsPrefix = "insert.assetsHierarchy.ignored"
-    spark.sparkContext.parallelize(assetTree).toDF().write
-      .format("cognite.spark.v1")
-      .option("apiKey", writeApiKey)
-      .option("type", "assethierarchy")
-      .option("batchSize", "2")
-      .option("allowSubtreeIngestion", "false")
-      .option("ignoreDisconnectedAssets", "true")
-      .option("collectMetrics", "true")
-      .option("metricsPrefix", metricsPrefix)
-      .save
+    ingest(assetTree, allowSubtreeIngestion = false, ignoreDisconnectedAssets = true, metricsPrefix = Some(metricsPrefix))
 
     val namesOfAssetsToInsert = assetTree.slice(0, 4).map(_.name).toSet
 
@@ -441,6 +435,115 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
     assert(extIdMap(Some("daughterSon")).parentId.contains(extIdMap(Some("daughter")).id))
 
     getNumberOfRowsCreated(metricsPrefix, "assethierarchy") shouldBe 4
+  }
+
+  it should "insert a tree and then add subtree" in {
+    cleanDB()
+
+    val metricsPrefix = "insert.assetsHierarchy.ingest.subtree"
+
+    ingest(Seq(
+      AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some("")),
+      AssetCreate("son", None, None, Some(testName),Some("son"), None, Some("dad"))
+    ), metricsPrefix = Some(metricsPrefix))
+
+    retryWhile[Array[Row]](
+      spark.sql(s"select * from assets where source = '$testName'").collect,
+      rows => rows.map(r => r.getString(1)).toSet != Set("dad", "son")
+    )
+
+    getNumberOfRowsCreated(metricsPrefix, "assethierarchy") shouldBe 2
+
+    ingest(Seq(
+      AssetCreate("daughter", None, None, Some(testName),Some("daughter"), None, Some("dad")),
+      AssetCreate("daughterSon", None, None, Some(testName),Some("daughterSon"), None, Some("daughter")),
+      AssetCreate("sonSon", None, None, Some(testName),Some("sonSon"), None, Some("son"))
+    ), metricsPrefix = Some(metricsPrefix))
+
+    val result = retryWhile[Array[Row]](
+      spark.sql(s"select * from assets where source = '$testName'").collect,
+      rows => rows.map(r => r.getString(1)).toSet != Set("dad", "son", "daughter", "daughterSon", "sonSon")
+    )
+
+    val extIdMap = getAssetsMap(result)
+    assert(extIdMap(Some("sonSon")).parentId.contains(extIdMap(Some("son")).id))
+    assert(extIdMap(Some("daughter")).parentId.contains(extIdMap(Some("dad")).id))
+    assert(extIdMap(Some("daughterSon")).parentId.contains(extIdMap(Some("daughter")).id))
+
+    getNumberOfRowsCreated(metricsPrefix, "assethierarchy") shouldBe 5
+  }
+
+  it should "allow updating different subtrees" in {
+    cleanDB()
+    val metricsPrefix = "insert.assetsHierarchy.update.subtrees"
+
+    //                    dad
+    //                   /   \
+    //                  /     \
+    //               son       daughter
+    //              /          |       \
+    //          path0      daughterSon  daughterDaughter
+    //            |
+    //          path1
+    //            |
+    //          path2
+    //            |
+    //          path3
+
+    val sourceTree = Seq(
+      AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some("")),
+      AssetCreate("son", None, None, Some(testName),Some("son"), None, Some("dad")),
+      AssetCreate("daughter", None, None, Some(testName),Some("daughter"), None, Some("dad")),
+      AssetCreate("daughterSon", None, None, Some(testName),Some("daughterSon"), None, Some("daughter")),
+      AssetCreate("daughterDaughter", None, None, Some(testName),Some("daughterDaughter"), None, Some("daughter")),
+      AssetCreate("path0", None, None, Some(testName),Some("path0"), None, Some("son")),
+      AssetCreate("path1", None, None, Some(testName),Some("path1"), None, Some("path0")),
+      AssetCreate("path2", None, None, Some(testName),Some("path2"), None, Some("path1")),
+      AssetCreate("path3", None, None, Some(testName),Some("path3"), None, Some("path2"))
+    )
+    ingest(sourceTree, metricsPrefix = Some(metricsPrefix))
+    getNumberOfRowsCreated(metricsPrefix, "assethierarchy") shouldBe sourceTree.length
+
+    retryWhile[Array[Row]](
+      spark.sql(s"select * from assets where source = '$testName'").collect,
+      rows => rows.length != sourceTree.length
+    )
+
+    //                    dad
+    //                   /   \
+    //                  /     \
+    //               son       daughter
+    //                         |       \
+    //                     daughterSon  daughterDaughter
+    //                                         |
+    //                                       path0
+    //                                         |
+    //                                       path1
+    //                                         |
+    //                                       path2*
+    //                                         |
+    //                                       path3
+
+    ingest(Seq(
+      AssetCreate("path0-updated", None, None, Some(testName), Some("path0"), None, Some("daughterDaughter")),
+      AssetCreate("path2-updated", None, Some("desc"), Some(testName), Some("path2"), None, Some("path1")),
+      AssetCreate("daughter-updated", None, Some("desc"), Some(testName),Some("daughter"), None, Some("dad")),
+      AssetCreate("dad-updated", None, Some("desc"), Some(testName),Some("dad"), None, Some("")),
+    ), metricsPrefix = Some(metricsPrefix))
+
+    val result = retryWhile[Array[Row]](
+      spark.sql(s"select * from assets where source = '$testName'").collect,
+      rows => rows.map(r => r.getString(1)).count(_.endsWith("-updated")) != 4
+    )
+
+    val extIdMap = getAssetsMap(result)
+    assert(extIdMap(Some("path0")).parentId.contains(extIdMap(Some("daughterDaughter")).id))
+    assert(extIdMap(Some("daughter")).description.contains("desc"))
+    assert(extIdMap(Some("dad")).description.contains("desc"))
+    assert(extIdMap(Some("path2")).description.contains("desc"))
+
+    getNumberOfRowsUpdated(metricsPrefix, "assethierarchy") shouldBe 4
+    getNumberOfRowsCreated(metricsPrefix, "assethierarchy") shouldBe sourceTree.length
   }
 
   def getAssetsMap(assets: Seq[Row]): Map[Option[String], AssetsReadSchema] =

--- a/src/test/scala/cognite/spark/v1/AssetHierarchyBuilderTest.scala
+++ b/src/test/scala/cognite/spark/v1/AssetHierarchyBuilderTest.scala
@@ -17,11 +17,16 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
 
   val testName = "assetHierarchyTest"
 
-  it should "throw an error on empty input" in {
+  it should "throw an error when everything is ignored" in {
+    val tree = Seq(
+      AssetCreate("dad", None, None, Some(testName),Some("dad"), None, Some("someNode"))
+    )
     val e = intercept[Exception] {
-      spark.sparkContext.parallelize(Seq[AssetCreate]()).toDF().write
+      spark.sparkContext.parallelize(tree).toDF().write
         .format("cognite.spark.v1")
         .option("apiKey", writeApiKey)
+        .option("allowSubtreeIngestion", "false")
+        .option("ignoreDisconnectedAssets", "true")
         .option("type", "assethierarchy")
         .save
     }
@@ -40,6 +45,7 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
         .format("cognite.spark.v1")
         .option("apiKey", writeApiKey)
         .option("type", "assethierarchy")
+        .option("allowSubtreeIngestion", "false")
         .save
     }
     e shouldBe an[InvalidTreeException]
@@ -57,6 +63,7 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
         .format("cognite.spark.v1")
         .option("apiKey", writeApiKey)
         .option("type", "assethierarchy")
+        .option("allowMultipleRoots", "false")
         .save
     }
     e shouldBe an[MultipleRootsException]
@@ -108,7 +115,7 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with SparkTest {
   it should "fail reasonably when parent does not exist" in {
     val assetTree = Seq(
       AssetCreate("testNode1", None, None, Some(testName),Some("testNode1"), None, Some("nonExistentNode-jakdhdslfskgslfuwfvbnvwbqrvotfeds")),
-      AssetCreate("testNode2", None, None, Some(testName),Some("testNode2"), None, None)
+      AssetCreate("testNode2", None, None, Some(testName),Some("testNode2"), None, Some(""))
     )
 
     val writer = spark.sparkContext.parallelize(assetTree).toDF().write

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -94,6 +94,8 @@ trait SparkTest {
       ignoreUnknownIds = true,
       deleteMissingAssets = false,
       ignoreDisconnectedAssets = false,
+      allowSubtreeIngestion = true,
+      allowMultipleRoots = true,
       legacyNameSource = LegacyNameSource.None
     )
 

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -25,10 +25,12 @@ trait SparkTest {
   implicit lazy val timer: Timer[IO] = IO.timer(ExecutionContext.global)
 
   val writeApiKey = System.getenv("TEST_API_KEY_WRITE")
+  assert(!writeApiKey.isEmpty, "Environment variable \"TEST_API_KEY_WRITE\" was not set")
   implicit val writeApiKeyAuth: ApiKeyAuth = ApiKeyAuth(writeApiKey)
   val writeClient = GenericClient.forAuth[Id, Nothing]("cdp-spark-datasource-test", writeApiKeyAuth)
 
   val readApiKey = System.getenv("TEST_API_KEY_READ")
+  assert(!readApiKey.isEmpty, "Environment variable \"TEST_API_KEY_READ\" was not set")
   implicit val readApiKeyAuth: ApiKeyAuth = ApiKeyAuth(readApiKey)
   val readClient = GenericClient.forAuth[Id, Nothing]("cdp-spark-datasource-test", readApiKeyAuth)
 
@@ -93,9 +95,7 @@ trait SparkTest {
       Constants.DefaultParallelismPerPartition,
       ignoreUnknownIds = true,
       deleteMissingAssets = false,
-      ignoreDisconnectedAssets = false,
-      allowSubtreeIngestion = true,
-      allowMultipleRoots = true,
+      subtrees = AssetSubtreeOption.Ingest,
       legacyNameSource = LegacyNameSource.None
     )
 


### PR DESCRIPTION
Add support for inserting subtrees (i.e. nodes rooted outside of the inserted tree) and multiple trees at once.

The builder now works like this:
* Group the input data into a set of trees (connected components)
   - and validate that it does not contain cycle. Note that previously cycles were allowed when `ignoreDisconnectedAssets` was set
* If `allowSubtreeIngestion` is `false`
    - drop trees without root when if `ignoreDisconnectedAssets` is set
    - otherwise raise an error
* If `allowMultipleRoots`, check that there is only one tree
* Empty insertions are now allowed (this will quite certainly if you are doing incremental updates). Only when the input set was non-empty and all nodes were dropped, the error is raised.
* Check that all subtree have an existing parent.
* The trees are inserted one-by-one (*1):
    - The corresponding subtree is downloaded from CDF for comparison
    - Which nodes are to be inserted, updated, deleted or kept is decided (based on matching `externalId`)
    - The insert, update, delete operations are performed (without parallelism)


Notes:

I think I have removed quadratic complexity, so it should now handle non-trivial asset hierarchies just fine. It still has to fit into RAM of one executor, and subtrees cannot be larger than 100,000 items.

*1: I don't want to make it parallel to prevent races. In case two trees overlap - one is on the path to root to another tree and `deleteMissingAssets` is set, then the result (if it error or not) depends on the tree order.