### PR TITLE
[CDF-5654] Check Map[String, String] (a metadata field) in fromRow

### DIFF
--- a/src/main/scala/cognite/spark/v1/CdpConnector.scala
+++ b/src/main/scala/cognite/spark/v1/CdpConnector.scala
@@ -51,14 +51,4 @@ object CdpConnector {
 
   type DataItems[A] = Data[Items[A]]
   type CdpApiError = Error[CdpApiErrorPayload]
-
-  // null values aren't allowed according to our schema, and also not allowed by CDP, but they can
-  // still end up here. Filter them out to avoid null pointer exceptions from Circe encoding.
-  // Since null keys don't make sense to CDP either, remove them as well.
-  // Additionally, values are limited to 512 characters, yet we still have data where values have
-  // more characters than that, so truncate them to the valid length if required: it's necessary for
-  // copying existing data, and probably for upserts as well.
-  def filterMetadata(metadata: Option[Map[String, String]]): Option[Map[String, String]] =
-    metadata.map(_.filter { case (k, v) => k != null && v != null }
-      .mapValues(_.slice(0, Constants.MetadataValuePostMaxLength)))
 }

--- a/src/main/scala/cognite/spark/v1/FilesRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FilesRelation.scala
@@ -14,10 +14,7 @@ class FilesRelation(config: RelationConfig)(val sqlContext: SQLContext)
     with InsertableRelation {
 
   override def getFromRowsAndCreate(rows: Seq[Row], doUpsert: Boolean = true): IO[Unit] = {
-    val files = rows.map { r =>
-      val file = fromRow[File](r)
-      file.copy(metadata = CdpConnector.filterMetadata(file.metadata))
-    }
+    val files = rows.map(fromRow[File](_))
     client.files.updateFromRead(files) *> IO.unit
   }
 

--- a/src/main/scala/cognite/spark/v1/SparkSchemaHelperRuntime.scala
+++ b/src/main/scala/cognite/spark/v1/SparkSchemaHelperRuntime.scala
@@ -1,0 +1,88 @@
+package cognite.spark.v1
+
+import org.apache.spark.sql.Row
+
+import scala.util.{Failure, Success, Try}
+
+private[spark] object SparkSchemaHelperRuntime {
+  private def simplifyTypeName(name: String) =
+    name match {
+      case "java.time.Instant" => "Timestamp"
+      case "java.lang.Integer" => "Int"
+      case "java.lang.Long" => "Long"
+      case "java.lang.Double" => "Double"
+      case "java.lang.String" => "String"
+      case x => x
+    }
+
+  private def rowIdentifier(row: Row) = {
+    val columns = row.schema.fieldNames
+    if (columns.contains("externalId")) {
+      s"with externalId='${row.getAs[Any]("externalId")}'"
+    } else if (columns.contains("id")) {
+      s"with id='${row.getAs[Any]("id")}'"
+    } else if (columns.contains("name")) {
+      s"with name='${row.getAs[Any]("name")}'"
+    } else {
+      row.toString
+    }
+  }
+
+  private def valueToString(value: Any) =
+    if (value == null) {
+      "NULL"
+    } else {
+      s"'$value' of type ${simplifyTypeName(value.getClass.getName)}"
+    }
+
+  // convert Map[Any, Any] to Map[String, String] by checking every key and value.
+  def checkMetadataMap(mapAny: Map[Any, Any], row: Row): Map[String, String] = {
+    val map = mapAny.asInstanceOf[Map[Any, Any]]
+    val badKeys = map.keys
+      .filter(!_.isInstanceOf[String])
+      .map(k =>
+        s"Map with string keys was expected, but ${valueToString(k)} was found (on row ${rowIdentifier(row)}).")
+
+    val badValues = map
+      .filter { case (k, v) => !v.isInstanceOf[String] && v != null }
+      .map {
+        case (k, v) =>
+          s"Map with string values was expected, but ${valueToString(v)} was found (under key '$k' on row ${rowIdentifier(row)})"
+      }
+
+    (badKeys ++ badValues).headOption match {
+      case Some(error) => throw new IllegalArgumentException(error)
+      case None => filterMetadata(map.asInstanceOf[Map[String, String]])
+    }
+  }
+
+  def badRowError(row: Row, name: String, typeName: String, rowType: String): Throwable =
+    Try(row.getAs[Any](name)) match {
+      case Failure(error) =>
+        new IllegalArgumentException(
+          s"Required column '$name' is missing on row [${row.schema.fieldNames.mkString(", ")}].")
+      case Success(value) =>
+        val hint =
+          if (rowType == "cognite.spark.v1.AssetsIngestSchema" && name == "parentExternalId" && value == null) {
+            " To mark the node as root, please use an empty string ('')."
+          } else {
+            ""
+          }
+
+        // this function is invoked only in case of an error -> we have some type issues
+        val valueString = valueToString(value)
+        new IllegalArgumentException(s"Column '$name' was expected to have type ${simplifyTypeName(
+          typeName)}, but $valueString was found (on row ${rowIdentifier(row)}).$hint")
+    }
+
+  // null values aren't allowed according to our schema, and also not allowed by CDP, but they can
+  // still end up here. Filter them out to avoid null pointer exceptions from Circe encoding.
+  // Since null keys don't make sense to CDP either, remove them as well.
+  // Additionally, values are limited to 512 characters, yet we still have data where values have
+  // more characters than that, so truncate them to the valid length if required: it's necessary for
+  // copying existing data, and probably for upserts as well.
+  def filterMetadata(metadata: Map[String, String]): Map[String, String] =
+    metadata
+      .filter { case (k, v) => k != null && v != null }
+      .mapValues(_.slice(0, Constants.MetadataValuePostMaxLength))
+}

--- a/src/test/scala/cognite/spark/v1/DataPointsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/DataPointsRelationTest.scala
@@ -604,7 +604,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with SparkTest {
         .option("onconflict", "upsert")
         .save
     }
-    exception.getMessage should include ("Column 'externalId' was expected to have type String, but value '1' of type Int was found (on row with externalId='1')")
+    exception.getMessage should include ("Column 'externalId' was expected to have type String, but '1' of type Int was found (on row with externalId='1')")
     enableSparkLogging()
   }
 
@@ -627,7 +627,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with SparkTest {
         .option("onconflict", "upsert")
         .save
     }
-    exception.getMessage should include ("Column 'value' was expected to have type Double, but value 'non-numeric value' of type String was found (on row with id='1')")
+    exception.getMessage should include ("Column 'value' was expected to have type Double, but 'non-numeric value' of type String was found (on row with id='1')")
     enableSparkLogging()
   }
 
@@ -650,7 +650,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with SparkTest {
         .option("onconflict", "upsert")
         .save
     }
-    exception.getMessage should include ("Column 'timestamp' was expected to have type Timestamp, but value '1509500001' of type Int was found (on row with id='1')")
+    exception.getMessage should include ("Column 'timestamp' was expected to have type Timestamp, but '1509500001' of type Int was found (on row with id='1')")
     enableSparkLogging()
   }
 

--- a/src/test/scala/cognite/spark/v1/SparkSchemaHelperTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkSchemaHelperTest.scala
@@ -9,7 +9,7 @@ import SparkSchemaHelper._
 
 final case class TestTypeBasic(a: Int, b: Double, c: Byte, d: Float, x: Map[String, String], g: Long, f: Seq[Long], s: String)
 final case class TestTypeOption(a: Option[Int], b: Option[Double], c: Option[Byte],
-                          d: Option[Float], x: Option[Map[String, Option[String]]],
+                          d: Option[Float], x: Option[Map[String, String]],
                           g: Option[Long], f: Option[Seq[Option[Long]]], s: Option[String])
 
 class SparkSchemaHelperTest extends FlatSpec with Matchers {
@@ -32,7 +32,7 @@ class SparkSchemaHelperTest extends FlatSpec with Matchers {
       StructField("b", DataTypes.DoubleType, true),
       StructField("c", DataTypes.ByteType, true),
       StructField("d", DataTypes.FloatType, true),
-      StructField("x", DataTypes.createMapType(DataTypes.StringType, DataTypes.StringType, true), true),
+      StructField("x", DataTypes.createMapType(DataTypes.StringType, DataTypes.StringType, false), true),
       StructField("g", DataTypes.LongType, true),
       StructField("f", DataTypes.createArrayType(DataTypes.LongType, true), true),
       StructField("s", DataTypes.StringType, true)
@@ -41,6 +41,12 @@ class SparkSchemaHelperTest extends FlatSpec with Matchers {
 
   "SparkSchemaHelper fromRow" should "construct type from Row" in {
     val r = new GenericRowWithSchema(Array(1, 2.toDouble, 3.toByte,
+      4, Map("foo" -> "bar"), 5.toLong, Seq[Long](10), "foo"), structType[TestTypeBasic])
+    fromRow[TestTypeBasic](r) should be(TestTypeBasic(1, 2, 3, 4, Map("foo" -> "bar"), 5, Seq(10), "foo"))
+  }
+
+  "SparkSchemaHelper fromRow" should "construct type from Row doing implicit conversions" in {
+    val r = new GenericRowWithSchema(Array(1, 2, 3.toByte,
       4.toFloat, Map("foo" -> "bar"), 5.toLong, Seq[Long](10), "foo"), structType[TestTypeBasic])
     fromRow[TestTypeBasic](r) should be(TestTypeBasic(1, 2, 3, 4, Map("foo" -> "bar"), 5, Seq(10), "foo"))
   }
@@ -51,16 +57,10 @@ class SparkSchemaHelperTest extends FlatSpec with Matchers {
       TestTypeOption(None, None, None, None, None, None, None, None))
   }
 
-  it should "construct optional type from Row of map values that are null" in {
-    val r = new GenericRowWithSchema(Array(null, null, null, null, Map("foo" -> null), null, null, null), structType[TestTypeOption])
-    fromRow[TestTypeOption](r) should be(
-      TestTypeOption(None, None, None, None, Some(Map("foo" -> None)), None, None, None))
-  }
-
   it should "construct optional type from Row of map values that can be null" in {
-    val r = new GenericRowWithSchema(Array(null, null, null, null, Map("foo" -> "row", "bar" -> null), null, null, null), structType[TestTypeOption])
+    val r = new GenericRowWithSchema(Array(null, null, null, null, Map("foo" -> "row", "bar" -> "a"), null, null, null), structType[TestTypeOption])
     fromRow[TestTypeOption](r) should be(
-      TestTypeOption(None, None, None, None, Some(Map("foo" -> Some("row"), "bar" -> None)), None, None, None))
+      TestTypeOption(None, None, None, None, Some(Map("foo" -> "row", "bar" -> "a")), None, None, None))
   }
 
   it should "construct optional type from Row of seq values that can be null" in {
@@ -75,13 +75,53 @@ class SparkSchemaHelperTest extends FlatSpec with Matchers {
   }
 
   it should "construct Row from optional map type" in {
-    asRow(TestTypeOption(None, None, None, None, Some(Map("foo" -> Some("row"), "bar" -> None)), None, None, None)) should
-      be(Row(None, None, None, None, Some(Map("foo" -> Some("row"), "bar" -> None)), None, None, None))
+    asRow(TestTypeOption(None, None, None, None, Some(Map("foo" -> "row", "bar" -> "a")), None, None, None)) should
+      be(Row(None, None, None, None, Some(Map("foo" -> "row", "bar" -> "a")), None, None, None))
   }
 
   it should "construct Row from optional seq type" in {
     val x = TestTypeOption(None, None, None, None, None, None, Some(Seq(None, Some(10L))), None)
     asRow(x) should
       be(Row(None, None, None, None, None, None, Some(Seq(None, Some(10L))), None))
+  }
+
+  it should "ignore null in map" in {
+    val x = new GenericRowWithSchema(Array(null, null, null, null, Map("foo" -> "row", "bar" -> null), null, null, null), structType[TestTypeOption])
+    val row = fromRow[TestTypeOption](x)
+    row.x.get shouldBe Map("foo" -> "row")
+  }
+
+  it should "fail nicely on different type in map" in {
+    val x = new GenericRowWithSchema(Array(null, null, null, null, Map("foo" -> "row", "bar" -> 1), null, null, null), structType[TestTypeOption])
+    val ex = intercept[IllegalArgumentException] { fromRow[TestTypeOption](x) }
+    ex.getMessage shouldBe "Map with string values was expected, but '1' of type Int was found (under key 'bar' on row [null,null,null,null,Map(foo -> row, bar -> 1),null,null,null])"
+  }
+
+  it should "fail nicely on type mismatch" in {
+    val x = new GenericRowWithSchema(Array("shouldBeInt", 2.toDouble, 3.toByte,
+      4.toFloat, Map("foo" -> "bar"), 5.toLong, Seq[Long](10), "foo"), structType[TestTypeBasic])
+    val ex = intercept[IllegalArgumentException] { fromRow[TestTypeBasic](x) }
+    ex.getMessage shouldBe "Column 'a' was expected to have type Int, but 'shouldBeInt' of type String was found (on row [shouldBeInt,2.0,3,4.0,Map(foo -> bar),5,List(10),foo])."
+  }
+
+  it should "fail nicely on unexpected NULL in int" in {
+    val x = new GenericRowWithSchema(Array(null, 2.toDouble, 3.toByte,
+      4.toFloat, Map("foo" -> "bar"), 5.toLong, Seq[Long](10), "foo"), structType[TestTypeBasic])
+    val ex = intercept[IllegalArgumentException] { fromRow[TestTypeBasic](x) }
+    ex.getMessage shouldBe "Column 'a' was expected to have type Int, but NULL was found (on row [null,2.0,3,4.0,Map(foo -> bar),5,List(10),foo])."
+  }
+
+  it should "fail nicely on unexpected NULL in string" in {
+    val x = new GenericRowWithSchema(Array(1, 2.toDouble, 3.toByte,
+      4.toFloat, Map("foo" -> "bar"), 5.toLong, Seq[Long](10), null), structType[TestTypeBasic])
+    val ex = intercept[IllegalArgumentException] { fromRow[TestTypeBasic](x) }
+    ex.getMessage shouldBe "Column 's' was expected to have type String, but NULL was found (on row [1,2.0,3,4.0,Map(foo -> bar),5,List(10),null])."
+  }
+
+  it should "fail nicely on unexpected NULL in map" in {
+    val x = new GenericRowWithSchema(Array(1, 2.toDouble, 3.toByte,
+      4.toFloat, null, 5.toLong, Seq[Long](10), "foo"), structType[TestTypeBasic])
+    val ex = intercept[IllegalArgumentException] { fromRow[TestTypeBasic](x) }
+    ex.getMessage shouldBe "Column 'x' was expected to have type Map[String,String], but NULL was found (on row [1,2.0,3,4.0,null,5,List(10),foo])."
   }
 }


### PR DESCRIPTION
the `fromRow` macro now checks that `Map[String, String]` contains only strings, ignores null values and trims the values to the metadata size limit.