### PR TITLE
Remove patch version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,14 +19,12 @@ lazy val gpgPass = Option(System.getenv("GPG_KEY_PASSWORD"))
 
 ThisBuild / scalafixDependencies += "org.typelevel" %% "typelevel-scalafix" % "0.1.4"
 
-lazy val patchVersion = scala.io.Source.fromFile("patch_version.txt").mkString.trim
-
 lazy val commonSettings = Seq(
   organization := "com.cognite.spark.datasource",
   organizationName := "Cognite",
   organizationHomepage := Some(url("https://cognite.com")),
-  version := "2.5." + patchVersion,
-  isSnapshot := patchVersion.endsWith("-SNAPSHOT"),
+  version := "2.5.4-SNAPSHOT",
+  isSnapshot := true,
   crossScalaVersions := supportedScalaVersions,
   semanticdbEnabled := true,
   semanticdbVersion := scalafixSemanticdb.revision,

--- a/patch_version.txt
+++ b/patch_version.txt
@@ -1,1 +1,0 @@
-4-SNAPSHOT


### PR DESCRIPTION
With `patch-version` file it is publishing a wrong version
https://github.com/cognitedata/cdp-spark-datasource/actions/runs/4698153321/jobs/8330098297
Same issue as in https://github.com/cognitedata/cognite-sdk-scala/pull/612