### PR TITLE
Use IO.blocking when dealing with queue in StreamIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,7 @@
 
 ## Fixes
 
-* Use Queue.offer() instead of Queue.put() to avoid block thread in StreamIterator
-
-# 2.0.3
-
-## Enhancements
-
-* Add pushdown filters on data model instances
-
-# 2.0.2
-
-## Enhancements
-
-* Support ingesting and reading data model instances
+* Use IO.blocking to wrap when dealing with queue in StreamIterator
 
 # 2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 2.0.4
+
+## Fixes
+
+* Use Queue.offer() instead of Queue.put() to avoid block thread in StreamIterator
+
+# 2.0.3
+
+## Enhancements
+
+* Add pushdown filters on data model instances
+
+# 2.0.2
+
+## Enhancements
+
+* Support ingesting and reading data model instances
+
 # 2.0.1
 
 ## Fixes

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbtassembly.MergeStrategy
 val scala212 = "2.12.15"
 val scala213 = "2.13.8"
 val supportedScalaVersions = List(scala212, scala213)
-val sparkVersion = "3.2.0"
+val sparkVersion = "3.2.1"
 val circeVersion = "0.14.1"
 val sttpVersion = "3.4.1"
 val Specs2Version = "4.6.0"
@@ -23,7 +23,7 @@ lazy val commonSettings = Seq(
   organization := "com.cognite.spark.datasource",
   organizationName := "Cognite",
   organizationHomepage := Some(url("https://cognite.com")),
-  version := "2.0.3",
+  version := "2.0.4",
   crossScalaVersions := supportedScalaVersions,
   scalaVersion := scala212, // default to Scala 2.12
   description := "Spark data source for the Cognite Data Platform.",

--- a/src/main/scala/cognite/spark/v1/CdpConnector.scala
+++ b/src/main/scala/cognite/spark/v1/CdpConnector.scala
@@ -113,7 +113,7 @@ object CdpConnector {
       retryingSttpBackend(
         config.maxRetries,
         config.maxRetryDelaySeconds,
-        config.partitions,
+        config.parallelismPerPartition,
         metricsPrefix)
     new GenericClient(
       applicationName = config.applicationName.getOrElse(Constants.SparkDatasourceVersion),

--- a/src/main/scala/cognite/spark/v1/StreamIterator.scala
+++ b/src/main/scala/cognite/spark/v1/StreamIterator.scala
@@ -2,8 +2,8 @@ package cognite.spark.v1
 
 import cats.effect.unsafe.IORuntime
 
-import java.util.concurrent.{ArrayBlockingQueue, Executors}
-import cats.effect.{Concurrent, IO}
+import java.util.concurrent.{ArrayBlockingQueue, Executors, TimeUnit}
+import cats.effect.IO
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import fs2.{Chunk, Stream}
 import org.log4s._
@@ -73,7 +73,7 @@ object StreamIterator {
     stream.chunks.parEvalMapUnordered(queueBufferSize) { chunk =>
       IO {
         val processedChunk = processChunk.map(f => f(chunk)).getOrElse(chunk)
-        queue.put(Right(processedChunk))
+        queue.offer(Right(processedChunk), 30, TimeUnit.SECONDS)
       }
     }
 

--- a/src/main/scala/cognite/spark/v1/StreamIterator.scala
+++ b/src/main/scala/cognite/spark/v1/StreamIterator.scala
@@ -36,7 +36,7 @@ object StreamIterator {
     val putOnQueueStream =
       enqueueStreamResults(stream, queue, queueBufferSize, processChunk)
         .handleErrorWith(e =>
-          Stream.eval(IO.blocking(queue.put(Left(e)))) ++ Stream.eval(IO {
+          Stream.eval(IO.blocking(queue.put(Left(e)))) ++ Stream.eval(IO.blocking {
             if (!drainPool.isShutdown) {
               drainPool.shutdownNow()
             }

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -65,8 +65,7 @@ trait SparkTest {
   val spark: SparkSession = SparkSession
     .builder()
     .master("local[*]")
-    .config("spark.ui.enabled", "false") //comment this and use the line below if you need to use Spark UI
-    //.config("spark.ui.port", "4041")
+    .config("spark.ui.enabled", "false") // comment this out to use Spark UI during tests, on https://localhost:4040 by default
     // https://medium.com/@mrpowers/how-to-cut-the-run-time-of-a-spark-sbt-test-suite-by-40-52d71219773f
     .config("spark.sql.shuffle.partitions", "1")
     .config("spark.sql.storeAssignmentPolicy", "legacy")


### PR DESCRIPTION
Spark is hanging because all the Threads `CDF-Spark-compute` is locked. Stack trace from thread dump in the spark UI
```
java.base@11.0.13/jdk.internal.misc.Unsafe.park(Native Method)
java.base@11.0.13/java.util.concurrent.locks.LockSupport.park(LockSupport.java:194)
java.base@11.0.13/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2081)
java.base@11.0.13/java.util.concurrent.ArrayBlockingQueue.put(ArrayBlockingQueue.java:367)
cognite.spark.v1.StreamIterator$.$anonfun$enqueueStreamResults$2(StreamIterator.scala:76)
cognite.spark.v1.StreamIterator$$$Lambda$1560/0x0000000840c22440.apply$mcV$sp(Unknown Source)
app//scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
cognite.shaded.cats.effect.IOFiber.runLoop(IOFiber.scala:283)
cognite.shaded.cats.effect.IOFiber.execR(IOFiber.scala:1327)
cognite.shaded.cats.effect.IOFiber.run(IOFiber.scala:139)
java.base@11.0.13/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
java.base@11.0.13/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
java.base@11.0.13/java.lang.Thread.run(Thread.java:829)
```
Use [IO.blocking](https://typelevel.org/cats-effect/docs/thread-model#blocking) when dealing with queue to move all the blocking task to the pool `CDF-Spark-blocking`
There are 2 minor changes I will comment on to make "the life of reviewer easier" 😁 , don't care about the reformat part
