### PR TITLE
Threadpool related fixes

### DIFF
--- a/performancebench/src/main/scala/cognite/spark/performancebench/EventPerformance.scala
+++ b/performancebench/src/main/scala/cognite/spark/performancebench/EventPerformance.scala
@@ -25,6 +25,7 @@ class EventPerformance extends PerformanceSuite {
           s"This is a test row ($id)",
           java.sql.Timestamp.from(Instant.now().minus(Math.min(id, 100), ChronoUnit.HOURS)),
           java.sql.Timestamp.from(Instant.now().plus(Math.min(id, 100), ChronoUnit.HOURS))))
+    .toVector
 
   private def writeEvents(): Unit =
     write(spark.sparkContext.parallelize(eventsTestData, 300).toDF(eventsTestSchema: _*))

--- a/performancebench/src/main/scala/cognite/spark/performancebench/EventPerformance.scala
+++ b/performancebench/src/main/scala/cognite/spark/performancebench/EventPerformance.scala
@@ -34,7 +34,7 @@ class EventPerformance extends PerformanceSuite {
 
   private def prepareForDelete(): Array[Row] =
     readEvents()
-      .where(s"externalId LIKE 'externalIdPrefix%'")
+      .where(s"externalId LIKE '$externalIdPrefix%'")
       .select($"id")
       .collect()
 

--- a/performancebench/src/main/scala/cognite/spark/performancebench/Main.scala
+++ b/performancebench/src/main/scala/cognite/spark/performancebench/Main.scala
@@ -11,7 +11,7 @@ object Main extends App {
     eventPerf.run()
   } finally {
     logger.info("Sleeping for 20 seconds before exiting, so that all metrics are scraped.")
-    Thread.sleep(20*1000) // Sleep for 20 seconds to make sure metrics are scraped
-    sys.exit(0) // Force shutdown as Spark creates threads that are not background threads
+    Thread.sleep(20 * 1000) // Sleep for 20 seconds to make sure metrics are scraped
+    metricsServer.stop()
   }
 }

--- a/src/main/scala/cognite/spark/v1/CdpConnector.scala
+++ b/src/main/scala/cognite/spark/v1/CdpConnector.scala
@@ -20,12 +20,7 @@ case class Login(user: String, loggedIn: Boolean, project: String, projectId: Lo
 object CdpConnector {
   @transient lazy val cdpConnectorExecutionContext: ExecutionContext =
     ExecutionContext.fromExecutor(
-      new ThreadPoolExecutor(
-        0,
-        Constants.MaxConcurrentRequests,
-        60L,
-        TimeUnit.SECONDS,
-        new SynchronousQueue()))
+      Executors.newFixedThreadPool(Math.max(Runtime.getRuntime().availableProcessors(), 4) * 2))
   @transient implicit lazy val cdpConnectorTimer: Timer[IO] = IO.timer(cdpConnectorExecutionContext)
   @transient implicit val cdpConnectorContextShift: ContextShift[IO] =
     IO.contextShift(cdpConnectorExecutionContext)

--- a/src/main/scala/cognite/spark/v1/CdpConnector.scala
+++ b/src/main/scala/cognite/spark/v1/CdpConnector.scala
@@ -20,6 +20,9 @@ case class Error[A](error: A)
 case class Login(user: String, loggedIn: Boolean, project: String, projectId: Long)
 
 object CdpConnector {
+  // It's important that the threads made here are daemon threads
+  // so that we don't hang applications using our library during exit.
+  // See for more info https://github.com/cognitedata/cdp-spark-datasource/pull/415/files#r396774391
   @transient lazy val cdpConnectorExecutionContext: ExecutionContext =
     ExecutionContext.fromExecutor(
       Executors.newFixedThreadPool(

--- a/src/main/scala/cognite/spark/v1/Constants.scala
+++ b/src/main/scala/cognite/spark/v1/Constants.scala
@@ -18,7 +18,6 @@ object Constants {
   val DefaultMaxBackoffDelay: FiniteDuration = 120.seconds
   val DefaultBaseUrl = "https://api.cognitedata.com"
   val MetadataValuePostMaxLength = 512
-  val MaxConcurrentRequests = 1000
   val SparkDatasourceVersion = s"${BuildInfo.organization}-${BuildInfo.version}"
   val millisSinceEpochIn2100 = 4102448400000L
 }

--- a/src/main/scala/cognite/spark/v1/DataPointsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/DataPointsRelation.scala
@@ -37,9 +37,10 @@ abstract class DataPointsRelationV1[A](config: RelationConfig, shortName: String
   override def insert(data: DataFrame, overwrite: Boolean): Unit =
     data.foreachPartition((rows: Iterator[Row]) => {
       val batches = rows.grouped(Constants.CreateDataPointsLimit).toVector
-      batches.grouped(Constants.MaxConcurrentRequests).foreach { batchGroup =>
-        batchGroup.parTraverse(insertSeqOfRows).unsafeRunSync()
-      }
+      batches
+        .parTraverse(insertSeqOfRows)
+        .unsafeRunSync()
+      ()
     })
 
   def insertSeqOfRows(rows: Seq[Row]): IO[Unit]

--- a/src/main/scala/cognite/spark/v1/DataPointsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/DataPointsRelation.scala
@@ -38,9 +38,8 @@ abstract class DataPointsRelationV1[A](config: RelationConfig, shortName: String
     data.foreachPartition((rows: Iterator[Row]) => {
       val batches = rows.grouped(Constants.CreateDataPointsLimit).toVector
       batches
-        .parTraverse(insertSeqOfRows)
+        .parTraverse_(insertSeqOfRows)
         .unsafeRunSync()
-      ()
     })
 
   def insertSeqOfRows(rows: Seq[Row]): IO[Unit]

--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -241,28 +241,16 @@ class DefaultSource
       data.foreachPartition((rows: Iterator[Row]) => {
         import CdpConnector._
 
-        val groupedBatches = rows.grouped(batchSize).toVector.grouped(Constants.MaxConcurrentRequests)
-
+        val batches = rows.grouped(batchSize).toVector
         config.onConflict match {
           case OnConflict.Abort =>
-            groupedBatches.foreach { batchGroup =>
-              batchGroup.parTraverse(relation.insert).unsafeRunSync()
-            }
-
+            batches.parTraverse(relation.insert).unsafeRunSync()
           case OnConflict.Upsert =>
-            groupedBatches.foreach { batchGroup =>
-              batchGroup.parTraverse(relation.upsert).unsafeRunSync()
-            }
-
+            batches.parTraverse(relation.upsert).unsafeRunSync()
           case OnConflict.Update =>
-            groupedBatches.foreach { batchGroup =>
-              batchGroup.parTraverse(relation.update).unsafeRunSync()
-            }
-
+            batches.parTraverse(relation.update).unsafeRunSync()
           case OnConflict.Delete =>
-            groupedBatches.foreach { batchGroup =>
-              batchGroup.parTraverse(relation.delete).unsafeRunSync()
-            }
+            batches.parTraverse(relation.delete).unsafeRunSync()
         }
 
         ()

--- a/src/main/scala/cognite/spark/v1/RawTableRelation.scala
+++ b/src/main/scala/cognite/spark/v1/RawTableRelation.scala
@@ -169,9 +169,8 @@ class RawTableRelation(
     dfWithUnRenamedKeyColumns.foreachPartition((rows: Iterator[Row]) => {
       val batches = rows.grouped(batchSize).toVector
       batches
-        .parTraverse(postRows(columnNames, _))
+        .parTraverse_(postRows(columnNames, _))
         .unsafeRunSync()
-      ()
     })
   }
 

--- a/src/main/scala/cognite/spark/v1/RawTableRelation.scala
+++ b/src/main/scala/cognite/spark/v1/RawTableRelation.scala
@@ -168,9 +168,9 @@ class RawTableRelation(
     val (columnNames, dfWithUnRenamedKeyColumns) = prepareForInsert(df.drop(lastUpdatedTimeColName))
     dfWithUnRenamedKeyColumns.foreachPartition((rows: Iterator[Row]) => {
       val batches = rows.grouped(batchSize).toVector
-      batches.grouped(Constants.MaxConcurrentRequests).foreach { batchGroup =>
-        batchGroup.parTraverse(postRows(columnNames, _)).unsafeRunSync()
-      }
+      batches
+        .parTraverse(postRows(columnNames, _))
+        .unsafeRunSync()
       ()
     })
   }

--- a/src/main/scala/cognite/spark/v1/SdkV1Relation.scala
+++ b/src/main/scala/cognite/spark/v1/SdkV1Relation.scala
@@ -55,9 +55,8 @@ abstract class SdkV1Relation[A <: Product, I](config: RelationConfig, shortName:
       import CdpConnector._
       val batches = rows.grouped(config.batchSize.getOrElse(Constants.DefaultBatchSize)).toVector
       batches
-        .parTraverse(getFromRowsAndCreate(_))
+        .parTraverse_(getFromRowsAndCreate(_))
         .unsafeRunSync()
-      ()
     })
 
   def toRow(item: A, requiredColumns: Array[String]): Row =

--- a/src/main/scala/cognite/spark/v1/SdkV1Relation.scala
+++ b/src/main/scala/cognite/spark/v1/SdkV1Relation.scala
@@ -54,11 +54,9 @@ abstract class SdkV1Relation[A <: Product, I](config: RelationConfig, shortName:
     data.foreachPartition((rows: Iterator[Row]) => {
       import CdpConnector._
       val batches = rows.grouped(config.batchSize.getOrElse(Constants.DefaultBatchSize)).toVector
-      batches.grouped(Constants.MaxConcurrentRequests).foreach { batchGroup =>
-        batchGroup
-          .parTraverse(getFromRowsAndCreate(_))
-          .unsafeRunSync()
-      }
+      batches
+        .parTraverse(getFromRowsAndCreate(_))
+        .unsafeRunSync()
       ()
     })
 

--- a/src/main/scala/cognite/spark/v1/SttpClientBackendFactory.scala
+++ b/src/main/scala/cognite/spark/v1/SttpClientBackendFactory.scala
@@ -7,10 +7,19 @@ import org.asynchttpclient.AsyncHttpClient
 
 object SttpClientBackendFactory {
   def create(): AsyncHttpClient = {
+    // It's important that the threads made by the async http client is daemon threads,
+    // so that we don't hang applications using our library during exit.
+    // See for more info https://github.com/cognitedata/cdp-spark-datasource/pull/415/files#r396774391
     lazy val clientThreadFactory =
-      new ThreadFactoryBuilder().setNameFormat("AsyncHttpClient-%d").setDaemon(true).build()
+      new ThreadFactoryBuilder()
+        .setNameFormat("AsyncHttpClient-%d")
+        .setDaemon(true)
+        .build()
     lazy val timerThreadFactory =
-      new ThreadFactoryBuilder().setNameFormat("AsyncHttpClient-%d-timer").setDaemon(true).build()
+      new ThreadFactoryBuilder()
+        .setNameFormat("AsyncHttpClient-%d-timer")
+        .setDaemon(true)
+        .build()
     AsyncHttpClientBackend.clientWithModifiedOptions(
       SttpBackendOptions.Default,
       options =>

--- a/src/main/scala/cognite/spark/v1/SttpClientBackendFactory.scala
+++ b/src/main/scala/cognite/spark/v1/SttpClientBackendFactory.scala
@@ -1,0 +1,22 @@
+package com.softwaremill.sttp.asynchttpclient
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+import com.softwaremill.sttp.SttpBackendOptions
+import io.netty.util.HashedWheelTimer
+import org.asynchttpclient.AsyncHttpClient
+
+object SttpClientBackendFactory {
+  def create(): AsyncHttpClient = {
+    lazy val clientThreadFactory =
+      new ThreadFactoryBuilder().setNameFormat("AsyncHttpClient-%d").setDaemon(true).build()
+    lazy val timerThreadFactory =
+      new ThreadFactoryBuilder().setNameFormat("AsyncHttpClient-%d-timer").setDaemon(true).build()
+    AsyncHttpClientBackend.clientWithModifiedOptions(
+      SttpBackendOptions.Default,
+      options =>
+        options
+          .setThreadFactory(clientThreadFactory)
+          .setNettyTimer(new HashedWheelTimer(timerThreadFactory))
+    )
+  }
+}


### PR DESCRIPTION
SyncQueue doesn't queue the Runnables in a queue collection, but instead queues the runnable for an available thread, or if no threads are available it will create a thread. However, if max number of threads is reached, it'll throw. I propose using a fixed thread pool instead based on the number of CPUs available.
I don't see why this needs to be related to max concurrent requests, as this thread pool is not used for the actual request. It's only used for scheduling a request. It could probably be smaller as well, as it shouldn't take long to schedule.