### PR TITLE
Don't crash on NULL in labels

### DIFF
--- a/src/main/scala/cognite/spark/v1/PushdownUtilities.scala
+++ b/src/main/scala/cognite/spark/v1/PushdownUtilities.scala
@@ -182,7 +182,7 @@ object PushdownUtilities {
       strExternalIds: Option[Seq[String]]): Option[Seq[CogniteExternalId]] =
     strExternalIds match {
       case Some(Seq()) => None
-      case _ => strExternalIds.map(l => l.map(CogniteExternalId(_)))
+      case _ => strExternalIds.map(l => l.filter(_ != null).map(CogniteExternalId(_)))
     }
 
   def externalIdsToContainsAny(externalIds: String): Option[ContainsAny] = {

--- a/src/test/scala/cognite/spark/v1/AssetsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/AssetsRelationTest.scala
@@ -462,7 +462,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecuti
                 |lastUpdatedTime,
                 |0 as rootId,
                 |null as aggregates,
-                |null as labels,
+                |array(cast(null as string)) as labels,
                 |dataSetId
                 |from sourceAssets
                 |limit 100


### PR DESCRIPTION
First I thought about raing some nicer error, but it's easier
to just ignore nulls in the array. It's also more convenient for
some use cases - users sometimes have a label column
in their raw table that is nullable  and then want to do `array(label)` in SQL