### PR TITLE
Add warmup logic to perf. bench

### DIFF
--- a/performancebench/src/main/scala/cognite/spark/performancebench/Main.scala
+++ b/performancebench/src/main/scala/cognite/spark/performancebench/Main.scala
@@ -9,6 +9,8 @@ object Main extends App {
   val metricsServer = new HTTPServer(8123, true)
   PrometheusDefaultExports.initialize()
   try {
+    // We need to warm-up our Spark cluster to get fair metrics
+    Warmup.run()
     val eventPerf = new EventPerformance()
     eventPerf.run()
   } finally {

--- a/performancebench/src/main/scala/cognite/spark/performancebench/Main.scala
+++ b/performancebench/src/main/scala/cognite/spark/performancebench/Main.scala
@@ -1,11 +1,13 @@
 package cognite.spark.performancebench
 
 import io.prometheus.client.exporter.HTTPServer
+import io.prometheus.client.hotspot.{DefaultExports => PrometheusDefaultExports}
 import org.log4s._
 
 object Main extends App {
   val logger = getLogger
   val metricsServer = new HTTPServer(8123, true)
+  PrometheusDefaultExports.initialize()
   try {
     val eventPerf = new EventPerformance()
     eventPerf.run()

--- a/performancebench/src/main/scala/cognite/spark/performancebench/Warmup.scala
+++ b/performancebench/src/main/scala/cognite/spark/performancebench/Warmup.scala
@@ -1,0 +1,11 @@
+package cognite.spark.performancebench
+
+import org.apache.spark.sql.Row
+
+object Warmup extends SparkUtil {
+  def run(): Array[Row] =
+    read()
+      .option("type", "events")
+      .load()
+      .collect()
+}


### PR DESCRIPTION
Read some events to warmup the Spark cluster, since without warmup, we get biased metric results.