### PR TITLE
[DT-1127] Improve error message for column incorrect type

### DIFF
--- a/macro/src/main/scala/SparkSchemaHelper.scala
+++ b/macro/src/main/scala/SparkSchemaHelper.scala
@@ -6,7 +6,7 @@ import org.apache.spark.sql.types.StructType
 import com.cognite.sdk.scala.common.{NonNullableSetter, Setter}
 
 import scala.reflect.macros.blackbox.Context
-import scala.util.{Try, Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 class SparkSchemaHelperImpl(val c: Context) {
   def asRow[T: c.WeakTypeTag](x: c.Expr[T]): c.Expr[Row] = {
@@ -80,16 +80,54 @@ class SparkSchemaHelperImpl(val c: Context) {
           innerType
         }
 
-        val column = q"scala.util.Try(Option($r.getAs[$rowType]($name))).toOption.flatten"
+        val throwError =
+          q"throw cognite.spark.v1.SparkSchemaHelper.badRowError($r, $name, ${rowType.toString}, ${structType.toString})"
+
+        def handleFieldValue(value: Tree) =
+          if (rowType <:< typeOf[Double]) {
+            // do implicit conversion to double
+            q"""($value match {
+             case x:Double => Some(x)
+             case x:Int => Some(x: Double)
+             case x:Long => Some(x: Double)
+             case x:BigDecimal => Some(x.toDouble)
+             case x:BigInt => Some(x.toDouble)
+             case _ => $throwError
+           })"""
+          } else if (rowType <:< typeOf[Long]) {
+            q"""($value match {
+             case x:Long => Some(x)
+             case x:Int => Some(x: Long)
+             case _ => $throwError
+           })"""
+          } else if (rowType <:< typeOf[java.time.Instant]) {
+            q"""($value match {
+             case x:java.time.Instant => Some(x)
+             case x:java.sql.Timestamp => Some(x.toInstant())
+             case _ => $throwError
+           })"""
+          } else {
+            q"""($value match {
+             case x: $rowType => Some(x)
+             case _ => $throwError
+           })"""
+          }
+
+        val column =
+          q"""(scala.util.Try($r.getAs[Any]($name)) match {
+             case scala.util.Success(null) => None
+             case scala.util.Failure(_) => None
+             case scala.util.Success(x) => ${handleFieldValue(q"x")}
+           })"""
         val baseExpr =
           if (isOptionSetter) {
-            q"$setterType.optionToSetter[$rowType].transform(scala.util.Try(Option($r.getAs[$rowType]($name))).toOption.flatten)"
+            q"$setterType.optionToSetter[$rowType].transform($column)"
           } else if (isOptionNonNullableSetter) {
-            q"$nonNullableSetterType.optionToNonNullableSetter[$rowType].transform(scala.util.Try(Option($r.getAs[$rowType]($name))).toOption.flatten)"
+            q"$nonNullableSetterType.optionToNonNullableSetter[$rowType].transform($column)"
           } else if (isOuterOption) {
             column
           } else {
-            q"""$column.getOrElse(throw cognite.spark.v1.SparkSchemaHelper.badRowError($r, $name, scala.reflect.runtime.universe.typeOf[$rowType].toString))"""
+            q"""$column.getOrElse($throwError)"""
           }
 
         val resExpr =
@@ -116,21 +154,7 @@ class SparkSchemaHelperImpl(val c: Context) {
             baseExpr
           }
 
-        if (rowType <:< typeOf[java.time.Instant]) {
-          val instantBaseExpr =
-            q"scala.util.Try(Option($r.getAs[java.sql.Timestamp]($name))).toOption.flatten.map(x => x.toInstant())"
-          if (isOptionSetter) {
-            q"$setterType.optionToSetter[java.time.Instant].transform(scala.util.Try(Option($r.getAs[java.sql.Timestamp]($name))).toOption.flatten.map(x => x.toInstant()))"
-          } else if (isOptionNonNullableSetter) {
-            q"$nonNullableSetterType.optionToNonNullableSetter[java.time.Instant].transform(scala.util.Try(Option($r.getAs[java.sql.Timestamp]($name))).toOption.flatten.map(x => x.toInstant()))"
-          } else if (isOuterOption) {
-            instantBaseExpr
-          } else {
-            q"""$instantBaseExpr.getOrElse(throw cognite.spark.v1.SparkSchemaHelper.badRowError($r, $name, scala.reflect.runtime.universe.typeOf[$rowType].toString))"""
-          }
-        } else {
-          q"$resExpr.asInstanceOf[${param.typeSignature}]"
-        }
+        q"$resExpr.asInstanceOf[${param.typeSignature}]"
       })
       q"new ${structType}(..$params)"
     }
@@ -146,12 +170,23 @@ object SparkSchemaHelper {
   def asRow[T](x: T): Row = macro SparkSchemaHelperImpl.asRow[T]
   def fromRow[T](row: Row): T = macro SparkSchemaHelperImpl.fromRow[T]
 
-  def badRowError(row: Row, name: String, typeName: String): Throwable = {
+  private def simplifyTypeName(name: String) =
+    name match {
+      case "java.time.Instant" => "Timestamp"
+      case "java.lang.Integer" => "Int"
+      case "java.lang.Long" => "Long"
+      case "java.lang.Double" => "Double"
+      case "java.lang.String" => "String"
+      case x => x
+    }
+
+  def badRowError(row: Row, name: String, typeName: String, rowType: String): Throwable = {
     val columns = row.schema.fieldNames
     Try(row.getAs[Any](name)) match {
       case Failure(error) =>
-        new IllegalArgumentException(s"Required column '$name' is missing on row [${columns.mkString(", ")}].")
-      case Success(value) => {
+        new IllegalArgumentException(
+          s"Required column '$name' is missing on row [${columns.mkString(", ")}].")
+      case Success(value) =>
         val rowIdentifier =
           if (columns.contains("externalId")) {
             s"with externalId='${row.getAs[Any]("externalId")}'"
@@ -162,10 +197,18 @@ object SparkSchemaHelper {
           } else {
             row.toString
           }
+
+        val hint = if (rowType == "cognite.spark.v1.AssetsIngestSchema" && name == "parentExternalId" && value == null) {
+          " To mark the node as root, please use an empty string ('')."
+        } else {
+          ""
+        }
+
         // this function is invoked only in case of an error -> we have some type issues
-        val valueString = if (value == null) { "NULL" } else { s"value '$value' of type '${value.getClass.toString}'" }
-        new IllegalArgumentException(s"Column '$name' was expected to have type $typeName, but $valueString was found (on row $rowIdentifier).")
-      }
+        val valueString =
+          if (value == null) { "NULL" } else { s"value '$value' of type ${simplifyTypeName(value.getClass.getName)}" }
+        new IllegalArgumentException(
+          s"Column '$name' was expected to have type ${simplifyTypeName(typeName)}, but $valueString was found (on row $rowIdentifier).$hint")
     }
 
   }

--- a/macro/src/main/scala/SparkSchemaHelper.scala
+++ b/macro/src/main/scala/SparkSchemaHelper.scala
@@ -87,23 +87,23 @@ class SparkSchemaHelperImpl(val c: Context) {
           if (rowType <:< typeOf[Double]) {
             // do implicit conversion to double
             q"""($value match {
-             case x:Double => Some(x)
-             case x:Int => Some(x: Double)
-             case x:Long => Some(x: Double)
-             case x:BigDecimal => Some(x.toDouble)
-             case x:BigInt => Some(x.toDouble)
+             case x: Double => Some(x)
+             case x: Int => Some(x: Double)
+             case x: Long => Some(x: Double)
+             case x: BigDecimal => Some(x.toDouble)
+             case x: BigInt => Some(x.toDouble)
              case _ => $throwError
            })"""
           } else if (rowType <:< typeOf[Long]) {
             q"""($value match {
-             case x:Long => Some(x)
-             case x:Int => Some(x: Long)
+             case x: Long => Some(x)
+             case x: Int => Some(x: Long)
              case _ => $throwError
            })"""
           } else if (rowType <:< typeOf[java.time.Instant]) {
             q"""($value match {
-             case x:java.time.Instant => Some(x)
-             case x:java.sql.Timestamp => Some(x.toInstant())
+             case x: java.time.Instant => Some(x)
+             case x: java.sql.Timestamp => Some(x.toInstant())
              case _ => $throwError
            })"""
           } else {

--- a/src/test/scala/cognite/spark/v1/EventsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/EventsRelationTest.scala
@@ -183,9 +183,9 @@ class EventsRelationTest extends FlatSpec with Matchers with SparkTest {
     val metricsPrefix = "pushdown.filters.maxStartTime"
     val df = getBaseReader(true, metricsPrefix)
       .where(s"startTime < timestamp('1970-01-19 00:00:00.000Z')")
-    assert(df.count == 58)
+    assert(df.count > 10)
     val eventsRead = getNumberOfRowsRead(metricsPrefix, "events")
-    assert(eventsRead == 58)
+    assert(eventsRead == df.count)
   }
 
   it should "handle pushdown filters on minimum and maximum startTime" taggedAs WriteTest in {

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -16,6 +16,7 @@ import scala.util.Random
 import cats.effect.{IO, Timer}
 import cats.implicits._
 import com.cognite.sdk.scala.v1._
+import org.scalactic.{Prettifier, source}
 
 object ReadTest extends Tag("ReadTest")
 object WriteTest extends Tag("WriteTest")
@@ -66,12 +67,12 @@ trait SparkTest {
   }
   // scalastyle:on cyclomatic.complexity
 
-  def retryWhile[A](action: => A, shouldRetry: A => Boolean): A =
+  def retryWhile[A](action: => A, shouldRetry: A => Boolean)(implicit prettifier: Prettifier, pos: source.Position): A =
     retryWithBackoff(
       IO {
         val actionValue = action
         if (shouldRetry(actionValue)) {
-          throw new TimeoutException("Retry")
+          throw new TimeoutException(s"Retry timed out at ${pos.fileName}:${pos.lineNumber}, value = ${prettifier(actionValue)}")
         }
         actionValue
       },

--- a/src/test/scala/cognite/spark/v1/URLTest.scala
+++ b/src/test/scala/cognite/spark/v1/URLTest.scala
@@ -3,7 +3,9 @@ package cognite.spark.v1
 import org.scalatest.FlatSpec
 
 class URLTest extends FlatSpec with SparkTest {
-  private val greenfieldApiKey = System.getenv("TEST_API_KEY_GREENFIELD")
+  private val greenfieldApiKey =
+    Option(System.getenv("TEST_API_KEY_GREENFIELD"))
+      .getOrElse(throw new Exception("Greenfield API key was not specified in the TEST_API_KEY_GREENFIELD env variable."))
 
   it should "read different files metadata from greenfield and api" taggedAs GreenfieldTest in {
 


### PR DESCRIPTION
We now explicitly handle the case when the column has an unexpected type.

We also do implicit conversions to Double and Long from other numeric types.

Minor improvements: shorter type names, hint for parentExternalId=NULL