### PR TITLE
Fix duplicate property bug

### DIFF
--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelRelationFactory.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelRelationFactory.scala
@@ -117,10 +117,10 @@ object FlexibleDataModelRelationFactory {
       .flatMap {
         _.flatMap(_.views.getOrElse(Seq.empty)).toVector
           .flatTraverse {
-            case vc: ViewDefinition =>
+            case vc: ViewDefinition if vc.externalId == modelConnectionConfig.viewExternalId =>
               IO.delay(
                 filterConnectionDefinition(vc, modelConnectionConfig.connectionPropertyName).toVector)
-            case vr: ViewReference =>
+            case vr: ViewReference if vr.externalId == modelConnectionConfig.viewExternalId =>
               fetchViewWithAllProps(client, vr).map(
                 _.headOption
                   .flatMap(filterConnectionDefinition(_, modelConnectionConfig.connectionPropertyName))


### PR DESCRIPTION
[CDF-18991]

When looking for the matching property from `connectionPropertyName`, we failed to check that the found property is a property of the view indicated by `viewExternalId`. This would lead to a bug where the wrong property was picked if multiple views had properties of the same name.

[CDF-18991]: https://cognitedata.atlassian.net/browse/CDF-18991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ