### PR TITLE
Support metrics in cdf_dump

### DIFF
--- a/cdf_dump/README.md
+++ b/cdf_dump/README.md
@@ -154,6 +154,8 @@ Options:
                                                  10) and we use exponential backoff. Set to 0 for debugging, to improve
                                                  responsibility.
 
+      --preview  <count>                         When specified, a preview of the loaded data will be printed to standard output.
+                                                 --preview 100 will print the first 100 rows.
   -Skey=value [key=value]...                     Spark config option. You can use any property listed in the Spark Docs:
                                                  https://spark.apache.org/docs/latest/configuration.html#available-properties
   -h, --help                                     Show help message

--- a/cdf_dump/src/main/scala/cognite/spark/cdfdump/MetricsWatcher.scala
+++ b/cdf_dump/src/main/scala/cognite/spark/cdfdump/MetricsWatcher.scala
@@ -1,0 +1,93 @@
+package cognite.spark.cdfdump
+
+import cats.effect.IO
+import com.codahale.metrics.Counting
+import org.apache.spark.datasource.MetricsSource
+import org.log4s.getLogger
+
+import java.time.{Duration, Instant}
+import java.util.Locale
+import scala.concurrent.duration.FiniteDuration
+import scala.math.pow
+
+class MetricsWatcher {
+  private var lastState: Map[String, Long] = Map()
+  private val startTime = Instant.now
+  private var lastTime = startTime
+
+  private def getCurrentValues(): Map[String, Long] =
+    MetricsSource.metricsMap
+      .map { case(k, v) => k.stripPrefix(".") -> v.value }
+      // all metrics are counters currently, but better to check it in case we want to add something later
+      .filter(_._2.isInstanceOf[Counting])
+      .mapValues(_.asInstanceOf[Counting].getCount)
+      .toMap
+
+  def formatNumber(n: Double): String = {
+    // from https://stackoverflow.com/questions/45885151/bytes-in-human-readable-format-with-idiomatic-scala
+    val tera = pow(10, 12)
+    val giga = pow(10, 9)
+    val mega = pow(10, 6)
+    val kilo = pow(10, 3)
+
+    val (value, unit) = {
+      if (n >= tera) {
+        (n / tera, "T")
+      } else if (n >= giga) {
+        (n / giga, "G")
+      } else if (n >= mega) {
+        (n / mega, "M")
+      } else if (n >= kilo) {
+        (n / kilo, "k")
+      } else {
+        (n, "")
+      }
+    }
+    "%.1f%s".formatLocal(Locale.US, value, unit)
+  }
+
+  private def formatMessage(values: Seq[(String, Long)], time: Duration, isIncremental: Boolean): String =
+    values
+      .filter { case (_, v) => v != 0 }
+      .sortBy(-_._2)
+      .map {
+        case (k, v) =>
+          val perSecond = (v.toDouble / time.toMillis * 1000 * 60).toLong
+          val plus = if (isIncremental) "+" else ""
+          s"$k $plus${formatNumber(v)} (${formatNumber(perSecond)}/min)"
+      }.mkString(",       ")
+
+  def createMessage(): String = {
+    val lastState = this.lastState
+    val currentState = this.getCurrentValues()
+    this.lastState = currentState
+
+    val now = Instant.now
+    val time = java.time.Duration.between(this.lastTime, now)
+    this.lastTime = now
+
+    formatMessage(
+      currentState.toVector
+        .map { case (k, v) => k -> (v - lastState.getOrElse(k, 0L)) },
+      time,
+      true
+    )
+  }
+
+  def startLogger(rate: FiniteDuration): Unit = {
+    import cognite.spark.v1.CdpConnector.ioRuntime
+    val logger = getLogger
+    fs2.Stream.repeatEval {
+      IO(logger.info(createMessage()))
+    }
+      .metered(rate)
+      .compile.drain.unsafeRunCancelable()
+  }
+
+
+  /** Returns a message of all metrics including average throughput over the entire runtime */
+  def getFullMessage(): String = {
+    val time = Duration.between(this.startTime, Instant.now)
+    formatMessage(getCurrentValues().toVector, time, false)
+  }
+}

--- a/cdf_dump/src/main/scala/cognite/spark/cdfdump/SparkHelper.scala
+++ b/cdf_dump/src/main/scala/cognite/spark/cdfdump/SparkHelper.scala
@@ -9,8 +9,9 @@ class SparkHelper(
   sparkConfig: Map[String, String],
   writeOptions: Map[String, String],
   readOptions: Map[String, String],
-  outDir: String,
+  outDir: Option[String],
   format: String,
+  show: Option[Int],
   columns: Option[List[String]],
   excludeColumns: List[String],
   filter: Option[String],
@@ -97,11 +98,17 @@ class SparkHelper(
     val df4 = outPartitions.filter(_ => format != "parquet" && format != "orc")
       .fold(df3)(p => df3.repartition(p))
 
-    df4
-      .write
-      .format(format)
-      .options(writeOptions)
-      .save(outDir + "/" + name)
+    show.foreach { limit =>
+      df4.show(limit)
+    }
+
+    outDir.foreach { outDir =>
+      df4
+        .write
+        .format(format)
+        .options(writeOptions)
+        .save(outDir + "/" + name)
+    }
   }
 
 


### PR DESCRIPTION
It also shows throughput which makes it much easier
to compare Spark DS performance across different
RAW tables, for example. Also makes it less frustrating
to wait few minutes when I see that it's crunching
though millions of rows each minute :)

It prints something like this:

```
22/02/25 11:57:22 INFO MetricsWatcher: raw.test.cpu2.rows.read +2.2M (8.7M/min),       requests +364.0 (1.4k/min),       requestsWithoutRetries +336.0 (1.3k/min),       requests.429.response +30.0 (116.0/min)
22/02/25 11:57:37 INFO MetricsWatcher: raw.test.cpu2.rows.read +2.8M (11.0M/min),       requests +278.0 (1.1k/min),       requestsWithoutRetries +267.0 (1.1k/min),       requests.429.response +9.0 (35.0/min)
22/02/25 11:57:52 INFO MetricsWatcher: raw.test.cpu2.rows.read +2.3M (9.3M/min),       requests +234.0 (941.0/min),       requestsWithoutRetries +233.0 (937.0/min),       requests.429.response +1.0 (4.0/min)
22/02/25 11:58:07 INFO MetricsWatcher: raw.test.cpu2.rows.read +2.1M (8.3M/min),       requests +226.0 (898.0/min),       requestsWithoutRetries +222.0 (883.0/min),       requests.429.response +4.0 (15.0/min)
22/02/25 11:58:22 INFO MetricsWatcher: raw.test.cpu2.rows.read +2.0M (7.7M/min),       requests +204.0 (802.0/min),       requestsWithoutRetries +204.0 (802.0/min)

```


I also added `--preview 100` which calls Spark's show function instead of writing to disk