### PR TITLE
Renovate: Less rebasing

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "local>cognitedata/renovate-config-public"
   ],
+  "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchDatasources": ["maven", "sbt-package"],


### PR DESCRIPTION
Don't trigger automatic rebase of renovate pr unless there's a merge conflict.

This should stop CD from failing once we're merged because of CI overload.