### PR TITLE
Fix batchSize for deleting datapoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.4.30
+
+## Fixes
+
+* Fixed default batchSize for deleting datapoints
+
 # 1.4.29
 
 ## Enhancements

--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -188,8 +188,13 @@ class DefaultSource
         case _ => sys.error(s"Resource type $resourceType does not support save()")
       }
       val batchSizeDefault = relation match {
-        case _: NumericDataPointsRelationV1 => Constants.CreateDataPointsLimit
-        case _: StringDataPointsRelationV1 => Constants.CreateDataPointsLimit
+        case _: NumericDataPointsRelationV1 | _: StringDataPointsRelationV1 =>
+          // Datapoints support 100_000 per request when inserting, but only 10_000 when deleting
+          if (config.onConflict == OnConflict.Delete) {
+            Constants.DefaultDataPointsLimit
+          } else {
+            Constants.CreateDataPointsLimit
+          }
         case _: SequenceRowsRelation => Constants.DefaultSequenceRowsBatchSize
         case _ => Constants.DefaultBatchSize
       }


### PR DESCRIPTION
While debugging other issue in Jetfire, I run into this limitation.