### PR TITLE
Run asset hierarchy on executors

### DIFF
--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -160,7 +160,7 @@ class DefaultSource
     val resourceType = parameters.getOrElse("type", sys.error("Resource type must be specified"))
     if (resourceType == "assethierarchy") {
       val relation = new AssetHierarchyBuilder(config)(sqlContext)
-      relation.build(data).unsafeRunSync()
+      relation.buildFromDf(data)
       relation
     } else {
       val relation = resourceType match {


### PR DESCRIPTION
essentially use .repartition(1).foreachPartition instead of collect.
Although this will not enable parallelism it will not run on the driver.
In Jetfire this seemed to overload the driver in some cases, so
we'll move this work to one of the executors, which can be scaled easily