### PR TITLE
Limit parallelism on write according to settings

### DIFF
--- a/src/main/scala/cognite/spark/v1/DataPointsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/DataPointsRelation.scala
@@ -46,7 +46,7 @@ abstract class DataPointsRelationV1[A](config: RelationConfig, shortName: String
   }
 
   override def insert(data: DataFrame, overwrite: Boolean): Unit = {
-    val partitions = Math.max(1, config.partitions / config.parallelismPerPartition)
+    val partitions = config.sparkPartitions
     val partitionCols =
       data.schema.fieldNames.filter(f => f.equalsIgnoreCase("id") || f.equalsIgnoreCase("externalId"))
     import org.apache.spark.sql.functions.col

--- a/src/test/scala/cognite/spark/v1/RelationshipsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/RelationshipsRelationTest.scala
@@ -5,6 +5,7 @@ import cognite.spark.v1.SparkSchemaHelper.fromRow
 import com.cognite.sdk.scala.v1.{CogniteExternalId, RelationshipCreate}
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{DataFrame, Row}
+import org.scalatest.prop.TableDrivenPropertyChecks.forAll
 import org.scalatest.{FlatSpec, Inspectors, Matchers}
 
 class RelationshipsRelationTest extends FlatSpec with Matchers with SparkTest with Inspectors {
@@ -147,7 +148,7 @@ class RelationshipsRelationTest extends FlatSpec with Matchers with SparkTest wi
     createResources(externalIdPrefix)
   }
 
-  it should "be able to update a relationship" taggedAs ReadTest in {
+  it should "be able to update a relationship" taggedAs ReadTest in forAll(updateAndUpsert) { updateMode =>
     val externalId = s"relationship-update-${shortRandomString()}"
     writeClient.relationships.create(
       Seq(
@@ -176,7 +177,7 @@ class RelationshipsRelationTest extends FlatSpec with Matchers with SparkTest wi
       .format("cognite.spark.v1")
       .option("type", "relationships")
       .option("apiKey", writeApiKey)
-      .option("onconflict", "update")
+      .option("onconflict", updateMode)
       .option("collectMetrics", "true")
       .save()
 

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -98,7 +98,7 @@ trait SparkTest {
     ).unsafeRunTimed(5.minutes).getOrElse(throw new RuntimeException("Test timed out during retries"))
 
 
-  val updateAndUpsert: TableFor1[String] = Table("mode", "upsert", "update")
+  val updateAndUpsert: TableFor1[String] = Table(heading = "mode", "upsert", "update")
 
   def getDefaultConfig(auth: CdfSparkAuth): RelationConfig =
     RelationConfig(


### PR DESCRIPTION
The only thing limiting number of write requests when
the dataset was large was the RateLimitingBackend's.
However, that's not very strict, and more importantly
scales with the number of Spark partitions. So when the
user had many partitions, we would allow basically
infinitely many parallel requests.

This PR limits the write parallelism in the same way as
we limit read paralelism - capped by config.partitions
(meaning CDF partitions). Also we do a repartition if the
number of Spark partitions is large, compared to CDF
insertion, repartition is fairly cheap and it avoids Jetfire
getting stuck on inserting one large partition, if the
distribution is uneven.