### PR TITLE
autoCreateStart/EndNodes in ConnectionRelation

### DIFF
--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelConnectionRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelConnectionRelation.scala
@@ -56,7 +56,9 @@ private[spark] class FlexibleDataModelConnectionRelation(
           .flatMap { instances =>
             val instanceCreate = InstanceCreate(
               items = instances,
-              replace = Some(true)
+              replace = Some(true),
+              autoCreateStartNodes = Some(true),
+              autoCreateEndNodes = Some(true)
             )
             client.instances.createItems(instanceCreate)
           }


### PR DESCRIPTION
We had added autoCreate parameters in FlexibleDataModelCorePropertyRelation, but I believe we need it in FlexibleDataModelConnectionRelation too.