### PR TITLE
asset hierarchy: batch mutiple subtrees together 

### DIFF
--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -160,7 +160,7 @@ class DefaultSource
     val resourceType = parameters.getOrElse("type", sys.error("Resource type must be specified"))
     if (resourceType == "assethierarchy") {
       val relation = new AssetHierarchyBuilder(config)(sqlContext)
-      relation.build(data).unsafeRunSync()
+      relation.buildFromDf(data)
       relation
     } else {
       val relation = resourceType match {

--- a/src/test/scala/cognite/spark/v1/AssetHierarchyBuilderTest.scala
+++ b/src/test/scala/cognite/spark/v1/AssetHierarchyBuilderTest.scala
@@ -936,7 +936,7 @@ class AssetHierarchyBuilderTest
     row.getAs[String]("parentExternalId") shouldBe s"grandma$key"
 
     getNumberOfRowsUpdated(afterMoveMetricsPrefix, "assethierarchy") shouldBe 1
-    getNumberOfRowsCreated(afterMoveMetricsPrefix, "assethierarchy") shouldBe 0
+    intercept[Exception](getNumberOfRowsCreated(afterMoveMetricsPrefix, "assethierarchy"))
 
     cleanDB(key)
   }
@@ -988,7 +988,7 @@ class AssetHierarchyBuilderTest
     row.getAs[String]("parentExternalId") shouldBe s"child1$key"
 
     getNumberOfRowsUpdated(afterMoveMetricsPrefix, "assethierarchy") shouldBe 1
-    getNumberOfRowsCreated(afterMoveMetricsPrefix, "assethierarchy") shouldBe 0
+    intercept[Exception](getNumberOfRowsCreated(afterMoveMetricsPrefix, "assethierarchy"))
 
     cleanDB(key)
   }
@@ -1047,7 +1047,7 @@ class AssetHierarchyBuilderTest
 
     rootChangeException shouldBe an[InvalidRootChangeException]
     rootChangeException.getMessage shouldBe (
-      s"Attempted to move some assets to a different root asset with id $newRootAssetId. " +
+      s"Attempted to move some assets to a different root asset in subtree subtree2$key under the rootId=$newRootAssetId. " +
         "If this is intended, the assets must be manually deleted and re-created under the new root asset. " +
         s"The following assets were attempted to be moved: (externalId=child$key)."
     )


### PR DESCRIPTION
this fixes part of the problem that we fired at least 3 request
for each subtree, which was a lot for flat hierarchies

This patch is not complete fix of the problem as it does not batch fetching of
existing subtrees

It changes the behavior of AsserHierarchyBuilder slightly:
* assets.created metric is not even created when no asset is created. This is
   consistent with how the other metrics work.
* error message of moving asset between subtrees also includes externalId of
   the subtree root. No information is missing compared to previous version.