### PR TITLE
Fix: Leave unmentioned properties alone

### DIFF
--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelation.scala
@@ -253,7 +253,7 @@ private[spark] class FlexibleDataModelCorePropertyRelation(
       case Right(items) if items.nonEmpty =>
         val instanceCreate = InstanceCreate(
           items = items,
-          replace = Some(true),
+          replace = Some(false),
           // These options need to made dynamic by moving to frontend
           // https://cognitedata.slack.com/archives/C03G11UNHBJ/p1678971213050319
           autoCreateStartNodes = Some(true),
@@ -278,7 +278,7 @@ private[spark] class FlexibleDataModelCorePropertyRelation(
       case Right(items) if items.nonEmpty =>
         val instanceCreate = InstanceCreate(
           items = items,
-          replace = Some(true),
+          replace = Some(false),
           // These options need to made dynamic by moving to frontend
           // https://cognitedata.slack.com/archives/C03G11UNHBJ/p1678971213050319
           autoCreateStartNodes = Some(true),


### PR DESCRIPTION
If we don't see a property in the row for a node or edge, don't remove it. This amounts to setting `replace = false` in the sdk call.

We still don't handle nulls completely correctly: If `ignoreNullFields = false`, we ought to remove properties that are null in the row. But let's leave that for later - the first fix is more important to get out.

Also, we need to figure out what to do in the other class, `FlexibleDataModelConnectionRelation`. But that's also for later.