### PR TITLE
Remove first row schema based nullability check

### DIFF
--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelRelationUtils.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelRelationUtils.scala
@@ -267,23 +267,9 @@ object FlexibleDataModelRelationUtils {
     val (nullablePropsMissingInSchema @ _, nonNullablePropsMissingInSchema) =
       propsMissingInSchema.partition { case (_, prop) => prop.nullable.getOrElse(true) }
 
-    val (falselyNullableFieldsInSchema, trulyNullableOrNonNullableFieldsInSchema @ _) =
-      propsExistsInSchema.partition {
-        case (propName, prop) => (prop.nullable contains false) && schema(propName).nullable
-      }
-
     if (nonNullablePropsMissingInSchema.nonEmpty) {
       val propsAsStr = nonNullablePropsMissingInSchema.keys.mkString(", ")
       Left(new CdfSparkException(s"Could not find required properties: [$propsAsStr]"))
-    } else if (falselyNullableFieldsInSchema.nonEmpty) {
-      val propsAsStr = falselyNullableFieldsInSchema.keys.mkString(", ")
-      Left(
-        new CdfSparkException(
-          s"""Properties [$propsAsStr] cannot contain null values
-             |Please verify your data!
-             |""".stripMargin
-        )
-      )
     } else {
       Right(true)
     }

--- a/src/test/scala/cognite/spark/v1/FlexibleDataModelRelationUtilsTest.scala
+++ b/src/test/scala/cognite/spark/v1/FlexibleDataModelRelationUtilsTest.scala
@@ -113,30 +113,6 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
     verifyErrorMessage(result, "Could not find required properties")
   }
 
-  it should "fail to create nodes when required a property is nullable" in {
-    val propertyMap = Map(
-      "stringProp" ->
-        TextPropertyNonListWithDefaultValueNonNullable,
-      "intProp" ->
-        Int32NonListWithoutAutoIncrementWithDefaultValueNullable
-    )
-    val schema =
-      StructType(
-        Array(
-          StructField("externalId", StringType, nullable = false),
-          StructField("stringProp", StringType, nullable = true),
-          StructField("intProp", IntegerType, nullable = true)
-        )
-      )
-
-    val values =
-      Seq[Array[Any]](Array("extId1", "stringProp1", 1), Array("extId2", "stringProp2", null))
-    val rows = values.map(r => new GenericRowWithSchema(r, schema))
-
-    val result = createNodes("instanceSpaceExternalId1", rows, schema, propertyMap, destRef)
-    verifyErrorMessage(result, "cannot contain null values")
-  }
-
   it should "successfully create nodes with all nullable/non-nullable properties" in {
     val propertyMap = Map(
       "stringProp" ->


### PR DESCRIPTION
- Checking nullability of `Row` fields based on the first `Row` schema seems to be not working in e2e tests
- This works fine in integrations tests

<img width="508" alt="Screenshot 2023-02-07 at 19 51 04" src="https://user-images.githubusercontent.com/1578747/217338452-a38c3c93-cfe0-42fc-b38b-ab3c741fb262.png">


The error `Property [Name] cannot contain null values` is not correct.
That data column is `null` free
