### PR TITLE
Use fs2.Pull for datapoints

### DIFF
--- a/src/main/scala/cognite/spark/v1/NumericDataPointsRdd.scala
+++ b/src/main/scala/cognite/spark/v1/NumericDataPointsRdd.scala
@@ -389,11 +389,12 @@ final case class NumericDataPointsRdd(
         dataPointsRange.id,
         dataPointsRange.start,
         dataPointsRange.end)
-      .map { allDataPoints =>
-        increaseReadMetrics(allDataPoints.length)
+      .stream
+      .mapChunks { allDataPoints =>
+        increaseReadMetrics(allDataPoints.size)
         allDataPoints.map(p => dataPointToRow(dataPointsRange.id, p))
       }
-    Stream.evalUnChunk(points.map(Chunk.seq))
+    points
   }
 
   private val rowIndicesLength = rowIndices.length

--- a/src/main/scala/cognite/spark/v1/StringDataPointsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/StringDataPointsRelation.scala
@@ -104,13 +104,17 @@ class StringDataPointsRelationV1(config: RelationConfig)(override val sqlContext
     val (lowerTimeLimit, upperTimeLimit) = filtersToTimestampLimits(filters, "timestamp")
 
     ids.zip(ids.map { id =>
-      DataPointsRelationV1.getAllDataPoints[StringDataPoint](
-        queryStrings,
-        config.batchSize.getOrElse(Constants.DefaultDataPointsLimit),
-        id,
-        lowerTimeLimit,
-        upperTimeLimit.plusMillis(1),
-        config.limitPerPartition)
+      DataPointsRelationV1
+        .getAllDataPoints[StringDataPoint](
+          queryStrings,
+          config.batchSize.getOrElse(Constants.DefaultDataPointsLimit),
+          id,
+          lowerTimeLimit,
+          upperTimeLimit.plusMillis(1),
+          config.limitPerPartition)
+        .stream
+        .compile
+        .to(Seq)
     })
   }
 


### PR DESCRIPTION
Surprisingly, this scala lalalalala improves performance quite
a bit. What took 102 seconds now takes just 50 (and it's
now limited by my network instead of the CPU).

The problem was that we were appending quite big Seq together, which was pretty slow.
fs2 does lot of things to avoid this, so that's why it's faster.