### PR TITLE
Fix filter pushdown for datapoints.value

### DIFF
--- a/src/main/scala/cognite/spark/v1/DataPointsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/DataPointsRelation.scala
@@ -88,7 +88,7 @@ abstract class DataPointsRelationV1[A](config: RelationConfig, shortName: String
       "discreteVariance")
     aggregation match {
       case agg: String if allowedAggregations.contains(agg) => AggregationFilter(agg)
-      case _ => sys.error(s"Invalid aggregation $aggregation")
+      case _ => throw new CdfSparkIllegalArgumentException(s"Invalid aggregation $aggregation")
     }
   }
 
@@ -99,16 +99,16 @@ abstract class DataPointsRelationV1[A](config: RelationConfig, shortName: String
       case EqualNullSafe("aggregation", value) => Seq(toAggregationFilter(value.toString))
       case In("aggregation", values) =>
         values.map(v => toAggregationFilter(v.toString))
-      case And(_, _) => sys.error("AND is not allowed for aggregations")
+      case And(_, _) => throw new CdfSparkIllegalArgumentException("AND is not allowed for aggregations")
       case Or(f1, f2) => getAggregation(f1) ++ getAggregation(f2)
       case StringStartsWith("aggregation", value) =>
-        sys.error(
+        throw new CdfSparkIllegalArgumentException(
           s"Choosing aggregation using 'string starts with' not allowed for data points, attempted for ${value.toString}")
       case StringEndsWith("aggregation", value) =>
-        sys.error(
+        throw new CdfSparkIllegalArgumentException(
           s"Choosing aggregation using 'string starts with' not allowed for data points, attempted for ${value.toString}")
       case StringContains("aggregation", value) =>
-        sys.error(
+        throw new CdfSparkIllegalArgumentException(
           s"Choosing aggregation using 'string starts with' not allowed for data points, attempted for ${value.toString}")
       case _ => Seq()
     }
@@ -123,17 +123,17 @@ abstract class DataPointsRelationV1[A](config: RelationConfig, shortName: String
       case EqualNullSafe("granularity", value) => toGranularityFilter(value.toString)
       case In("granularity", values) =>
         values.flatMap(v => toGranularityFilter(v.toString))
-      case And(_, _) => sys.error("AND is not allowed for granularity")
+      case And(_, _) => throw new CdfSparkIllegalArgumentException("AND is not allowed for granularity")
       case Or(f1, f2) => getGranularity(f1) ++ getGranularity(f2)
       case StringStartsWith("granularity", value) =>
-        sys.error(
-          s"Choosing granularity using 'string starts with' not allowed for data points, attempted for ${value.toString}")
+        throw new CdfSparkIllegalArgumentException(
+          s"Choosing granularity using 'string starts with' not allowed for data points, attempted for $value")
       case StringEndsWith("granularity", value) =>
-        sys.error(
-          s"Choosing granularity using 'string starts with' not allowed for data points, attempted for ${value.toString}")
+        throw new CdfSparkIllegalArgumentException(
+          s"Choosing granularity using 'string starts with' not allowed for data points, attempted for $value")
       case StringContains("granularity", value) =>
-        sys.error(
-          s"Choosing granularity using 'string starts with' not allowed for data points, attempted for ${value.toString}")
+        throw new CdfSparkIllegalArgumentException(
+          s"Choosing granularity using 'string starts with' not allowed for data points, attempted for $value")
       case _ => Seq()
     }
 }

--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -73,7 +73,7 @@ class DefaultSource
           parameters.get("externalId").map(CogniteExternalId(_))
         )
         .getOrElse(
-          sys.error("id or externalId option must be specified.")
+          throw new CdfSparkIllegalArgumentException("id or externalId option must be specified.")
         )
 
     new SequenceRowsRelation(config, sequenceId)(sqlContext)

--- a/src/main/scala/cognite/spark/v1/PushdownUtilities.scala
+++ b/src/main/scala/cognite/spark/v1/PushdownUtilities.scala
@@ -118,7 +118,7 @@ object PushdownUtilities {
     val timestampLimits = filters.flatMap(getTimestampLimit(_, colName))
 
     if (timestampLimits.exists(_.value.isBefore(Instant.ofEpochMilli(0)))) {
-      sys.error("timestamp limits must exceed 1970-01-01T00:00:00Z")
+      throw new CdfSparkIllegalArgumentException("timestamp limits must exceed 1970-01-01T00:00:00Z")
     }
 
     Tuple2(
@@ -149,10 +149,10 @@ object PushdownUtilities {
 
   def getTimestampLimit(filter: Filter, colName: String): Seq[Limit] =
     filter match {
-      case LessThan(colName, value) => Seq(timeStampStringToMax(value, -1))
-      case LessThanOrEqual(colName, value) => Seq(timeStampStringToMax(value, 0))
-      case GreaterThan(colName, value) => Seq(timeStampStringToMin(value, 1))
-      case GreaterThanOrEqual(colName, value) => Seq(timeStampStringToMin(value, 0))
+      case LessThan(`colName`, value) => Seq(timeStampStringToMax(value, -1))
+      case LessThanOrEqual(`colName`, value) => Seq(timeStampStringToMax(value, 0))
+      case GreaterThan(`colName`, value) => Seq(timeStampStringToMin(value, 1))
+      case GreaterThanOrEqual(`colName`, value) => Seq(timeStampStringToMin(value, 0))
       case And(f1, f2) => getTimestampLimit(f1, colName) ++ getTimestampLimit(f2, colName)
       // case Or(f1, f2) => we might possibly want to do something clever with joining an "or" clause
       //                    with timestamp limits on each side (including replacing "max of Min's" with the less strict

--- a/src/main/scala/cognite/spark/v1/RawTableRelation.scala
+++ b/src/main/scala/cognite/spark/v1/RawTableRelation.scala
@@ -146,7 +146,7 @@ class RawTableRelation(
     val timestampLimits = filters.flatMap(getTimestampLimit(_, colName))
 
     if (timestampLimits.exists(_.value.isBefore(Instant.ofEpochMilli(0)))) {
-      sys.error("timestamp limits must exceed 1970-01-01T00:00:00Z")
+      throw new CdfSparkIllegalArgumentException("timestamp limits must exceed 1970-01-01T00:00:00Z")
     }
 
     Tuple2(

--- a/src/test/scala/cognite/spark/v1/DataPointsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/DataPointsRelationTest.scala
@@ -240,6 +240,18 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
     assert(df.count() > 200000)
     assert(df.count() == df.distinct().count())
   }
+  it should "read datapoint with value > 100" taggedAs ReadTest in {
+    val df = spark.read
+      .format("cognite.spark.v1")
+      .option("apiKey", readApiKey)
+      .option("type", "datapoints")
+      .load()
+      .where(
+        s"timestamp >= to_timestamp(1510150000) and timestamp <= to_timestamp(1510358401) and value > 100 and id = $valhallTimeSeriesId")
+      .cache()
+    assert(df.count() > 200000)
+    assert(df.count() == df.distinct().count())
+  }
 
   it should "read data points while respecting limitPerPartition" taggedAs ReadTest in {
     val df = spark.read


### PR DESCRIPTION
Also, changed error messages from sys.error to throwing a
CdfSparkIllegalArgumentException. The problem was that
Transformations displayed it as internal error instead of
showing used the erorr message.