### PR TITLE
Fixup sonatype publishall

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,4 +79,4 @@ jobs:
         run: |
           ./secrets/decrypt.sh secrets/gpg-key-password.gpg secrets/gpg-key-password
           export GPG_KEY_PASSWORD=$(cat secrets/gpg-key-password)
-          sbt -Dsbt.log.noformat=true +fatJar/publishSigned +fatJar/sonatypeReleaseAll
+          sbt -Dsbt.log.noformat=true +fatJar/publishSigned sonatypeReleaseAll


### PR DESCRIPTION
Looks like that command is only defined at top-level project. It should still be ok to call it there as it shouldn't publish, only find what's published and release that

```
Error:  Not a valid key: sonatypeReleaseAll (similar: sonatypeLogLevel, sonatypeProfileName, sonatypeBundleClean)
Error:  +fatJar/sonatypeReleaseAll
```