### PR TITLE
Add support for property Json in FDM

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,7 +33,9 @@ jobs:
       - name: Run tests
         env:
           TEST_API_KEY_WRITE: ${{ secrets.TEST_API_KEY_WRITE }}
-          TEST_API_KEY_READ: ${{ secrets.TEST_API_KEY_READ }}
+          TEST_OIDC_READ_CLIENT_ID: ${{ secrets.TEST_OIDC_READ_CLIENT_ID }}
+          TEST_OIDC_READ_CLIENT_SECRET: ${{ secrets.TEST_OIDC_READ_CLIENT_SECRET }}
+          TEST_OIDC_READ_TENANT: ${{ secrets.TEST_OIDC_READ_TENANT }}
           TEST_CLIENT_ID_BLUEFIELD: ${{ secrets.BLUEFIELD_CLIENT_ID }}
           TEST_CLIENT_SECRET_BLUEFIELD: ${{ secrets.BLUEFIELD_CLIENT_SECRET }}
           TEST_AAD_TENANT_BLUEFIELD: "b86328db-09aa-4f0e-9a03-0136f604d20a"

--- a/README.md
+++ b/README.md
@@ -1279,7 +1279,8 @@ show how to backup assets to a RAW table](docs/assets-raw-backup.py)
 ## Build the project with sbt
 
 The project runs read-only integration tests against the Open Industrial Data project. Navigate to
-https://openindustrialdata.com/ to get an API key and store it in the `TEST_API_KEY_READ` environment variable.
+https://hub.cognite.com/open-industrial-data-211 to get a Client Secret and store it in the `TEST_OIDC_READ_CLIENT_SECRET` environment variable along with
+`TEST_OIDC_READ_CLIENT_ID` and `TEST_OIDC_READ_TENANT`. The value of Client ID and Tenant ID can be found [here](https://hub.cognite.com/open-industrial-data-211/openid-connect-on-open-industrial-data-993)
 
 To run the write integration tests, you'll also need to set the `TEST_API_KEY_WRITE` environment variable to an API key for a project where you have write access.
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ val circeVersion = "0.14.1"
 val sttpVersion = "3.4.1"
 val Specs2Version = "4.6.0"
 val artifactory = "https://cognite.jfrog.io/cognite/"
-val cogniteSdkVersion = "2.4.0"
+val cogniteSdkVersion = "2.4.1"
 
 val prometheusVersion = "0.15.0"
 val log4sVersion = "1.8.2"
@@ -25,7 +25,7 @@ lazy val commonSettings = Seq(
   organization := "com.cognite.spark.datasource",
   organizationName := "Cognite",
   organizationHomepage := Some(url("https://cognite.com")),
-  version := "2.3.0",
+  version := "2.3.1",
   crossScalaVersions := supportedScalaVersions,
   semanticdbEnabled := true,
   semanticdbVersion := scalafixSemanticdb.revision,

--- a/src/main/scala/cognite/spark/v1/DataModelInstancesHelper.scala
+++ b/src/main/scala/cognite/spark/v1/DataModelInstancesHelper.scala
@@ -88,8 +88,7 @@ object DataModelInstancesHelper {
 
   def propertyTypeToSparkType(propertyType: PropertyType[_]): DataType =
     propertyType match {
-      case PropertyType.Text =>
-        DataTypes.StringType
+      case PropertyType.Text => DataTypes.StringType
       case PropertyType.Boolean => DataTypes.BooleanType
       case PropertyType.Numeric | PropertyType.Float64 => DataTypes.DoubleType
       case PropertyType.Float32 => DataTypes.FloatType
@@ -97,6 +96,7 @@ object DataModelInstancesHelper {
       case PropertyType.Int32 => DataTypes.IntegerType
       case PropertyType.Int64 => DataTypes.LongType
       case PropertyType.Bigint => DataTypes.LongType
+      case PropertyType.Json => DataTypes.StringType
       case PropertyType.Date => DataTypes.DateType
       case PropertyType.Timestamp => DataTypes.TimestampType
       case PropertyType.DirectRelation => DataTypes.createArrayType(DataTypes.StringType)
@@ -157,6 +157,12 @@ object DataModelInstancesHelper {
       }
     case a =>
       throw new CdfSparkException(s"$directRelationErr but got $a as the value.")
+  }
+
+  private def toJsonProperty: Any => Option[DataModelProperty[_]] = {
+    case x: String => Some(PropertyType.Json.Property(x))
+    case a =>
+      throw new CdfSparkException(notValidPropertyTypeMessage(a, PropertyType.Json.code, Some("string")))
   }
 
   private def toGeographyProperty: Any => Option[DataModelProperty[_]] = {
@@ -338,10 +344,10 @@ object DataModelInstancesHelper {
       case PropertyType.Text => toStringProperty
       case PropertyType.Date => toDateProperty
       case PropertyType.Timestamp => toTimestampProperty
-      case PropertyType.DirectRelation =>
-        toDirectRelationProperty
+      case PropertyType.DirectRelation => toDirectRelationProperty
       case PropertyType.Geometry => toGeometryProperty
       case PropertyType.Geography => toGeographyProperty
+      case PropertyType.Json => toJsonProperty
       case PropertyType.Array.Text => toStringArrayProperty
       case PropertyType.Array.Float32 => toFloat32ArrayProperty
       case PropertyType.Array.Float64 | PropertyType.Array.Numeric =>

--- a/src/main/scala/cognite/spark/v1/udf/CogniteUdfs.scala
+++ b/src/main/scala/cognite/spark/v1/udf/CogniteUdfs.scala
@@ -66,21 +66,21 @@ object CogniteUdfs {
       implicit ioRuntime: IORuntime): IO[Json] = {
     var res = result
     var i = 0
-    while (res.status.isDefined && res.status.get == "Running" && i < 30) {
+    while (res.status == "Running" && i < 30) {
       Thread.sleep(500)
       i += 1
       res = client
         .functionCalls(functionId)
-        .retrieveById(res.id.get)
+        .retrieveById(res.id)
         .unsafeRunSync()
     }
 
-    if (res.status.isDefined && res.status.get == "Completed") {
+    if (res.status == "Completed") {
       for {
         functionCallResponse <- client
           .functionCalls(functionId)
-          .retrieveResponse(res.id.getOrElse(0L))
-      } yield functionCallResponse.response.getOrElse(Json.fromJsonObject(JsonObject.empty))
+          .retrieveResponse(res.id)
+      } yield functionCallResponse.response
     } else {
       throw new CdfSparkException("CDF function call failed. Call = " + res.toString + ".")
     }

--- a/src/test/scala/cognite/spark/v1/AssetsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/AssetsRelationTest.scala
@@ -13,11 +13,11 @@ import scala.util.control.NonFatal
 
 class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecution with SparkTest {
 
-  val sourceDf = spark.read
-    .format("cognite.spark.v1")
-    .option("apiKey", readApiKey)
+  val sourceDf = dataFrameReaderUsingOidc
+    .option("project", "publicdata")
     .option("type", "assets")
     .load()
+
   sourceDf.createOrReplaceTempView("sourceAssets")
 
   val destinationDf = spark.read
@@ -28,9 +28,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecuti
   destinationDf.createOrReplaceTempView("destinationAssets")
 
   "AssetsRelation" should "read assets" taggedAs ReadTest in {
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "assets")
       .option("limitPerPartition", "1000")
       .option("partitions", "1")
@@ -44,9 +42,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecuti
   }
 
   it should "read assets with a small batchSize" taggedAs ReadTest in {
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "assets")
       .option("batchSize", "1")
       .option("limitPerPartition", "10")
@@ -58,9 +54,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecuti
 
   it should "support pushdown filters on name" taggedAs ReadTest in {
     val metricsPrefix = s"pushdown.assets.name.${shortRandomString()}"
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "assets")
       .option("collectMetrics", "true")
       .option("metricsPrefix", metricsPrefix)
@@ -114,9 +108,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecuti
 
   it should "support pushdown filters with nulls" taggedAs ReadTest in {
     val metricsPrefix = s"pushdown.assets.name.null.${shortRandomString()}"
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "assets")
       .option("collectMetrics", "true")
       .option("metricsPrefix", metricsPrefix)
@@ -132,41 +124,31 @@ class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecuti
 
     // these just should not fail:
 
-    spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    dataFrameReaderUsingOidc
       .option("type", "assets")
       .load()
       .where("name = NULL")
       .collect() shouldBe empty
 
-    spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    dataFrameReaderUsingOidc
       .option("type", "assets")
       .load()
       .where("name = '23-TT-92604B' and name <> NULL")
       .collect() shouldBe empty
 
-    spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    dataFrameReaderUsingOidc
       .option("type", "assets")
       .load()
       .where("createdTime > NULL")
       .collect() shouldBe empty
 
-    spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    dataFrameReaderUsingOidc
       .option("type", "assets")
       .load()
       .where("name in (NULL)")
       .collect() shouldBe empty
 
-    spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    dataFrameReaderUsingOidc
       .option("type", "assets")
       .load()
       .where("name = '23-TT-92604B' or name <> NULL")
@@ -194,9 +176,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecuti
 
   it should "support pushdown filters on dataSetId" taggedAs ReadTest in {
     val metricsPrefix = s"pushdown.assets.dataSetId.${shortRandomString()}"
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "assets")
       .option("collectMetrics", "true")
       .option("metricsPrefix", metricsPrefix)
@@ -213,9 +193,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecuti
 
   it should "not fetch all items if filter on id" taggedAs WriteTest in {
     val metricsPrefix = "pushdown.assets.id"
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "assets")
       .option("collectMetrics", "true")
       .option("metricsPrefix", metricsPrefix)
@@ -231,9 +209,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecuti
 
   it should "not fetch all items if filter on externalId" taggedAs WriteTest in {
     val metricsPrefix = "pushdown.assets.externalId"
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "assets")
       .option("collectMetrics", "true")
       .option("metricsPrefix", metricsPrefix)
@@ -249,9 +225,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecuti
 
   it should "not fetch all items if filter on externalIdPrefix" taggedAs WriteTest in {
     val metricsPrefix = "pushdown.assets.externalIdPrefix"
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "assets")
       .option("collectMetrics", "true")
       .option("metricsPrefix", metricsPrefix)
@@ -266,9 +240,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecuti
   }
 
   it should "support filtering on null" taggedAs ReadTest in {
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "assets")
       .option("limitPerPartition", "1000")
       .option("partitions", "1")
@@ -299,9 +271,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecuti
   }
 
   it should "support option filter assetSubtreeIds" taggedAs ReadTest in {
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "assets")
       .option("limitPerPartition", "1000")
       .option("partitions", "1")
@@ -312,9 +282,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecuti
   }
 
   it should "support option filter assetSubtreeIds with externalId" taggedAs ReadTest in {
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "assets")
       .option("limitPerPartition", "1000")
       .option("partitions", "1")
@@ -325,9 +293,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecuti
   }
 
   it should "support option filter assetSubtreeIds with internal and externalId" taggedAs ReadTest in {
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "assets")
       .option("limitPerPartition", "1000")
       .option("partitions", "1")
@@ -339,9 +305,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecuti
 
   it should "support option filter assetSubtreeIds with pushdown filters" taggedAs ReadTest in {
     val metricsPrefix = s"pushdown.assets.name.${shortRandomString()}"
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "assets")
       .option("collectMetrics", "true")
       .option("metricsPrefix", metricsPrefix)

--- a/src/test/scala/cognite/spark/v1/DataModelInstancesRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/DataModelInstancesRelationTest.scala
@@ -98,7 +98,8 @@ class DataModelInstancesRelationTest
   private val props2 = Map(
     "prop_float" -> DataModelPropertyDefinition(`type` = PropertyType.Float64, nullable = true),
     "prop_bool" -> DataModelPropertyDefinition(`type` = PropertyType.Boolean, nullable = true),
-    "prop_string" -> DataModelPropertyDefinition(`type` = PropertyType.Text, nullable = true)
+    "prop_string" -> DataModelPropertyDefinition(`type` = PropertyType.Text, nullable = true),
+    "prop_json" -> DataModelPropertyDefinition(`type` = PropertyType.Json, nullable = true)
   )
   private val props3 = Map(
     "prop_int32" -> DataModelPropertyDefinition(`type` = PropertyType.Int32, nullable = false),
@@ -319,6 +320,7 @@ class DataModelInstancesRelationTest
                           |select 2.0 as prop_float,
                           |true as prop_bool,
                           |'abc' as prop_string,
+                          |to_json(named_struct("string_val", "toto", "int_val", 1)) as prop_json,
                           |'$randomId' as externalId""".stripMargin),
               )
             }.isFailure
@@ -352,6 +354,8 @@ class DataModelInstancesRelationTest
         //prop_bool and prop_string still have old values
         result.get("prop_bool") shouldBe Some(PropertyType.Boolean.Property(true))
         result.get("prop_string") shouldBe Some(PropertyType.Text.Property("abc"))
+        result.get("prop_json") shouldBe Some(
+          PropertyType.Json.Property("""{"string_val":"toto","int_val":1}"""))
       }
     )
   }
@@ -539,6 +543,7 @@ class DataModelInstancesRelationTest
                           |select 2.1 as prop_float,
                           |false as prop_bool,
                           |'abc' as prop_string,
+                          |to_json(named_struct("string_val", "toto", "int_val", 1)) as prop_json,
                           |'$randomId' as externalId""".stripMargin)
               )
             }.isFailure

--- a/src/test/scala/cognite/spark/v1/DataPointsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/DataPointsRelationTest.scala
@@ -12,7 +12,12 @@ import org.apache.spark.sql.Row
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExecution with SparkTest with BeforeAndAfterAll {
+class DataPointsRelationTest
+    extends FlatSpec
+    with Matchers
+    with ParallelTestExecution
+    with SparkTest
+    with BeforeAndAfterAll {
 
   val valhallTimeSeries = "'pi:195975'"
 
@@ -32,23 +37,47 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
     val bluefieldClient = getBlufieldClient()
     bluefieldClient.timeSeries.deleteByExternalId("emel", true).unsafeRunSync()
     bluefieldClient.timeSeries.deleteByExternalId("emel2", true).unsafeRunSync()
-    bluefieldClient.timeSeries.createOne(TimeSeriesCreate(externalId = Some("emel"), name = Some("emel"), isString = false, isStep = false)).unsafeRunSync()
-    bluefieldClient.dataPoints.insert(id = CogniteExternalId("emel"), Seq(
-      DataPoint(timestamp = Instant.ofEpochMilli(1661990400000L).minusMillis(1), value =0.1),
-      DataPoint(timestamp = Instant.ofEpochMilli(1661990400000L), value = 0.2),
-      DataPoint(timestamp = Instant.ofEpochMilli(1661990400000L).plusMillis(1), value = 0.3),
-      DataPoint(timestamp = Instant.ofEpochMilli(1662076800000L).minusMillis(1), value = 0.4),
-      DataPoint(timestamp = Instant.ofEpochMilli(1662076800000L), value = 0.5),
-      DataPoint(timestamp = Instant.ofEpochMilli(1662076800000L).plusMillis(1), value = 0.6))
-    ).unsafeRunSync()
+    bluefieldClient.timeSeries
+      .createOne(
+        TimeSeriesCreate(
+          externalId = Some("emel"),
+          name = Some("emel"),
+          isString = false,
+          isStep = false))
+      .unsafeRunSync()
+    bluefieldClient.dataPoints
+      .insert(
+        id = CogniteExternalId("emel"),
+        Seq(
+          DataPoint(timestamp = Instant.ofEpochMilli(1661990400000L).minusMillis(1), value = 0.1),
+          DataPoint(timestamp = Instant.ofEpochMilli(1661990400000L), value = 0.2),
+          DataPoint(timestamp = Instant.ofEpochMilli(1661990400000L).plusMillis(1), value = 0.3),
+          DataPoint(timestamp = Instant.ofEpochMilli(1662076800000L).minusMillis(1), value = 0.4),
+          DataPoint(timestamp = Instant.ofEpochMilli(1662076800000L), value = 0.5),
+          DataPoint(timestamp = Instant.ofEpochMilli(1662076800000L).plusMillis(1), value = 0.6)
+        )
+      )
+      .unsafeRunSync()
 
-    bluefieldClient.timeSeries.createOne(TimeSeriesCreate(externalId = Some("emel2"), name = Some("emel2"), isString = false, isStep = false)).unsafeRunSync()
-    bluefieldClient.dataPoints.insert(id = CogniteExternalId("emel2"), Seq(
-      DataPoint(timestamp = Instant.ofEpochMilli(1661990400000L).minusMillis(1), value =0.7),
-      DataPoint(timestamp = Instant.ofEpochMilli(1661990400000L), value = 0.8),
-      DataPoint(timestamp = Instant.ofEpochMilli(1662076800000L), value = 0.9),
-      DataPoint(timestamp = Instant.ofEpochMilli(1662076800000L).plusMillis(1), value = 1.0))
-    ).unsafeRunSync()
+    bluefieldClient.timeSeries
+      .createOne(
+        TimeSeriesCreate(
+          externalId = Some("emel2"),
+          name = Some("emel2"),
+          isString = false,
+          isStep = false))
+      .unsafeRunSync()
+    bluefieldClient.dataPoints
+      .insert(
+        id = CogniteExternalId("emel2"),
+        Seq(
+          DataPoint(timestamp = Instant.ofEpochMilli(1661990400000L).minusMillis(1), value = 0.7),
+          DataPoint(timestamp = Instant.ofEpochMilli(1661990400000L), value = 0.8),
+          DataPoint(timestamp = Instant.ofEpochMilli(1662076800000L), value = 0.9),
+          DataPoint(timestamp = Instant.ofEpochMilli(1662076800000L).plusMillis(1), value = 1.0)
+        )
+      )
+      .unsafeRunSync()
   }
 
   private val bluefieldDestinationDf = spark.read
@@ -64,9 +93,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
   bluefieldDestinationDf.createOrReplaceTempView("destinationDatapointsBluefield")
 
   "DataPointsRelation" should "use our own schema for data points" taggedAs (ReadTest) in {
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .load()
       .where(s"id = $valhallTimeSeriesId")
@@ -84,9 +111,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
 
   it should "throw an error when no id/externalId filter is provided" taggedAs ReadTest in {
     val thrown = the[CdfSparkIllegalArgumentException] thrownBy {
-      spark.read
-        .format("cognite.spark.v1")
-        .option("apiKey", readApiKey)
+      dataFrameReaderUsingOidc
         .option("type", "datapoints")
         .load()
         .show()
@@ -97,9 +122,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
   }
 
   it should "test that start/stop time are handled correctly for data points" taggedAs (ReadTest) in {
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .load()
       .where(
@@ -108,33 +131,25 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
   }
 
   it should "support aggregations" taggedAs (ReadTest) in {
-    val df1 = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df1 = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .load()
       .where(s"aggregation = 'stepInterpolation' and granularity = '1d' and id = $valhallTimeSeriesId")
 
     assert(df1.count() > 10)
-    val df1Partitions = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df1Partitions = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .load()
       .where(
         s"timestamp >= to_timestamp(1509490000) and timestamp <= to_timestamp(1510358400) and aggregation = 'max' and granularity = '1d' and id = $valhallTimeSeriesId")
     assert(df1Partitions.count() == 11)
-    val df2 = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df2 = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .load()
       .where(
         s"timestamp >= to_timestamp(1520035200) and timestamp <= to_timestamp(1561507200) and aggregation = 'average' and granularity = '60d' and id = $valhallTimeSeriesId")
     assert(df2.count() == 8)
-    val df3 = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df3 = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .load()
       .sort("timestamp")
@@ -146,9 +161,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
   }
 
   it should "shift non-aligned aggregates to correct timestamps" taggedAs ReadTest in {
-    val df1 = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df1 = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .load()
       .sort("timestamp")
@@ -157,9 +170,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
     val results1 = df1.collect()
     assert(results1.length == 11)
     assert(results1(0).getTimestamp(2).getTime == 1509494400000L)
-    val df2 = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df2 = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .load()
       .sort("timestamp")
@@ -172,9 +183,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
 
   it should "be possible to specify multiple aggregation types in one query" taggedAs (ReadTest) in {
     val metricsPrefix = s"multi.aggregation.${shortRandomString()}"
-    val results = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val results = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .option("collectMetrics", "true")
       .option("metricsPrefix", metricsPrefix)
@@ -199,9 +208,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
   }
 
   it should "be an error to specify an aggregation without specifying a granularity" taggedAs (ReadTest) in {
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .load()
       .where(
@@ -213,9 +220,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
   }
 
   it should "be an error to specify a granularity without specifying an aggregation" taggedAs (ReadTest) in {
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .load()
       .where(
@@ -228,9 +233,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
 
   it should "be an error to specify an invalid granularity" taggedAs (ReadTest) in {
     for (granularity <- Seq("30", "dd", "d30", "1", "0", "1.2d", "1.4y", "1.4seconds")) {
-      val df = spark.read
-        .format("cognite.spark.v1")
-        .option("apiKey", readApiKey)
+      val df = dataFrameReaderUsingOidc
         .option("type", "datapoints")
         .load()
         .where(
@@ -256,9 +259,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
         "13day",
         "7m",
         "7minute")) {
-      val df = spark.read
-        .format("cognite.spark.v1")
-        .option("apiKey", readApiKey)
+      val df = dataFrameReaderUsingOidc
         .option("type", "datapoints")
         .load()
         .where(
@@ -268,9 +269,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
   }
 
   it should "accept all aggregation options" in {
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .load()
       .where(s"timestamp > to_timestamp(0) and timestamp <= to_timestamp(1510358400) and " +
@@ -280,9 +279,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
   }
 
   it should "read data points without duplicates" taggedAs ReadTest in {
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .load()
       .where(
@@ -292,9 +289,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
     assert(df.count() == df.distinct().count())
   }
   it should "read datapoint with value > 100" taggedAs ReadTest in {
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .load()
       .where(
@@ -305,9 +300,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
   }
 
   it should "read data points while respecting limitPerPartition" taggedAs ReadTest in {
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .option("limitPerPartition", "1000")
       .load()
@@ -318,26 +311,20 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
   }
 
   it should "read very many aggregates correctly and without duplicates" taggedAs ReadTest in {
-    val emptyDf = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val emptyDf = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .load()
       .where(
         s"timestamp >= to_timestamp(1510358400) and timestamp <= to_timestamp(1510358400) and aggregation in ('max') and granularity = '1s' and id = $valhallTimeSeriesId")
     assert(emptyDf.count() == 0)
-    val oneDf = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val oneDf = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .load()
       .where(
         s"timestamp >= to_timestamp(1510358400) and timestamp < to_timestamp(1510358401) and aggregation in ('max') and granularity = '1s' and id = $valhallTimeSeriesId")
     assert(oneDf.count() == 1)
 
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .load()
       .where(
@@ -348,9 +335,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
 
   it should "handle missing aggregates" taggedAs ReadTest in {
     val metricsPrefix = s"missing.aggregates.${shortRandomString()}"
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .option("collectMetrics", "true")
       .option("metricsPrefix", metricsPrefix)
@@ -368,9 +353,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
     val testUnit = s"test ${shortRandomString()}"
     val tsName = s"datapoints-insert-${shortRandomString()}"
 
-    val sourceTimeSeriesDf = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val sourceTimeSeriesDf = dataFrameReaderUsingOidc
       .option("type", "timeseries")
       .load()
     sourceTimeSeriesDf.createOrReplaceTempView("sourceTimeSeries")
@@ -478,9 +461,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
     val testUnit = s"last testing ${shortRandomString()}"
     val tsName = s"lastpoint${shortRandomString()}"
 
-    val sourceTimeSeriesDf = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val sourceTimeSeriesDf = dataFrameReaderUsingOidc
       .option("type", "timeseries")
       .load()
     sourceTimeSeriesDf.createOrReplaceTempView("sourceTimeSeries")
@@ -959,9 +940,7 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
   }
 
   it should "fail reasonably when TS is string" in {
-    val destinationDf = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val destinationDf = dataFrameReaderUsingOidc
       .option("type", "datapoints")
       .load()
     destinationDf.createOrReplaceTempView("destinationStringDatapoints")
@@ -1099,16 +1078,14 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
   }
 
   it should "list datapoints in a day with inclusive start and exclusive end limits" taggedAs (ReadTest) in {
-    val res = spark.sql(
-      """SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
+    val res = spark.sql("""SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
         |WHERE dp.externalId == 'emel' AND
         |dp.timestamp >= TO_TIMESTAMP('2022-09-01T00:00:00Z') AND
         |dp.timestamp < TO_TIMESTAMP('2022-09-02T00:00:00Z')""".stripMargin).collect()
     res.length shouldBe 3
     res.map(row => row.getDouble(1)).toSet shouldBe Set(0.2, 0.3, 0.4)
 
-    val res2 = spark.sql(
-      """SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
+    val res2 = spark.sql("""SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
         |WHERE dp.externalId == 'emel2' AND
         |dp.timestamp >= TO_TIMESTAMP('2022-09-01T00:00:00Z') AND
         |dp.timestamp < TO_TIMESTAMP('2022-09-02T00:00:00Z')""".stripMargin).collect()
@@ -1117,16 +1094,14 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
   }
 
   it should "list datapoints in a day with exclusive start and inclusive end limits" taggedAs (ReadTest) in {
-    val res3 = spark.sql(
-      """SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
+    val res3 = spark.sql("""SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
         |WHERE dp.externalId == 'emel' AND
         |dp.timestamp > TO_TIMESTAMP('2022-09-01T00:00:00Z') AND
         |dp.timestamp <= TO_TIMESTAMP('2022-09-02T00:00:00Z')""".stripMargin).collect()
     res3.length shouldBe 3
     res3.map(row => row.getDouble(1)).toSet shouldBe Set(0.3, 0.4, 0.5)
 
-    val res4 = spark.sql(
-      """SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
+    val res4 = spark.sql("""SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
         |WHERE dp.externalId == 'emel2' AND
         |dp.timestamp > TO_TIMESTAMP('2022-09-01T00:00:00Z') AND
         |dp.timestamp <= TO_TIMESTAMP('2022-09-02T00:00:00Z')""".stripMargin).collect()
@@ -1135,16 +1110,14 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
   }
 
   it should "list datapoints in a day with exclusive start and exclusive end limits" taggedAs (ReadTest) in {
-    val res5 = spark.sql(
-      """SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
+    val res5 = spark.sql("""SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
         |WHERE dp.externalId == 'emel' AND
         |dp.timestamp > TO_TIMESTAMP('2022-09-01T00:00:00Z') AND
         |dp.timestamp < TO_TIMESTAMP('2022-09-02T00:00:00Z')""".stripMargin).collect()
     res5.length shouldBe 2
     res5.map(row => row.getDouble(1)).toSet shouldBe Set(0.3, 0.4)
 
-    val res6 = spark.sql(
-      """SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
+    val res6 = spark.sql("""SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
         |WHERE dp.externalId == 'emel2' AND
         |dp.timestamp > TO_TIMESTAMP('2022-09-01T00:00:00Z') AND
         |dp.timestamp < TO_TIMESTAMP('2022-09-02T00:00:00Z')""".stripMargin).collect()
@@ -1152,56 +1125,48 @@ class DataPointsRelationTest extends FlatSpec with Matchers with ParallelTestExe
   }
 
   it should "list datapoints only with start limit" taggedAs (ReadTest) in {
-    val res7 = spark.sql(
-      """SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
+    val res7 = spark.sql("""SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
         |WHERE dp.externalId == 'emel' AND
         |dp.timestamp > TO_TIMESTAMP('2022-09-01T00:00:00Z')""".stripMargin).collect()
     res7.length shouldBe 4
     res7.map(row => row.getDouble(1)).toSet shouldBe Set(0.3, 0.4, 0.5, 0.6)
 
-    val res8 = spark.sql(
-      """SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
+    val res8 = spark.sql("""SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
         |WHERE dp.externalId == 'emel2' AND
         |dp.timestamp > TO_TIMESTAMP('2022-09-01T00:00:00Z')""".stripMargin).collect()
     res8.length shouldBe 2
 
-    val res9 = spark.sql(
-      """SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
+    val res9 = spark.sql("""SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
         |WHERE dp.externalId == 'emel' AND
         |dp.timestamp >= TO_TIMESTAMP('2022-09-01T00:00:00Z')""".stripMargin).collect()
     res9.length shouldBe 5
     res9.map(row => row.getDouble(1)).toSet shouldBe Set(0.2, 0.3, 0.4, 0.5, 0.6)
 
-    val res10 = spark.sql(
-      """SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
+    val res10 = spark.sql("""SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
         |WHERE dp.externalId == 'emel2' AND
         |dp.timestamp >= TO_TIMESTAMP('2022-09-01T00:00:00Z')""".stripMargin).collect()
     res10.length shouldBe 3
   }
 
   it should "list datapoints only with end limit" taggedAs (ReadTest) in {
-    val res11 = spark.sql(
-      """SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
+    val res11 = spark.sql("""SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
         |WHERE dp.externalId == 'emel' AND
         |dp.timestamp < TO_TIMESTAMP('2022-09-02T00:00:00Z')""".stripMargin).collect()
     res11.length shouldBe 4
     res11.map(row => row.getDouble(1)).toSet shouldBe Set(0.1, 0.2, 0.3, 0.4)
 
-    val res12 = spark.sql(
-      """SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
+    val res12 = spark.sql("""SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
         |WHERE dp.externalId == 'emel2' AND
         |dp.timestamp < TO_TIMESTAMP('2022-09-02T00:00:00Z')""".stripMargin).collect()
     res12.length shouldBe 2
 
-    val res13 = spark.sql(
-      """SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
+    val res13 = spark.sql("""SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
         |WHERE dp.externalId == 'emel' AND
         |dp.timestamp <= TO_TIMESTAMP('2022-09-02T00:00:00Z')""".stripMargin).collect()
     res13.length shouldBe 5
     res13.map(row => row.getDouble(1)).toSet shouldBe Set(0.1, 0.2, 0.3, 0.4, 0.5)
 
-    val res14 = spark.sql(
-      """SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
+    val res14 = spark.sql("""SELECT dp.timestamp, dp.value FROM destinationDatapointsBluefield dp
         |WHERE dp.externalId == 'emel2' AND
         |dp.timestamp <= TO_TIMESTAMP('2022-09-02T00:00:00Z')""".stripMargin).collect()
     res14.length shouldBe 3

--- a/src/test/scala/cognite/spark/v1/FilesRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/FilesRelationTest.scala
@@ -8,9 +8,7 @@ import org.scalatest.{FlatSpec, Matchers, ParallelTestExecution}
 import scala.util.control.NonFatal
 
 class FilesRelationTest extends FlatSpec with Matchers with ParallelTestExecution with SparkTest {
-  val sourceDf = spark.read
-    .format("cognite.spark.v1")
-    .option("apiKey", readApiKey)
+  val sourceDf = dataFrameReaderUsingOidc
     .option("type", "files")
     .load()
 
@@ -32,9 +30,7 @@ class FilesRelationTest extends FlatSpec with Matchers with ParallelTestExecutio
   }
 
   it should "respect the limit option" taggedAs ReadTest in {
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "files")
       .option("limitPerPartition", "5")
       .option("partitions", "1")
@@ -44,9 +40,7 @@ class FilesRelationTest extends FlatSpec with Matchers with ParallelTestExecutio
   }
 
   it should "use cursors when necessary" taggedAs ReadTest in {
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "files")
       .option("batchSize", "2")
       .load()

--- a/src/test/scala/cognite/spark/v1/FunctionsUDFTest.scala
+++ b/src/test/scala/cognite/spark/v1/FunctionsUDFTest.scala
@@ -8,15 +8,18 @@ import org.apache.spark.sql.Row
 import org.scalatest.{FlatSpec, Inspectors, Matchers, ParallelTestExecution}
 import sttp.client3.SttpBackend
 
-
-class FunctionsUDFTest extends FlatSpec with Matchers with ParallelTestExecution with SparkTest with Inspectors {
+class FunctionsUDFTest
+    extends FlatSpec
+    with Matchers
+    with ParallelTestExecution
+    with SparkTest
+    with Inspectors {
   import CdpConnector.ioRuntime
 
   ignore should "read assets with functionUDF" taggedAs ReadTest in {
-    implicit val backend: SttpBackend[IO, Any] = CdpConnector.retryingSttpBackend(DefaultMaxRetries, DefaultMaxRetryDelaySeconds)
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    implicit val backend: SttpBackend[IO, Any] =
+      CdpConnector.retryingSttpBackend(DefaultMaxRetries, DefaultMaxRetryDelaySeconds)
+    val df = dataFrameReaderUsingOidc
       .option("type", "assets")
       .option("limitPerPartition", "1")
       .option("partitions", "1")
@@ -35,13 +38,14 @@ class FunctionsUDFTest extends FlatSpec with Matchers with ParallelTestExecution
     } yield functions.items.head
     val functionId = func.unsafeRunSync().id.get
 
-
     df.createOrReplaceTempView("assetsRead")
     val res: Array[Row] = spark
       .sql(s"""select cdf_function($functionId, \"{}\") as functionResult from assetsRead""")
       .collect()
 
-    forAll (res) { row: Row => row.getString(0) shouldEqual "42" }
+    forAll(res) { row: Row =>
+      row.getString(0) shouldEqual "42"
+    }
 
     assert(res.length == 1)
   }

--- a/src/test/scala/cognite/spark/v1/SdkV1RddTest.scala
+++ b/src/test/scala/cognite/spark/v1/SdkV1RddTest.scala
@@ -30,10 +30,12 @@ class SdkV1RddTest extends FlatSpec with Matchers with ParallelTestExecution wit
     val toRow = (_: String, _: Option[Int]) => Row.empty
     val uniqueId = (_: String) => "1"
 
+    implicit val backend: SttpBackend[IO, Any] = CdpConnector.retryingSttpBackend(3, 5)
+
     val sdkRdd =
       SdkV1Rdd[String, String](
         spark.sparkContext,
-        getDefaultConfig(CdfSparkAuth.Static(readApiKeyAuth)),
+        getDefaultConfig(CdfSparkAuth.OAuth2ClientCredentials(readOidcCredentials)),
         toRow,
         uniqueId,
         getStreams)

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -172,7 +172,7 @@ trait SparkTest {
       auth,
       Some("SparkDatasourceTestTag"),
       Some("SparkDatasourceTestApp"),
-      DefaultSource.getProjectFromAuth(auth)(
+      DefaultSource.getProjectFromAuth(auth, Constants.DefaultBaseUrl)(
         CdpConnector
           .retryingSttpBackend(Constants.DefaultMaxRetries, Constants.DefaultMaxRetryDelaySeconds)),
       Some(Constants.DefaultBatchSize),

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -51,7 +51,7 @@ trait SparkTest {
     "Environment variable \"TEST_API_KEY_READ\" was not set")
   implicit val readApiKeyAuth: ApiKeyAuth = ApiKeyAuth(readApiKey)
   val readClient: GenericClient[Id] =
-    GenericClient.forAuth[Id]("cdp-spark-datasource-test", readApiKeyAuth)
+    GenericClient.forAuth[Id]("cdp-spark-datasource-test", writeApiKeyAuth)
 
   // not needed to run tests, only for replicating some problems specific to this tenant
   lazy val jetfiretest2ApiKey = System.getenv("TEST_APU_KEY_JETFIRETEST2")

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -172,7 +172,7 @@ trait SparkTest {
       auth,
       Some("SparkDatasourceTestTag"),
       Some("SparkDatasourceTestApp"),
-      DefaultSource.getProjectFromAuth(auth, Constants.DefaultBaseUrl)(
+      DefaultSource.getProjectFromAuth(auth)(
         CdpConnector
           .retryingSttpBackend(Constants.DefaultMaxRetries, Constants.DefaultMaxRetryDelaySeconds)),
       Some(Constants.DefaultBatchSize),

--- a/src/test/scala/cognite/spark/v1/TimeSeriesRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/TimeSeriesRelationTest.scala
@@ -18,9 +18,7 @@ class TimeSeriesRelationTest
     with OptionValues {
   import spark.implicits._
 
-  val sourceDf = spark.read
-    .format("cognite.spark.v1")
-    .option("apiKey", readApiKey)
+  val sourceDf = dataFrameReaderUsingOidc
     .option("type", "timeseries")
     .load()
   sourceDf.createOrReplaceTempView("sourceTimeSeries")
@@ -33,9 +31,7 @@ class TimeSeriesRelationTest
   destinationDf.createOrReplaceTempView("destinationTimeSeries")
 
   "TimeSeriesRelation" should "read all data regardless of the number of partitions" taggedAs ReadTest in {
-    val dfreader = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val dfreader = dataFrameReaderUsingOidc
       .option("type", "timeseries")
     val singlePartitionCount = dfreader.option("partitions", 1).load().count()
     assert(singlePartitionCount > 0)
@@ -47,9 +43,7 @@ class TimeSeriesRelationTest
 
   it should "handle pushdown filters on assetId with multiple assetIds" taggedAs ReadTest in {
     val metricsPrefix = "pushdown.filters.assetIds"
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "timeseries")
       .option("collectMetrics", "true")
       .option("metricsPrefix", metricsPrefix)
@@ -64,9 +58,7 @@ class TimeSeriesRelationTest
 
   it should "handle pushdown filters on assetId, dataSetId" taggedAs WriteTest in {
     val metricsPrefix = "pushdown.filters.dataSetId"
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "timeseries")
       .option("collectMetrics", "true")
       .option("metricsPrefix", metricsPrefix)
@@ -82,9 +74,7 @@ class TimeSeriesRelationTest
 
   it should "handle pushdown filters on assetId on nonexisting assetId" taggedAs ReadTest in {
     val metricsPrefix = "pushdown.filters.assetIds.nonexisting"
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "timeseries")
       .option("collectMetrics", "true")
       .option("metricsPrefix", metricsPrefix)
@@ -98,9 +88,7 @@ class TimeSeriesRelationTest
 
   it should "not fetch all items if filter on id" taggedAs WriteTest in {
     val metricsPrefix = "pushdown.timeSeries.id"
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "timeseries")
       .option("collectMetrics", "true")
       .option("metricsPrefix", metricsPrefix)
@@ -116,9 +104,7 @@ class TimeSeriesRelationTest
 
   it should "not fetch all items if filter on externalId" taggedAs WriteTest in {
     val metricsPrefix = "pushdown.timeSeries.externalId"
-    val df = spark.read
-      .format("cognite.spark.v1")
-      .option("apiKey", readApiKey)
+    val df = dataFrameReaderUsingOidc
       .option("type", "timeseries")
       .option("collectMetrics", "true")
       .option("metricsPrefix", metricsPrefix)


### PR DESCRIPTION
CDF-17129


Test is added in https://github.com/cognitedata/cognite-sdk-scala/pull/577 but we don't need a new version of SDK since we keep treating Json as a String anyway.
Also doing migration to use OIDC instead of READ_API_KEY for public data.
More ref from https://hub.cognite.com/open-industrial-data-211/openid-connect-on-open-industrial-data-993