### PR TITLE
Move RawTableRelation.defaultSchema to companion object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Enhancements
+* Moved `RawTableRelation.defaultSchema` to its companion object.
+
 # 1.4.11
 
 ## Fixes

--- a/src/main/scala/cognite/spark/v1/RawTableRelation.scala
+++ b/src/main/scala/cognite/spark/v1/RawTableRelation.scala
@@ -43,12 +43,6 @@ class RawTableRelation(
 
   @transient lazy private val batchSize = config.batchSize.getOrElse(Constants.DefaultRawBatchSize)
 
-  @transient lazy val defaultSchema: StructType = StructType(
-    Seq(
-      StructField("key", DataTypes.StringType),
-      StructField(lastUpdatedTimeColName, DataTypes.TimestampType),
-      StructField("columns", DataTypes.StringType)
-    ))
   @transient lazy val mapper: ObjectMapper = {
     val mapper = new ObjectMapper()
     mapper.registerModule(DefaultScalaModule)
@@ -190,6 +184,13 @@ object RawTableRelation {
   private val lastUpdatedTimeColName = "lastUpdatedTime"
   private val keyColumnPattern = """^_*key$""".r
   private val lastUpdatedTimeColumnPattern = """^_*lastUpdatedTime$""".r
+
+  val defaultSchema: StructType = StructType(
+    Seq(
+      StructField("key", DataTypes.StringType),
+      StructField(lastUpdatedTimeColName, DataTypes.TimestampType),
+      StructField("columns", DataTypes.StringType)
+    ))
 
   private def keyColumns(schema: StructType): Array[String] =
     schema.fieldNames.filter(keyColumnPattern.findFirstIn(_).isDefined)


### PR DESCRIPTION
This makes the default RAW schema accessible without requiring an instance of RawTableRelation.
This is so that we can use it as the source of truth when querying RAW from Jetfire without schema inference, instead of copypasting the schema into the Jetfire codebase.