### PR TITLE
Add exception base classes and use custom exceptions

### DIFF
--- a/performancebench/src/main/scala/cognite/spark/performancebench/SparkUtil.scala
+++ b/performancebench/src/main/scala/cognite/spark/performancebench/SparkUtil.scala
@@ -1,10 +1,11 @@
 package cognite.spark.performancebench
 
+import cognite.spark.v1.CdfSparkException
 import org.apache.spark.sql.{DataFrame, DataFrameReader, DataFrameWriter, Row, SparkSession}
 
 trait SparkUtil {
   val spark = SparkUtil.spark
-  val cogniteApiKey = sys.env.getOrElse("COGNITE_API_KEY", throw new Exception("'COGNITE_API_KEY' is not set"))
+  val cogniteApiKey = sys.env.getOrElse("COGNITE_API_KEY", throw new CdfSparkException("'COGNITE_API_KEY' is not set"))
 
   def read(): DataFrameReader =
     spark.read

--- a/src/main/scala/cognite/spark/v1/AssetHierarchyBuilder.scala
+++ b/src/main/scala/cognite/spark/v1/AssetHierarchyBuilder.scala
@@ -54,16 +54,16 @@ final case class AssetSubtree(
 
 final case class NoRootException(
     message: String = """Tree has no root. Set parentExternalId to "" for the root Asset.""")
-    extends Exception(message)
+    extends CdfSparkException(message)
 final case class InvalidTreeException(message: String = s"The tree has an invalid structure.")
-    extends Exception(message)
+    extends CdfSparkException(message)
 final case class NonUniqueAssetId(id: String)
-    extends Exception(s"Asset tree contains asset '$id' multiple times.")
+    extends CdfSparkException(s"Asset tree contains asset '$id' multiple times.")
 final case class EmptyExternalIdException(message: String = s"ExternalId cannot be an empty String.")
-    extends Exception(message)
-final case class CdfDoesNotSupportException(message: String) extends Exception(message)
+    extends CdfSparkException(message)
+final case class CdfDoesNotSupportException(message: String) extends CdfSparkException(message)
 final case class InvalidNodeReferenceException(nodeIds: Seq[String], referencedFrom: Seq[String])
-    extends Exception({
+    extends CdfSparkException({
       val plural = (sg: String, pl: String) => if (nodeIds.length == 1) sg else pl
       val nodes = nodeIds.map(x => s"'$x'").sorted.mkString(", ")
       val refNodes = referencedFrom.map(x => s"'$x'").sorted.mkString(", ")

--- a/src/main/scala/cognite/spark/v1/AssetsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/AssetsRelation.scala
@@ -83,7 +83,7 @@ class AssetsRelation(config: RelationConfig)(val sqlContext: SQLContext)
       assets.partition(r => r.id.exists(_ > 0) || (r.name.isEmpty && r.externalId.nonEmpty))
 
     if (itemsToUpdateOrCreate.exists(_.name.isEmpty)) {
-      throw new IllegalArgumentException("The name field must be set when creating assets.")
+      throw new CdfSparkIllegalArgumentException("The name field must be set when creating assets.")
     }
 
     genericUpsert[Asset, AssetsUpsertSchema, AssetCreate, AssetUpdate, Assets[IO]](

--- a/src/main/scala/cognite/spark/v1/CDFSparkException.scala
+++ b/src/main/scala/cognite/spark/v1/CDFSparkException.scala
@@ -1,0 +1,23 @@
+package cognite.spark.v1
+
+class CdfSparkException(message: String) extends Exception(message) {
+  def this(message: String, cause: Throwable) {
+    this(message)
+    initCause(cause)
+  }
+
+  def this(cause: Throwable) {
+    this(Option(cause).map(_.toString).orNull, cause)
+  }
+}
+
+class CdfSparkIllegalArgumentException(message: String) extends CdfSparkException(message) {
+  def this(message: String, cause: Throwable) {
+    this(message)
+    initCause(cause)
+  }
+
+  def this(cause: Throwable) {
+    this(Option(cause).map(_.toString).orNull, cause)
+  }
+}

--- a/src/main/scala/cognite/spark/v1/DataPointsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/DataPointsRelation.scala
@@ -62,11 +62,12 @@ abstract class DataPointsRelationV1[A](config: RelationConfig, shortName: String
     val granularities = filters.flatMap(getGranularity).distinct
 
     if (aggregations.nonEmpty && granularities.isEmpty) {
-      throw new IllegalArgumentException(s"Aggregations requested but granularity is not specified")
+      throw new CdfSparkIllegalArgumentException(
+        s"Aggregations requested but granularity is not specified")
     }
 
     if (aggregations.isEmpty && granularities.nonEmpty) {
-      throw new IllegalArgumentException(s"Granularity specified but no aggregation requested")
+      throw new CdfSparkIllegalArgumentException(s"Granularity specified but no aggregation requested")
     }
 
     (aggregations, granularities)
@@ -194,14 +195,14 @@ object DataPointsRelationV1 {
       row: Any): Long =
     (lower, upper) match {
       case (Some(_), Some(_)) =>
-        throw new IllegalArgumentException(
+        throw new CdfSparkIllegalArgumentException(
           s"Delete row for data points can not contain both inclusive$part and exclusive$part (on row $row)")
       case (Some(lower), None) =>
         lower.toEpochMilli
       case (None, Some(upper)) =>
         upper.toEpochMilli + 1
       case (None, None) =>
-        throw new IllegalArgumentException(
+        throw new CdfSparkIllegalArgumentException(
           s"Delete row for data points must contain inclusive$part or exclusive$part (on row $row)")
     }
 
@@ -210,14 +211,14 @@ object DataPointsRelationV1 {
       case (Some(id), _) => CogniteInternalId(id)
       case (None, Some(externalId)) => CogniteExternalId(externalId)
       case (None, None) =>
-        throw new IllegalArgumentException(
+        throw new CdfSparkIllegalArgumentException(
           s"Delete row for data points must contain id or externalId (on row $x)")
     }
 
     val inclusiveBegin = toLowerbound(x.inclusiveBegin, x.exclusiveBegin, "Begin", x)
     val exclusiveEnd = toLowerbound(x.exclusiveEnd, x.inclusiveEnd, "End", x)
     if (exclusiveEnd <= inclusiveBegin) {
-      throw new IllegalArgumentException(
+      throw new CdfSparkIllegalArgumentException(
         s"Delete range [$inclusiveBegin, $exclusiveEnd) is invalid (on row $x)")
     }
     id match {

--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -44,7 +44,8 @@ object LegacyNameSource extends Enumeration {
       case "false" => LegacyNameSource.None
       case "true" | "name" => LegacyNameSource.Name
       case "externalid" => LegacyNameSource.ExternalId
-      case invalid => throw new IllegalArgumentException(s"Invalid value for useLegacyName: $invalid")
+      case invalid =>
+        throw new CdfSparkIllegalArgumentException(s"Invalid value for useLegacyName: $invalid")
     }
 }
 
@@ -241,7 +242,7 @@ object DefaultSource {
     val onConflictName = parameters.getOrElse("onconflict", "ABORT")
     OnConflict
       .withNameOpt(onConflictName.toUpperCase())
-      .getOrElse(throw new IllegalArgumentException(
+      .getOrElse(throw new CdfSparkIllegalArgumentException(
         s"$onConflictName is not a valid onConflict option. Please choose one of the following options instead: ${OnConflict.values
           .mkString(", ")}"))
   }
@@ -283,7 +284,7 @@ object DefaultSource {
           AssetSubtreeOption
             .withNameOpt(x)
             .getOrElse(
-              throw new IllegalArgumentException(
+              throw new CdfSparkIllegalArgumentException(
                 s"`$x` is an invalid value for option subtree. You can use ingest, ignore or value."))
         case (Some(_), None) =>
           if (toBoolean(parameters, "ignoreDisconnectedAssets")) {
@@ -293,7 +294,7 @@ object DefaultSource {
             AssetSubtreeOption.Error
           }
         case (Some(ignoreDisconnectedAssets), Some(subtree)) =>
-          throw new IllegalArgumentException(
+          throw new CdfSparkIllegalArgumentException(
             s"Can not specify both ignoreDisconnectedAssets=$ignoreDisconnectedAssets and subtree=$subtree")
       }
     RelationConfig(

--- a/src/main/scala/cognite/spark/v1/FilesRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FilesRelation.scala
@@ -67,7 +67,7 @@ class FilesRelation(config: RelationConfig)(val sqlContext: SQLContext)
       files.partition(r => r.id.exists(_ > 0) || (r.name.isEmpty && r.externalId.nonEmpty))
 
     if (itemsToUpdateOrCreate.exists(_.name.isEmpty)) {
-      throw new IllegalArgumentException("The name field must be set when creating files.")
+      throw new CdfSparkIllegalArgumentException("The name field must be set when creating files.")
     }
 
     genericUpsert[File, FilesUpsertSchema, FileCreate, FileUpdate, Files[IO]](

--- a/src/main/scala/cognite/spark/v1/NumericDataPointsRdd.scala
+++ b/src/main/scala/cognite/spark/v1/NumericDataPointsRdd.scala
@@ -70,7 +70,7 @@ final case class NumericDataPointsRdd(
     counts match {
       case count +: moreCounts =>
         if (count.value > maxPointsPerPartition) {
-          throw new RuntimeException(
+          throw new CdfSparkException(
             s"More than ${maxPointsPerPartition} for id $id in interval starting at ${count.timestamp.toString}" +
               " with granularity ${granularity.toString}. Please report this to Cognite.")
         }

--- a/src/main/scala/cognite/spark/v1/PushdownUtilities.scala
+++ b/src/main/scala/cognite/spark/v1/PushdownUtilities.scala
@@ -62,7 +62,7 @@ object PushdownUtilities {
       case IsNotNull(_) | IsNull(_) | EqualNullSafe(_, null) => NoPushdown()
       case EqualTo(_, null) | GreaterThan(_, null) | GreaterThanOrEqual(_, null) | LessThan(_, null) |
           LessThanOrEqual(_, null) =>
-        throw new Exception(
+        throw new CdfSparkException(
           "Unexpected error, seems that Spark query optimizer is misbehaving. Please contact support@cognite.com and tell them.")
       case EqualTo(colName, value) => PushdownFilter(colName, value.toString)
       case EqualNullSafe(colName, value) => PushdownFilter(colName, value.toString)

--- a/src/main/scala/cognite/spark/v1/RawTableRelation.scala
+++ b/src/main/scala/cognite/spark/v1/RawTableRelation.scala
@@ -159,7 +159,8 @@ class RawTableRelation(
 
   override def insert(df: DataFrame, overwrite: scala.Boolean): scala.Unit = {
     if (!df.columns.contains("key")) {
-      throw new IllegalArgumentException("The dataframe used for insertion must have a \"key\" column.")
+      throw new CdfSparkIllegalArgumentException(
+        "The dataframe used for insertion must have a \"key\" column.")
     }
 
     val (columnNames, dfWithUnRenamedKeyColumns) = prepareForInsert(df.drop(lastUpdatedTimeColName))
@@ -199,7 +200,7 @@ object RawTableRelation {
       row =>
         RawRow(
           Option(row.getString(row.fieldIndex(temporaryKeyName)))
-            .getOrElse(throw new IllegalArgumentException("\"key\" can not be null.")),
+            .getOrElse(throw new CdfSparkIllegalArgumentException("\"key\" can not be null.")),
           io.circe.parser
             .decode[Map[String, Json]](
               mapper.writeValueAsString(row.getValuesMap[Any](nonKeyColumnNames)))

--- a/src/main/scala/cognite/spark/v1/SdkV1Relation.scala
+++ b/src/main/scala/cognite/spark/v1/SdkV1Relation.scala
@@ -114,7 +114,7 @@ abstract class SdkV1Relation[A <: Product, I](config: RelationConfig, shortName:
       duplicated.flatMap(j => j("legacyName")).map(_.asString.get)
 
     if (legacyNameConflicts.nonEmpty) {
-      throw new IllegalArgumentException(
+      throw new CdfSparkIllegalArgumentException(
         "Found legacyName conflicts, upserts only supported with legacyName when using externalId as legacy name." +
           s" Conflicting legacyNames: ${legacyNameConflicts.mkString(", ")}." +
           requestId.map(id => s" Request ID: $id").getOrElse(""))

--- a/src/main/scala/cognite/spark/v1/SequencesRelation.scala
+++ b/src/main/scala/cognite/spark/v1/SequencesRelation.scala
@@ -44,7 +44,7 @@ class SequencesRelation(config: RelationConfig)(val sqlContext: SQLContext)
         NonEmptyList
           .fromList(s.columns.toList)
           .getOrElse(
-            throw new IllegalArgumentException(
+            throw new CdfSparkIllegalArgumentException(
               s"columns must not be empty (on row ${SparkSchemaHelperRuntime.rowIdentifier(row)})")
           ),
         s.dataSetId
@@ -77,7 +77,7 @@ class SequencesRelation(config: RelationConfig)(val sqlContext: SQLContext)
   override def upsert(rows: Seq[Row]): IO[Unit] =
     // Sequences fail with 400 error code when id already exists:
     // /api/v1/projects/jetfiretest2/sequences failed with status 400: The following external id(s) are already in the database:
-    throw new RuntimeException("Upsert not supported for sequences.")
+    throw new CdfSparkException("Upsert not supported for sequences.")
 
   override def getFromRowsAndCreate(rows: Seq[Row], doUpsert: Boolean = true): IO[Unit] = {
     val sequences = rows.map(fromRow[SequenceCreate](_))

--- a/src/main/scala/cognite/spark/v1/SparkSchemaHelperRuntime.scala
+++ b/src/main/scala/cognite/spark/v1/SparkSchemaHelperRuntime.scala
@@ -51,7 +51,7 @@ private[spark] object SparkSchemaHelperRuntime {
       }
 
     (badKeys ++ badValues).headOption match {
-      case Some(error) => throw new IllegalArgumentException(error)
+      case Some(error) => throw new CdfSparkIllegalArgumentException(error)
       case None => filterMetadata(map.asInstanceOf[Map[String, String]])
     }
   }
@@ -59,7 +59,7 @@ private[spark] object SparkSchemaHelperRuntime {
   def badRowError(row: Row, name: String, typeName: String, rowType: String): Throwable =
     Try(row.getAs[Any](name)) match {
       case Failure(error) =>
-        new IllegalArgumentException(
+        new CdfSparkIllegalArgumentException(
           s"Required column '$name' is missing on row [${row.schema.fieldNames.mkString(", ")}].")
       case Success(value) =>
         val hint =
@@ -71,7 +71,7 @@ private[spark] object SparkSchemaHelperRuntime {
 
         // this function is invoked only in case of an error -> we have some type issues
         val valueString = valueToString(value)
-        new IllegalArgumentException(s"Column '$name' was expected to have type ${simplifyTypeName(
+        new CdfSparkIllegalArgumentException(s"Column '$name' was expected to have type ${simplifyTypeName(
           typeName)}, but $valueString was found (on row ${rowIdentifier(row)}).$hint")
     }
 

--- a/src/main/scala/cognite/spark/v1/StringDataPointsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/StringDataPointsRelation.scala
@@ -39,12 +39,12 @@ class StringDataPointsRelationV1(config: RelationConfig)(override val sqlContext
     with WritableRelation {
   import CdpConnector._
   override def insert(rows: Seq[Row]): IO[Unit] =
-    throw new RuntimeException("Insert not supported for stringdatapoints. Please use upsert instead.")
+    throw new CdfSparkException("Insert not supported for stringdatapoints. Please use upsert instead.")
 
   override def upsert(rows: Seq[Row]): IO[Unit] = insertSeqOfRows(rows)
 
   override def update(rows: Seq[Row]): IO[Unit] =
-    throw new RuntimeException("Update not supported for stringdatapoints. Please use upsert instead.")
+    throw new CdfSparkException("Update not supported for stringdatapoints. Please use upsert instead.")
 
   def toRow(a: StringDataPointsItem): Row = asRow(a)
 
@@ -62,7 +62,7 @@ class StringDataPointsRelationV1(config: RelationConfig)(override val sqlContext
       rows.map(r => fromRow[StringDataPointsInsertItem](r)).partition(p => p.id.exists(_ > 0))
 
     if (dataPointsWithExternalId.exists(_.externalId.isEmpty)) {
-      throw new IllegalArgumentException(
+      throw new CdfSparkIllegalArgumentException(
         "The id or externalId fields must be set when inserting data points.")
     }
 
@@ -80,7 +80,7 @@ class StringDataPointsRelationV1(config: RelationConfig)(override val sqlContext
             dataPoints.map(dp => StringDataPoint(dp.timestamp, dp.value)))
           .flatTap(_ => incMetrics(itemsCreated, dataPoints.size))
       case (None, _) =>
-        throw new IllegalArgumentException(
+        throw new CdfSparkIllegalArgumentException(
           "The id or externalId fields must be set when inserting data points.")
     }
 
@@ -110,7 +110,7 @@ class StringDataPointsRelationV1(config: RelationConfig)(override val sqlContext
 
     // Notify users that they need to supply one or more ids/externalIds when reading data points
     if (ids.isEmpty && externalIds.isEmpty) {
-      throw new IllegalArgumentException(
+      throw new CdfSparkIllegalArgumentException(
         "Please filter by one or more ids or externalIds when reading string data points.")
     }
 

--- a/src/main/scala/cognite/spark/v1/TimeSeriesRelation.scala
+++ b/src/main/scala/cognite/spark/v1/TimeSeriesRelation.scala
@@ -65,7 +65,7 @@ class TimeSeriesRelation(config: RelationConfig)(val sqlContext: SQLContext)
         case (Some(legacyName), items) if items.length > 1 => legacyName
       }
     if (config.legacyNameSource != LegacyNameSource.None && duplicatedLegacyNames.nonEmpty) {
-      throw new IllegalArgumentException(
+      throw new CdfSparkIllegalArgumentException(
         "Found legacyName duplicates, upserts only supported with legacyName when using externalId as legacy name." +
           s" Duplicated legacyNames: ${duplicatedLegacyNames.mkString(", ")}.")
     }

--- a/src/test/scala/cognite/spark/v1/AssetHierarchyBuilderTest.scala
+++ b/src/test/scala/cognite/spark/v1/AssetHierarchyBuilderTest.scala
@@ -287,7 +287,7 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with ParallelTest
   }
 
   it should "fail reasonably on invalid source type" in {
-    val exception = intercept[IllegalArgumentException] {
+    val exception = intercept[CdfSparkIllegalArgumentException] {
       spark.sql(
         """
           |select "test-asset-rV2yGok98VNzWMb9yWGk" as externalId,
@@ -307,7 +307,7 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with ParallelTest
   }
 
   it should "fail reasonably on NULLs" in {
-    val exception = intercept[IllegalArgumentException] {
+    val exception = intercept[CdfSparkIllegalArgumentException] {
       spark.sql(
         """
           |select "test-asset-rV2yGok98VNzWMb9yWGk" as externalId,
@@ -327,7 +327,7 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with ParallelTest
   }
 
   it should "fail reasonably on invalid dataSetId type" in {
-    val exception = intercept[IllegalArgumentException] {
+    val exception = intercept[CdfSparkIllegalArgumentException] {
       spark.sql(
         """
           |select "test-asset-MNwWje501UZ83dFA3S" as externalId,
@@ -346,7 +346,7 @@ class AssetHierarchyBuilderTest extends FlatSpec with Matchers with ParallelTest
   }
 
   it should "fail with hint on parentExternalId=NULL" in {
-    val exception = intercept[IllegalArgumentException] {
+    val exception = intercept[CdfSparkIllegalArgumentException] {
       spark.sql(
         """
           |select "test-asset-55UbfFlTh2I95usWl7gnok" as externalId,

--- a/src/test/scala/cognite/spark/v1/AssetsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/AssetsRelationTest.scala
@@ -480,7 +480,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecuti
         |select 'upsertTestThree' as name, id from invalid
       """.stripMargin)
 
-    assertThrows[IllegalArgumentException] {
+    assertThrows[CdfSparkIllegalArgumentException] {
       wdf.write
         .format("cognite.spark.v1")
         .option("apiKey", writeApiKey)

--- a/src/test/scala/cognite/spark/v1/DataPointsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/DataPointsRelationTest.scala
@@ -34,7 +34,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
   }
 
   it should "throw an error when no id/externalId filter is provided" taggedAs ReadTest in {
-    val thrown = the[IllegalArgumentException] thrownBy {
+    val thrown = the[CdfSparkIllegalArgumentException] thrownBy {
       spark.read
         .format("cognite.spark.v1")
         .option("apiKey", readApiKey)
@@ -157,7 +157,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
     val e = intercept[Exception] {
       df.count()
     }
-    e shouldBe an[IllegalArgumentException]
+    e shouldBe an[CdfSparkIllegalArgumentException]
   }
 
   it should "be an error to specify a granularity without specifying an aggregation" taggedAs (ReadTest) in {
@@ -170,7 +170,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
     val e = intercept[Exception] {
       df.count()
     }
-    e shouldBe an[IllegalArgumentException]
+    e shouldBe an[CdfSparkIllegalArgumentException]
   }
 
   it should "be an error to specify an invalid granularity" taggedAs (ReadTest) in {
@@ -185,7 +185,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
       val e = intercept[Exception] {
         df.count()
       }
-      e shouldBe an[IllegalArgumentException]
+      e shouldBe an[CdfSparkIllegalArgumentException]
     }
   }
 
@@ -755,7 +755,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
         .option("onconflict", "delete")
         .save
     }
-    e.getCause shouldBe a[IllegalArgumentException]
+    e.getCause shouldBe a[CdfSparkIllegalArgumentException]
     e.getCause.getMessage should startWith("Delete range [1509900000000, 1509900000000) is invalid")
   }
 
@@ -775,7 +775,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
         .option("onconflict", "delete")
         .save
     }
-    e.getCause shouldBe a[IllegalArgumentException]
+    e.getCause shouldBe a[CdfSparkIllegalArgumentException]
     e.getCause.getMessage should startWith("Delete row for data points can not contain both inclusiveEnd and exclusiveEnd ")
   }
 
@@ -793,7 +793,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
         .option("onconflict", "delete")
         .save
     }
-    e.getCause shouldBe a[IllegalArgumentException]
+    e.getCause shouldBe a[CdfSparkIllegalArgumentException]
     e.getCause.getMessage should startWith("Delete row for data points must contain inclusiveBegin or exclusiveBegin ")
   }
 
@@ -811,7 +811,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
         .option("onconflict", "delete")
         .save
     }
-    e.getCause shouldBe a[IllegalArgumentException]
+    e.getCause shouldBe a[CdfSparkIllegalArgumentException]
     e.getCause.getMessage should startWith("Delete row for data points must contain id or externalId ")
   }
 

--- a/src/test/scala/cognite/spark/v1/RawTableRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/RawTableRelationTest.scala
@@ -201,11 +201,11 @@ class RawTableRelationTest extends FlatSpec with Matchers with ParallelTestExecu
     rawItems.map(_.columns) should equal(expectedResult)
   }
 
-  it should "throw an IllegalArgumentException when DataFrame has null key" in {
+  it should "throw an CDFSparkIllegalArgumentException when DataFrame has null key" in {
     val dfWithKey = dfWithNullKeyData.toDF("key", "lastUpdatedTime", "columns")
     val processedWithKey = flattenAndRenameColumns(spark.sqlContext, dfWithKey, dfWithKeySchema)
     val (columnNames, unRenamed) = prepareForInsert(processedWithKey)
-    an[IllegalArgumentException] should be thrownBy rowsToRawItems(
+    an[CdfSparkIllegalArgumentException] should be thrownBy rowsToRawItems(
       columnNames,
       unRenamed.collect.toSeq,
       mapper)

--- a/src/test/scala/cognite/spark/v1/SparkSchemaHelperTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkSchemaHelperTest.scala
@@ -101,35 +101,35 @@ class SparkSchemaHelperTest extends FlatSpec with ParallelTestExecution with Mat
 
   it should "fail nicely on different type in map" in {
     val x = new GenericRowWithSchema(Array(null, null, null, null, Map("foo" -> "row", "bar" -> 1), null, null, null), structType[TestTypeOption])
-    val ex = intercept[IllegalArgumentException] { fromRow[TestTypeOption](x) }
+    val ex = intercept[CdfSparkIllegalArgumentException] { fromRow[TestTypeOption](x) }
     ex.getMessage shouldBe "Map with string values was expected, but '1' of type Int was found (under key 'bar' on row [null,null,null,null,Map(foo -> row, bar -> 1),null,null,null])"
   }
 
   it should "fail nicely on type mismatch" in {
     val x = new GenericRowWithSchema(Array("shouldBeInt", 2.toDouble, 3.toByte,
       4.toFloat, Map("foo" -> "bar"), 5.toLong, Seq[Long](10), "foo"), structType[TestTypeBasic])
-    val ex = intercept[IllegalArgumentException] { fromRow[TestTypeBasic](x) }
+    val ex = intercept[CdfSparkIllegalArgumentException] { fromRow[TestTypeBasic](x) }
     ex.getMessage shouldBe "Column 'a' was expected to have type Int, but 'shouldBeInt' of type String was found (on row [shouldBeInt,2.0,3,4.0,Map(foo -> bar),5,List(10),foo])."
   }
 
   it should "fail nicely on unexpected NULL in int" in {
     val x = new GenericRowWithSchema(Array(null, 2.toDouble, 3.toByte,
       4.toFloat, Map("foo" -> "bar"), 5.toLong, Seq[Long](10), "foo"), structType[TestTypeBasic])
-    val ex = intercept[IllegalArgumentException] { fromRow[TestTypeBasic](x) }
+    val ex = intercept[CdfSparkIllegalArgumentException] { fromRow[TestTypeBasic](x) }
     ex.getMessage shouldBe "Column 'a' was expected to have type Int, but NULL was found (on row [null,2.0,3,4.0,Map(foo -> bar),5,List(10),foo])."
   }
 
   it should "fail nicely on unexpected NULL in string" in {
     val x = new GenericRowWithSchema(Array(1, 2.toDouble, 3.toByte,
       4.toFloat, Map("foo" -> "bar"), 5.toLong, Seq[Long](10), null), structType[TestTypeBasic])
-    val ex = intercept[IllegalArgumentException] { fromRow[TestTypeBasic](x) }
+    val ex = intercept[CdfSparkIllegalArgumentException] { fromRow[TestTypeBasic](x) }
     ex.getMessage shouldBe "Column 's' was expected to have type String, but NULL was found (on row [1,2.0,3,4.0,Map(foo -> bar),5,List(10),null])."
   }
 
   it should "fail nicely on unexpected NULL in map" in {
     val x = new GenericRowWithSchema(Array(1, 2.toDouble, 3.toByte,
       4.toFloat, null, 5.toLong, Seq[Long](10), "foo"), structType[TestTypeBasic])
-    val ex = intercept[IllegalArgumentException] { fromRow[TestTypeBasic](x) }
+    val ex = intercept[CdfSparkIllegalArgumentException] { fromRow[TestTypeBasic](x) }
     ex.getMessage shouldBe "Column 'x' was expected to have type Map[String,String], but NULL was found (on row [1,2.0,3,4.0,null,5,List(10),foo])."
   }
 }

--- a/src/test/scala/cognite/spark/v1/TimeSeriesRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/TimeSeriesRelationTest.scala
@@ -229,7 +229,7 @@ class TimeSeriesRelationTest extends FlatSpec with Matchers with ParallelTestExe
       .select(sourceDf.columns.map(col): _*)
       .write
       .insertInto("destinationTimeSeriesWithLegacyName")
-    assert(exception.getCause.isInstanceOf[IllegalArgumentException])
+    assert(exception.getCause.isInstanceOf[CdfSparkIllegalArgumentException])
 
     val before2 = the[CdpApiException] thrownBy writeClient.timeSeries.retrieveByExternalId(externalId2)
     before2.code shouldBe 400
@@ -377,7 +377,7 @@ class TimeSeriesRelationTest extends FlatSpec with Matchers with ParallelTestExe
     LegacyNameSource.fromSparkOption(Some("externalId")) shouldBe LegacyNameSource.ExternalId
     LegacyNameSource.fromSparkOption(Some("ExternalID")) shouldBe LegacyNameSource.ExternalId
 
-    assertThrows[IllegalArgumentException] {
+    assertThrows[CdfSparkIllegalArgumentException] {
       LegacyNameSource.fromSparkOption(Some("bogus"))
     }
   }
@@ -805,7 +805,7 @@ class TimeSeriesRelationTest extends FlatSpec with Matchers with ParallelTestExe
         .option("onconflict", "upsert")
         .option("useLegacyName", "true")
         .save()
-      assert(exception.getCause.isInstanceOf[IllegalArgumentException])
+      assert(exception.getCause.isInstanceOf[CdfSparkIllegalArgumentException])
 
       val nonExistingTimeSeriesWithLegacyNameDf =
         spark.sql(

--- a/src/test/scala/cognite/spark/v1/URLTest.scala
+++ b/src/test/scala/cognite/spark/v1/URLTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.FlatSpec
 class URLTest extends FlatSpec with SparkTest {
   private val greenfieldApiKey =
     Option(System.getenv("TEST_API_KEY_GREENFIELD"))
-      .getOrElse(throw new Exception("Greenfield API key was not specified in the TEST_API_KEY_GREENFIELD env variable."))
+      .getOrElse(throw new CdfSparkException("Greenfield API key was not specified in the TEST_API_KEY_GREENFIELD env variable."))
 
   it should "read different files metadata from greenfield and api" taggedAs GreenfieldTest in {
 


### PR DESCRIPTION
Exceptions in Spark must have common base class so that we can decide which to let through in Jetfire. https://cognitedata.atlassian.net/secure/RapidBoard.jspa?rapidView=303&modal=detail&selectedIssue=CDF-5649