### PR TITLE
[CDF-5528] Add delete for data points

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,29 @@ Assets and events will ignore existing ids on deletes. If you prefer to abort th
 when attempting to delete an unknown id, use `.option("ignoreUnknownIds", "false")`
 for those resources types.
 
+Expected schema for delete of Time series, Assets, Events or Files is:
+
+| Column name       | Type                  |  Nullable |
+| ------------------| ----------------------| --------- |
+| `id`              | `long`                | No        |
+
+Expected schema for delete of Datapoints or String Datapoints is:
+
+| Column name       | Type                  |  Nullable |
+| ------------------| ----------------------| --------- |
+| `id`             |  `long`                Yes      |
+| `externalId`      | `string`             | Yes     |
+| `inclusiveBegin`  | `timestamp`          | Yes     |
+| `exclusiveBegin`  | `timestamp`          | Yes     |
+| `inclusiveEnd`    | `timestamp`          | Yes     |
+| `exclusiveEnd`    | `timestamp`          | Yes     |
+
+One of `id` & `externalId`, `inclusiveBegin` & `exclusiveBegin` and `inclusiveEnd` & `exclusiveEnd` must be specified.
+Data points are deleted by a range and both bound must be specified.
+To delete a single data point, set `inclusiveBegin` and `inclusiveEnd` to the same value.
+To delete a range between two points, set `exclusiveBegin` to the first point and `exclusiveEnd` to the second one;
+this will not delete the boundaries, but everything between them.
+
 ## Asset hierarchy builder (beta)
 Note: The asset hierarchy builder is currently in beta, and has not been sufficiently tested to be used 
 on production data.

--- a/src/main/scala/cognite/spark/v1/NumericDataPointsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/NumericDataPointsRelation.scala
@@ -115,9 +115,6 @@ class NumericDataPointsRelationV1(config: RelationConfig)(sqlContext: SQLContext
   override def update(rows: Seq[Row]): IO[Unit] =
     throw new RuntimeException("Update not supported for datapoints. Use upsert instead.")
 
-  override def delete(rows: Seq[Row]): IO[Unit] =
-    throw new RuntimeException("Delete not supported for datapoints.")
-
   override def schema: StructType =
     StructType(
       Seq(
@@ -225,4 +222,5 @@ object NumericDataPointsRelation extends UpsertSchema {
   val upsertSchema: StructType = structType[InsertDataPointsItem]
   val readSchema: StructType = structType[DataPointsItem]
   val insertSchema: StructType = structType[InsertDataPointsItem]
+  val deleteSchema: StructType = structType[DeleteDataPointsItem]
 }

--- a/src/main/scala/cognite/spark/v1/StringDataPointsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/StringDataPointsRelation.scala
@@ -46,9 +46,6 @@ class StringDataPointsRelationV1(config: RelationConfig)(override val sqlContext
   override def update(rows: Seq[Row]): IO[Unit] =
     throw new RuntimeException("Update not supported for stringdatapoints. Please use upsert instead.")
 
-  override def delete(rows: Seq[Row]): IO[Unit] =
-    throw new RuntimeException("Delete not supported for stringdatapoints.")
-
   def toRow(a: StringDataPointsItem): Row = asRow(a)
 
   override def schema: StructType =
@@ -193,4 +190,5 @@ object StringDataPointsRelation extends UpsertSchema {
   val upsertSchema = structType[StringDataPointsInsertItem]
   val readSchema = structType[StringDataPointsItem]
   val insertSchema = structType[StringDataPointsInsertItem]
+  val deleteSchema = structType[DeleteDataPointsItem]
 }


### PR DESCRIPTION
This is the delete schema for datapoints delete:

```scala
final case class DeleteDataPointsItem(
  id: Option[Long],
  externalId: Option[String],
  exclusiveBegin: Option[Instant],
  inclusiveBegin: Option[Instant],
  exclusiveEnd: Option[Instant],
  inclusiveEnd: Option[Instant]
)
```

Can delete ranges. If you want to delete specific points, just set `inclusiveBegin` and `inclusiveEnd` to the same value.

TODO:
- [x] test for string data points
- [x] docs to README.md