### PR TITLE
WDL: add itemsCreated metric and upgrade to api-version v1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ val circeVersion = "0.14.1"
 val sttpVersion = "3.5.2"
 val Specs2Version = "4.6.0"
 val artifactory = "https://cognite.jfrog.io/cognite/"
-val cogniteSdkVersion = "2.5.8-SNAPSHOT"
+val cogniteSdkVersion = "2.5.9-SNAPSHOT"
 
 val prometheusVersion = "0.15.0"
 val log4sVersion = "1.8.2"
@@ -23,7 +23,7 @@ lazy val commonSettings = Seq(
   organization := "com.cognite.spark.datasource",
   organizationName := "Cognite",
   organizationHomepage := Some(url("https://cognite.com")),
-  version := "2.4.7-SNAPSHOT",
+  version := "2.4.8-SNAPSHOT",
   isSnapshot := true,
   crossScalaVersions := supportedScalaVersions,
   semanticdbEnabled := true,

--- a/src/main/scala/cognite/spark/v1/wdl/WellDataLayerRelation.scala
+++ b/src/main/scala/cognite/spark/v1/wdl/WellDataLayerRelation.scala
@@ -45,7 +45,7 @@ class WellDataLayerRelation(
 
     val url = WdlModels.fromIngestionSchemaName(model).ingest.getOrElse(sys.error("Unreachable")).url
 
-    client.wdl.setItems(url, jsonObjects)
+    client.wdl.setItems(url, jsonObjects).flatTap(_ => incMetrics(itemsCreated, jsonObjects.size))
   }
 
   override def update(rows: Seq[Row]): IO[Unit] =

--- a/src/test/scala/cognite/spark/v1/wdl/TestWdlClient.scala
+++ b/src/test/scala/cognite/spark/v1/wdl/TestWdlClient.scala
@@ -2,7 +2,7 @@ package cognite.spark.v1.wdl
 
 import cats.effect.IO
 import cognite.spark.v1.CdfSparkException
-import com.cognite.sdk.scala.playground._
+import com.cognite.sdk.scala.v1._
 import com.cognite.sdk.scala.v1.GenericClient
 import org.apache.spark.sql.types.{DataType, StructType}
 

--- a/src/test/scala/cognite/spark/v1/wdl/WDLWellSourcesTest.scala
+++ b/src/test/scala/cognite/spark/v1/wdl/WDLWellSourcesTest.scala
@@ -1,7 +1,7 @@
 package cognite.spark.v1.wdl
 
 import cognite.spark.v1.{DataFrameMatcher, SparkTest}
-import com.cognite.sdk.scala.playground._
+import com.cognite.sdk.scala.v1._
 import org.scalatest.{BeforeAndAfter, FlatSpec, Inspectors}
 
 class WDLWellSourcesTest


### PR DESCRIPTION
- Transformations writing to the well data layer didn't update the `itemsCreated` metric.
- Update cognite-sdk-scala so that it is using the `v1` version of the well data layer.

[WDL-1034]


[WDL-1034]: https://cognitedata.atlassian.net/browse/WDL-1034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ