### PR TITLE
Remove RAW deduplication table again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.0.1
+
+## Fixes
+
+* Remove deduplication table for RAW (again, the revert didn't fix our problem).
+
 # 2.0.0
 
 ## Enhancements

--- a/src/main/scala/cognite/spark/v1/RawTableRelation.scala
+++ b/src/main/scala/cognite/spark/v1/RawTableRelation.scala
@@ -117,7 +117,7 @@ class RawTableRelation(
       },
       (r: RawRow) => r.key,
       getStreams(filter),
-      deduplicateRows = true // if false we might end up with 429 when trying to update assets with multiple same request
+      deduplicateRows = false // RAW never returns duplicates since we can't have overlapping filters
     )
   }
 


### PR DESCRIPTION
We tried to add it back to fix the 429 Conflict issue, but
it didn't help, so I'm adding this back.
With the table added back, I'm unable to dump some
RAW tables on my laptop.