### PR TITLE
Limit per-partition parallelism if maxWritePartitions is set

### DIFF
--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -354,7 +354,12 @@ class DefaultSource
       dataRepartitioned.foreachPartition((rows: Iterator[Row]) => {
         import CdpConnector.ioRuntime
 
-        val maxParallelism = Math.max(1, config.partitions / numberOfPartitions)
+        val maxParallelism = if (config.maxWritePartitions.isDefined) {
+          1
+        } else {
+          Math.max(1, config.partitions / numberOfPartitions)
+        }
+
         val batches = Stream.fromIterator[IO](rows, chunkSize = batchSize).chunks
 
         val operation = config.onConflict match {


### PR DESCRIPTION
maxWritePartitions is used when ingesting into WDL to reduce the amount of parallel requests.

When writing a dataframe to CDF, the `partitions` property is not sent to the spark datasource.  That means that the value is set to 200 since it is the default. The result was that each spark partition ran with a very high `maxParallelism` setting.