### PR TITLE
Set x-cdp headers correcly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val circeVersion: Option[(Long, Long)] => String = {
 val sttpVersion = "1.7.2"
 val Specs2Version = "4.2.0"
 val artifactory = "https://cognite.jfrog.io/cognite/"
-val cogniteSdkVersion = "1.3.4"
+val cogniteSdkVersion = "1.3.6"
 val prometheusVersion = "0.8.1"
 val log4sVersion = "1.8.2"
 

--- a/src/main/scala/cognite/spark/v1/CdpConnector.scala
+++ b/src/main/scala/cognite/spark/v1/CdpConnector.scala
@@ -7,9 +7,9 @@ import cats.effect.{ContextShift, IO, Timer}
 import com.cognite.sdk.scala.common.{GzipSttpBackend, RetryingBackend}
 import com.cognite.sdk.scala.v1.GenericClient
 import com.google.common.util.concurrent.ThreadFactoryBuilder
-import com.softwaremill.sttp.asynchttpclient.cats.AsyncHttpClientCatsBackend
 import com.softwaremill.sttp._
 import com.softwaremill.sttp.asynchttpclient.SttpClientBackendFactory
+import com.softwaremill.sttp.asynchttpclient.cats.AsyncHttpClientCatsBackend
 
 import scala.concurrent.ExecutionContext
 
@@ -44,10 +44,11 @@ object CdpConnector {
 
   def clientFromConfig(config: RelationConfig): GenericClient[IO] =
     new GenericClient[IO](
-      Constants.SparkDatasourceVersion,
+      config.applicationName.getOrElse(Constants.SparkDatasourceVersion),
       config.projectName,
       config.baseUrl,
-      config.auth)(implicitly, retryingSttpBackend(config.maxRetries))
+      config.auth,
+      clientTag = config.clientTag)(implicitly, retryingSttpBackend(config.maxRetries))
 
   type DataItems[A] = Data[Items[A]]
   type CdpApiError = Error[CdpApiErrorPayload]

--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -18,6 +18,8 @@ import scala.util.parsing.json.JSONObject
 
 final case class RelationConfig(
     auth: Auth,
+    clientTag: Option[String],
+    applicationName: Option[String],
     projectName: String,
     batchSize: Option[Int],
     limitPerPartition: Option[Int],
@@ -262,6 +264,8 @@ object DefaultSource {
     val maxRetries = toPositiveInt(parameters, "maxRetries")
       .getOrElse(Constants.DefaultMaxRetries)
     val baseUrl = parameters.getOrElse("baseUrl", Constants.DefaultBaseUrl)
+    val clientTag = parameters.get("clientTag")
+    val applicationName = parameters.get("applicationName")
     val bearerToken = parameters
       .get("bearerToken")
       .map(bearerToken => BearerTokenAuth(bearerToken))
@@ -311,6 +315,8 @@ object DefaultSource {
 
     RelationConfig(
       auth,
+      clientTag,
+      applicationName,
       projectName,
       batchSize,
       limitPerPartition,

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -85,6 +85,8 @@ trait SparkTest {
   def getDefaultConfig(auth: Auth): RelationConfig =
     RelationConfig(
       auth,
+      Some("SparkDatasourceTestTag"),
+      Some("SparkDatasourceTestApp"),
       DefaultSource.getProjectFromAuth(auth, Constants.DefaultMaxRetries, Constants.DefaultBaseUrl),
       Some(Constants.DefaultBatchSize),
       None,


### PR DESCRIPTION
Let the new sdk version set `x-cdp-sdk`, let `x-cdp-app` remain as `com.cognite.spark.datasource-VERSION`, and let user (optionally) set `x-cdp-clienttag` in options.