### PR TITLE
Bump scala-sdk to 2.5.6-SNAPSHOT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ val circeVersion = "0.14.1"
 val sttpVersion = "3.5.2"
 val Specs2Version = "4.6.0"
 val artifactory = "https://cognite.jfrog.io/cognite/"
-val cogniteSdkVersion = "2.5.3-SNAPSHOT"
+val cogniteSdkVersion = "2.5.6-SNAPSHOT"
 
 val prometheusVersion = "0.15.0"
 val log4sVersion = "1.8.2"

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelRelationUtils.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelRelationUtils.scala
@@ -97,12 +97,13 @@ object FlexibleDataModelRelationUtils {
           externalId = extId,
           startNode = startNode,
           endNode = endNode,
-          sources = Seq(
-            EdgeOrNodeData(
-              source = source,
-              properties = Some(props.toMap)
-            )
-          )
+          sources = Some(
+            Seq(
+              EdgeOrNodeData(
+                source = source,
+                properties = Some(props.toMap)
+              )
+            ))
         )
     }
 
@@ -125,12 +126,13 @@ object FlexibleDataModelRelationUtils {
             externalId = externalId,
             startNode = startNode,
             endNode = endNode,
-            sources = Seq(
-              EdgeOrNodeData(
-                source = source,
-                properties = Some(props.toMap)
-              )
-            )
+            sources = Some(
+              Seq(
+                EdgeOrNodeData(
+                  source = source,
+                  properties = Some(props.toMap)
+                )
+              ))
           )
         )
       case (None, None, None) =>
@@ -138,12 +140,13 @@ object FlexibleDataModelRelationUtils {
           NodeWrite(
             space = instanceSpaceExternalId,
             externalId = externalId,
-            sources = Seq(
-              EdgeOrNodeData(
-                source = source,
-                properties = Some(props.toMap)
-              )
-            )
+            sources = Some(
+              Seq(
+                EdgeOrNodeData(
+                  source = source,
+                  properties = Some(props.toMap)
+                )
+              ))
           )
         )
       case _ =>
@@ -174,12 +177,13 @@ object FlexibleDataModelRelationUtils {
         NodeWrite(
           space = instanceSpaceExternalId,
           externalId = externalId,
-          sources = Seq(
-            EdgeOrNodeData(
-              source = source,
-              properties = Some(props.toMap)
-            )
-          )
+          sources = Some(
+            Seq(
+              EdgeOrNodeData(
+                source = source,
+                properties = Some(props.toMap)
+              )
+            ))
         )
     }
 

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelsRelation.scala
@@ -5,7 +5,7 @@ import cats.implicits._
 import cognite.spark.v1.FlexibleDataModelRelationUtils.{createEdges, createNodes, createNodesOrEdges}
 import cognite.spark.v1.FlexibleDataModelsRelation._
 import com.cognite.sdk.scala.v1.GenericClient
-import com.cognite.sdk.scala.v1.fdm.common.Usage
+import com.cognite.sdk.scala.v1.fdm.common.{DataModelReference, Usage}
 import com.cognite.sdk.scala.v1.fdm.common.filters.FilterValueDefinition.{
   ComparableFilterValue,
   SeqFilterValue
@@ -20,7 +20,7 @@ import com.cognite.sdk.scala.v1.fdm.instances.InstanceDeletionRequest.{
   NodeDeletionRequest
 }
 import com.cognite.sdk.scala.v1.fdm.instances._
-import com.cognite.sdk.scala.v1.fdm.views.{DataModelReference, ViewDefinition}
+import com.cognite.sdk.scala.v1.fdm.views.ViewDefinition
 import fs2.Stream
 import io.circe.{Decoder, Json}
 import org.apache.spark.rdd.RDD
@@ -110,7 +110,7 @@ class FlexibleDataModelsRelation(
     : IO[Option[(ViewDefinition, Map[String, ViewPropertyDefinition], StructType)]] =
     client.views
       .retrieveItems(
-        Seq(DataModelReference(viewSpaceExternalId, viewExternalId, viewVersion)),
+        Seq(DataModelReference(viewSpaceExternalId, viewExternalId, Some(viewVersion))),
         includeInheritedProperties = Some(true))
       .map(_.headOption)
       .flatMap {
@@ -127,7 +127,7 @@ class FlexibleDataModelsRelation(
             } else {
               client.views
                 .retrieveItems(v.map(vRef =>
-                  DataModelReference(vRef.space, vRef.externalId, vRef.version)))
+                  DataModelReference(vRef.space, vRef.externalId, Some(vRef.version))))
                 .map { inheritingViews =>
                   // If there are properties with the same name,
                   // most recent view's property will override the old view's property.

--- a/src/test/scala/cognite/spark/v1/FlexibleDataModelsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/FlexibleDataModelsRelationTest.scala
@@ -11,7 +11,7 @@ import com.cognite.sdk.scala.v1.fdm.common.properties.PropertyDefinition.{
 }
 import com.cognite.sdk.scala.v1.fdm.common.properties.PropertyType.DirectNodeRelationProperty
 import com.cognite.sdk.scala.v1.fdm.common.properties.{PrimitivePropType, PropertyType}
-import com.cognite.sdk.scala.v1.fdm.common.{DirectRelationReference, Usage}
+import com.cognite.sdk.scala.v1.fdm.common.{DataModelReference, DirectRelationReference, Usage}
 import com.cognite.sdk.scala.v1.fdm.containers.{
   ContainerCreateDefinition,
   ContainerDefinition,
@@ -573,12 +573,12 @@ class FlexibleDataModelsRelationTest extends FlatSpec with Matchers with SparkTe
 
     client.views
       .deleteItems(Seq(
-        DataModelReference(spaceExternalId, viewAllListAndNonListExternalId, viewVersion),
-        DataModelReference(spaceExternalId, viewNodesListAndNonListExternalId, viewVersion),
-        DataModelReference(spaceExternalId, viewEdgesListAndNonListExternalId, viewVersion),
-        DataModelReference(spaceExternalId, viewAllNumericProps, viewVersion),
-        DataModelReference(spaceExternalId, viewFilterByProps, viewVersion),
-        DataModelReference(spaceExternalId, viewStartNodeAndEndNodesExternalId, viewVersion),
+        DataModelReference(spaceExternalId, viewAllListAndNonListExternalId, Some(viewVersion)),
+        DataModelReference(spaceExternalId, viewNodesListAndNonListExternalId, Some(viewVersion)),
+        DataModelReference(spaceExternalId, viewEdgesListAndNonListExternalId, Some(viewVersion)),
+        DataModelReference(spaceExternalId, viewAllNumericProps, Some(viewVersion)),
+        DataModelReference(spaceExternalId, viewFilterByProps, Some(viewVersion)),
+        DataModelReference(spaceExternalId, viewStartNodeAndEndNodesExternalId, Some(viewVersion)),
       ))
       .unsafeRunSync()
 
@@ -815,13 +815,13 @@ class FlexibleDataModelsRelationTest extends FlatSpec with Matchers with SparkTe
         externalId = s"${edgeExternalIdPrefix}1",
         startNode = startNode,
         endNode = endNode,
-        Seq(
+        Some(Seq(
           EdgeOrNodeData(
             viewRef,
             Some(viewDef.properties.collect { case (n, p: ViewCorePropertyDefinition) => n -> p }.map {
               case (n, p) => n -> createInstancePropertyValue(n, p.`type`, directNodeReference)
             })
-          ))
+          )))
       ),
       EdgeWrite(
         `type` =
@@ -830,13 +830,13 @@ class FlexibleDataModelsRelationTest extends FlatSpec with Matchers with SparkTe
         externalId = s"${edgeExternalIdPrefix}2",
         startNode = startNode,
         endNode = endNode,
-        Seq(
+        Some(Seq(
           EdgeOrNodeData(
             viewRef,
             Some(viewDef.properties.collect { case (n, p: ViewCorePropertyDefinition) => n -> p }.map {
               case (n, p) => n -> createInstancePropertyValue(n, p.`type`, directNodeReference)
             })
-          ))
+          )))
       )
     )
   }
@@ -850,24 +850,24 @@ class FlexibleDataModelsRelationTest extends FlatSpec with Matchers with SparkTe
       NodeWrite(
         spaceExternalId,
         s"${viewDef.externalId}${randomPrefix}Node1",
-        Seq(
+        Some(Seq(
           EdgeOrNodeData(
             viewRef,
             Some(viewDef.properties.collect { case (n, p: ViewCorePropertyDefinition) => n -> p }.map {
               case (n, p) => n -> createInstancePropertyValue(n, p.`type`, directNodeReference)
             })
-          ))
+          )))
       ),
       NodeWrite(
         spaceExternalId,
         s"${viewDef.externalId}${randomPrefix}Node2",
-        Seq(
+        Some(Seq(
           EdgeOrNodeData(
             viewRef,
             Some(viewDef.properties.collect { case (n, p: ViewCorePropertyDefinition) => n -> p }.map {
               case (n, p) => n -> createInstancePropertyValue(n, p.`type`, directNodeReference)
             })
-          ))
+          )))
       )
     )
   }
@@ -903,7 +903,7 @@ class FlexibleDataModelsRelationTest extends FlatSpec with Matchers with SparkTe
                 NodeWrite(
                   spaceExternalId,
                   s"${viewDef.externalId}Node1",
-                  Seq(EdgeOrNodeData(
+                  Some(Seq(EdgeOrNodeData(
                     viewRef,
                     Some(Map(
                       "forEqualsFilter" -> InstancePropertyValue.String("str1"),
@@ -916,12 +916,12 @@ class FlexibleDataModelsRelationTest extends FlatSpec with Matchers with SparkTe
                       "forOrFilter2" -> InstancePropertyValue.Float64(6.1),
                       "forIsNotNullFilter" -> InstancePropertyValue.Date(LocalDate.now())
                     ))
-                  ))
+                  )))
                 ),
                 NodeWrite(
                   spaceExternalId,
                   s"${viewDef.externalId}Node2",
-                  Seq(EdgeOrNodeData(
+                  Some(Seq(EdgeOrNodeData(
                     viewRef,
                     Some(Map(
                       "forEqualsFilter" -> InstancePropertyValue.String("str2"),
@@ -936,7 +936,7 @@ class FlexibleDataModelsRelationTest extends FlatSpec with Matchers with SparkTe
                       "forIsNullFilter" -> InstancePropertyValue.Object(Json.fromJsonObject(
                         JsonObject("a" -> Json.fromString("a"), "b" -> Json.fromInt(1))))
                     ))
-                  ))
+                  )))
                 )
               ),
               replace = Some(true)
@@ -1045,7 +1045,7 @@ class FlexibleDataModelsRelationTest extends FlatSpec with Matchers with SparkTe
       viewExternalId: String,
       viewVersion: String): IO[ViewDefinition] =
     client.views
-      .retrieveItems(items = Seq(DataModelReference(spaceExternalId, viewExternalId, viewVersion)))
+      .retrieveItems(items = Seq(DataModelReference(spaceExternalId, viewExternalId, Some(viewVersion))))
       .flatMap { views =>
         if (views.isEmpty) {
           val containerRef = container.toSourceReference
@@ -1108,22 +1108,22 @@ class FlexibleDataModelsRelationTest extends FlatSpec with Matchers with SparkTe
                 NodeWrite(
                   spaceExternalId,
                   startNodeExtId,
-                  Seq(EdgeOrNodeData(
+                  Some(Seq(EdgeOrNodeData(
                     viewStartAndEndNodes.toSourceReference,
                     Some(Map(
                       "stringProp1" -> InstancePropertyValue.String("stringProp1Val"),
                       "stringProp2" -> InstancePropertyValue.String("stringProp2Val")))
-                  ))
+                  )))
                 ),
                 NodeWrite(
                   spaceExternalId,
                   endNodeExtId,
-                  Seq(EdgeOrNodeData(
+                  Some(Seq(EdgeOrNodeData(
                     viewStartAndEndNodes.toSourceReference,
                     Some(Map(
                       "stringProp1" -> InstancePropertyValue.String("stringProp1Val"),
                       "stringProp2" -> InstancePropertyValue.String("stringProp2Val")))
-                  ))
+                  )))
                 )
               ),
               replace = Some(true)

--- a/src/test/scala/cognite/spark/v1/utils/fdm/FDMTestUtils.scala
+++ b/src/test/scala/cognite/spark/v1/utils/fdm/FDMTestUtils.scala
@@ -253,7 +253,7 @@ object FDMTestUtils {
         NodeWrite(
           space,
           s"node_instances_${container.externalId}",
-          nodeData
+          Some(nodeData)
         )
     }
 
@@ -297,7 +297,7 @@ object FDMTestUtils {
           externalId = edgeExternalId,
           startNode = startNode,
           endNode = endNode,
-          nodeData
+          Some(nodeData)
         )
     }
 


### PR DESCRIPTION
Bump the scala-sdk to version 2.5.6-SNAPSHOT.

Please review this carefully. Especially the `Helpers` object I added to `FlexibleDataModelRelationUtilsTest.scala`.