### PR TITLE
Fix slim artifact publish: publish struct_type helper classes artifact too

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,4 +79,4 @@ jobs:
         run: |
           ./secrets/decrypt.sh secrets/gpg-key-password.gpg secrets/gpg-key-password
           export GPG_KEY_PASSWORD=$(cat secrets/gpg-key-password)
-          sbt -Dsbt.log.noformat=true +fatJarShaded/publishSigned +publishSigned sonatypeReleaseAll
+          sbt -Dsbt.log.noformat=true +fatJarShaded/publishSigned +structType/publishSigned +publishSigned sonatypeReleaseAll

--- a/macro/src/main/scala/cognite/spark/compiletime/macros/StructTypeEncoderMacro.scala
+++ b/macro/src/main/scala/cognite/spark/compiletime/macros/StructTypeEncoderMacro.scala
@@ -1,63 +1,12 @@
-package cognite.spark.v1
+package cognite.spark.compiletime.macros
 
-import cats.Monad
-import io.scalaland.chimney.Transformer
 import org.apache.spark.sql.types.{StructField, StructType}
 
-import scala.annotation.tailrec
 import scala.reflect.macros.blackbox.Context
 
-trait StructTypeEncoder[T] {
-  def structType(): StructType
-}
+import cognite.spark.v1.{OptionalField, StructTypeEncoder}
 
-sealed trait OptionalField[+T] {
-  def toOption: Option[T]
-  def flatMap[B](f: T => OptionalField[B]): OptionalField[B]
-  def map[B](f: T => B): OptionalField[B]
-  @inline
-  final def getOrElse[B >: T](default: => B): B = toOption.getOrElse(default)
-}
-final case class FieldSpecified[+T](value: T) extends OptionalField[T] {
-  override def toOption: Option[T] =
-    if (value == null) { throw new Exception("FieldSpecified(null) observed, that's bad. Please reach out to Cognite support.") } else { Some(value) }
-  override def flatMap[B](f: T => OptionalField[B]): OptionalField[B] = f(value)
-  override def map[B](f: T => B): OptionalField[B] = FieldSpecified(f(value))
-}
-case object FieldNotSpecified extends OptionalField[Nothing] {
-  override def toOption: Option[Nothing] = None
-  override def flatMap[B](f: Nothing => OptionalField[B]): OptionalField[B] = this
-  override def map[B](f: Nothing => B): OptionalField[B] = this
-}
-case object FieldNull extends OptionalField[Nothing] {
-  override def toOption: Option[Nothing] = None
-  override def flatMap[B](f: Nothing => OptionalField[B]): OptionalField[B] = this
-  override def map[B](f: Nothing => B): OptionalField[B] = this
-}
-
-object OptionalField {
-  implicit def fieldToOption[T]: Transformer[OptionalField[T], Option[T]] =
-    new Transformer[OptionalField[T], Option[T]] {
-      override def transform(src: OptionalField[T]): Option[T] = src.toOption
-    }
-
-  implicit val monad: Monad[OptionalField] = new Monad[OptionalField] {
-    override def flatMap[A, B](fa: OptionalField[A])(f: A => OptionalField[B]): OptionalField[B] = fa.flatMap(f)
-
-    @tailrec
-    override def tailRecM[A, B](a: A)(f: A => OptionalField[Either[A, B]]): OptionalField[B] =
-      f(a) match {
-        case FieldNull => FieldNull
-        case FieldNotSpecified => FieldNotSpecified
-        case FieldSpecified(Right(x)) => pure(x)
-        case FieldSpecified(Left(x)) => tailRecM(x)(f)
-      }
-
-    override def pure[A](x: A): OptionalField[A] = FieldSpecified(x)
-  }
-}
-
-object StructTypeEncoder {
+object StructTypeEncoderMacro {
   implicit def defaultStructTypeEncoder[T]: StructTypeEncoder[T] = macro structTypeEncoder_impl[T]
   // scalastyle:off method.name
   def structTypeEncoder_impl[T: c.WeakTypeTag](c: Context): c.Expr[StructTypeEncoder[T]] = {

--- a/src/main/scala/cognite/spark/v1/AssetHierarchyBuilder.scala
+++ b/src/main/scala/cognite/spark/v1/AssetHierarchyBuilder.scala
@@ -3,7 +3,7 @@ package cognite.spark.v1
 import cats.effect.IO
 import cats.implicits._
 import cognite.spark.v1.PushdownUtilities.stringSeqToCogniteExternalIdSeq
-import cognite.spark.v1.SparkSchemaHelper.{fromRow, structType}
+import cognite.spark.compiletime.macros.SparkSchemaHelper.{fromRow, structType}
 import com.cognite.sdk.scala.common.{CdpApiException, SetValue}
 import com.cognite.sdk.scala.v1.{
   Asset,
@@ -73,6 +73,8 @@ final case class InvalidRootChangeException(assetIds: Seq[String], subtreeId: St
 
 class AssetHierarchyBuilder(config: RelationConfig)(val sqlContext: SQLContext)
     extends CdfRelation(config, "assethierarchy") {
+
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
 
   import CdpConnector.ioRuntime
 
@@ -410,5 +412,7 @@ class AssetHierarchyBuilder(config: RelationConfig)(val sqlContext: SQLContext)
 }
 
 object AssetHierarchyBuilder {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
+
   val upsertSchema: StructType = structType[AssetsIngestSchema]()
 }

--- a/src/main/scala/cognite/spark/v1/AssetsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/AssetsRelation.scala
@@ -2,7 +2,7 @@ package cognite.spark.v1
 
 import cats.effect.IO
 import cognite.spark.v1.PushdownUtilities._
-import cognite.spark.v1.SparkSchemaHelper._
+import cognite.spark.compiletime.macros.SparkSchemaHelper._
 import com.cognite.sdk.scala.common._
 import com.cognite.sdk.scala.v1._
 import com.cognite.sdk.scala.v1.resources.Assets
@@ -20,6 +20,8 @@ class AssetsRelation(config: RelationConfig, subtreeIds: Option[List[CogniteId]]
     extends SdkV1Relation[AssetsReadSchema, Long](config, "assets")
     with InsertableRelation
     with WritableRelation {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
+
   Array("name", "source", "dataSetId", "labels", "id", "externalId", "externalIdPrefix")
   override def getStreams(sparkFilters: Array[Filter])(
       client: GenericClient[IO],
@@ -114,6 +116,8 @@ class AssetsRelation(config: RelationConfig, subtreeIds: Option[List[CogniteId]]
 }
 
 object AssetsRelation extends UpsertSchema {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
+
   val upsertSchema: StructType = structType[AssetsUpsertSchema]()
   val insertSchema: StructType = structType[AssetsInsertSchema]()
   val readSchema: StructType = structType[AssetsReadSchema]()

--- a/src/main/scala/cognite/spark/v1/DataModelInstancesHelper.scala
+++ b/src/main/scala/cognite/spark/v1/DataModelInstancesHelper.scala
@@ -1,6 +1,6 @@
 package cognite.spark.v1
 
-import cognite.spark.v1.SparkSchemaHelper.fromRow
+import cognite.spark.compiletime.macros.SparkSchemaHelper.fromRow
 
 import java.time.{Instant, LocalDate, LocalDateTime, OffsetDateTime, ZoneId, ZonedDateTime}
 import com.cognite.sdk.scala.v1.DataModelType.NodeType

--- a/src/main/scala/cognite/spark/v1/DataModelInstancesRelation.scala
+++ b/src/main/scala/cognite/spark/v1/DataModelInstancesRelation.scala
@@ -2,6 +2,7 @@ package cognite.spark.v1
 
 import cats.effect.IO
 import cats.implicits._
+import cognite.spark.compiletime.macros.SparkSchemaHelper
 import cognite.spark.v1.DataModelInstancesHelper._
 import com.cognite.sdk.scala.common.{
   CdpApiException,

--- a/src/main/scala/cognite/spark/v1/DataPointsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/DataPointsRelation.scala
@@ -21,7 +21,7 @@ sealed case class Max(value: Instant) extends Limit
 
 final case class AggregationFilter(aggregation: String)
 
-import cognite.spark.v1.SparkSchemaHelper.fromRow
+import cognite.spark.compiletime.macros.SparkSchemaHelper.fromRow
 
 abstract class DataPointsRelationV1[A](config: RelationConfig, shortName: String)(
     override val sqlContext: SQLContext)

--- a/src/main/scala/cognite/spark/v1/DataSetsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/DataSetsRelation.scala
@@ -2,7 +2,7 @@ package cognite.spark.v1
 
 import cats.effect.IO
 import cognite.spark.v1.PushdownUtilities.{executeFilterOnePartition, pushdownToFilters, timeRange}
-import cognite.spark.v1.SparkSchemaHelper._
+import cognite.spark.compiletime.macros.SparkSchemaHelper._
 import com.cognite.sdk.scala.common.WithId
 import com.cognite.sdk.scala.v1.resources.DataSets
 import com.cognite.sdk.scala.v1.{DataSet, DataSetCreate, DataSetFilter, DataSetUpdate, GenericClient}
@@ -18,6 +18,7 @@ class DataSetsRelation(config: RelationConfig)(val sqlContext: SQLContext)
     with InsertableRelation
     with WritableRelation {
 
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
   override def schema: StructType = structType[DataSet]()
 
   override def toRow(a: DataSet): Row = asRow(a)
@@ -71,6 +72,8 @@ class DataSetsRelation(config: RelationConfig)(val sqlContext: SQLContext)
     throw new CdfSparkException("Delete is not supported for data sets.")
 }
 object DataSetsRelation extends UpsertSchema {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
+
   val upsertSchema: StructType = structType[DataSetsUpsertSchema]()
   val insertSchema: StructType = structType[DataSetsInsertSchema]()
   val readSchema: StructType = structType[DataSetsReadSchema]()

--- a/src/main/scala/cognite/spark/v1/EventsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/EventsRelation.scala
@@ -2,7 +2,7 @@ package cognite.spark.v1
 
 import cats.effect.IO
 import cognite.spark.v1.PushdownUtilities._
-import cognite.spark.v1.SparkSchemaHelper.{asRow, fromRow, structType}
+import cognite.spark.compiletime.macros.SparkSchemaHelper.{asRow, fromRow, structType}
 import com.cognite.sdk.scala.common.{WithExternalIdGeneric, WithId}
 import com.cognite.sdk.scala.v1._
 import com.cognite.sdk.scala.v1.resources.Events
@@ -17,7 +17,7 @@ class EventsRelation(config: RelationConfig)(val sqlContext: SQLContext)
     extends SdkV1Relation[Event, Long](config, "events")
     with InsertableRelation
     with WritableRelation {
-
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
   override def getStreams(sparkFilters: Array[Filter])(
       client: GenericClient[IO],
       limit: Option[Int],
@@ -90,6 +90,8 @@ class EventsRelation(config: RelationConfig)(val sqlContext: SQLContext)
   override def uniqueId(a: Event): Long = a.id
 }
 object EventsRelation extends UpsertSchema {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
+
   val upsertSchema: StructType = structType[EventsUpsertSchema]()
   val insertSchema: StructType = structType[EventsInsertSchema]()
   val readSchema: StructType = structType[EventsReadSchema]()

--- a/src/main/scala/cognite/spark/v1/FilesRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FilesRelation.scala
@@ -2,7 +2,7 @@ package cognite.spark.v1
 
 import cats.effect.IO
 import cognite.spark.v1.PushdownUtilities._
-import cognite.spark.v1.SparkSchemaHelper._
+import cognite.spark.compiletime.macros.SparkSchemaHelper._
 import com.cognite.sdk.scala.common.WithId
 import com.cognite.sdk.scala.v1.resources.Files
 import com.cognite.sdk.scala.v1.{
@@ -26,7 +26,7 @@ class FilesRelation(config: RelationConfig)(val sqlContext: SQLContext)
     extends SdkV1Relation[FilesReadSchema, Long](config, "files")
     with InsertableRelation
     with WritableRelation {
-
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
   override def getFromRowsAndCreate(rows: Seq[Row], doUpsert: Boolean = true): IO[Unit] = {
     val filesUpserts = rows.map(fromRow[FilesUpsertSchema](_))
     val files = filesUpserts.map(_.transformInto[FileCreate])
@@ -113,6 +113,8 @@ class FilesRelation(config: RelationConfig)(val sqlContext: SQLContext)
   override def uniqueId(a: FilesReadSchema): Long = a.id
 }
 object FilesRelation extends UpsertSchema {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
+
   val upsertSchema: StructType = structType[FilesUpsertSchema]()
   val insertSchema: StructType = structType[FilesInsertSchema]()
   val readSchema: StructType = structType[FilesReadSchema]()

--- a/src/main/scala/cognite/spark/v1/LabelsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/LabelsRelation.scala
@@ -1,7 +1,7 @@
 package cognite.spark.v1
 
 import cats.effect.IO
-import cognite.spark.v1.SparkSchemaHelper._
+import cognite.spark.compiletime.macros.SparkSchemaHelper._
 import com.cognite.sdk.scala.v1.{GenericClient, Label, LabelCreate, LabelsFilter}
 import org.apache.spark.sql.sources.{Filter, InsertableRelation}
 import org.apache.spark.sql.types._
@@ -13,7 +13,7 @@ class LabelsRelation(config: RelationConfig)(val sqlContext: SQLContext)
     extends SdkV1Relation[Label, String](config, "labels")
     with InsertableRelation
     with WritableRelation {
-
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
   override def schema: StructType = structType[Label]()
 
   override def toRow(a: Label): Row = asRow(a)
@@ -48,6 +48,8 @@ class LabelsRelation(config: RelationConfig)(val sqlContext: SQLContext)
 }
 
 object LabelsRelation {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
+
   val insertSchema: StructType = structType[LabelInsertSchema]()
   val readSchema: StructType = structType[LabelReadSchema]()
   val deleteSchema: StructType = structType[LabelDeleteSchema]()

--- a/src/main/scala/cognite/spark/v1/NumericDataPointsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/NumericDataPointsRelation.scala
@@ -8,7 +8,7 @@ import cognite.spark.v1.PushdownUtilities.{
   pushdownToParameters,
   toPushdownFilterExpression
 }
-import cognite.spark.v1.SparkSchemaHelper.{asRow, fromRow, structType}
+import cognite.spark.compiletime.macros.SparkSchemaHelper.{asRow, fromRow, structType}
 import com.cognite.sdk.scala.common.{DataPoint => SdkDataPoint}
 import com.cognite.sdk.scala.v1.{CogniteExternalId, CogniteId, CogniteInternalId}
 import fs2.Stream
@@ -223,6 +223,8 @@ class NumericDataPointsRelationV1(config: RelationConfig)(sqlContext: SQLContext
 }
 
 object NumericDataPointsRelation extends UpsertSchema {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
+
   val upsertSchema: StructType = structType[InsertDataPointsItem]()
   val readSchema: StructType = structType[DataPointsItem]()
   val insertSchema: StructType = structType[InsertDataPointsItem]()

--- a/src/main/scala/cognite/spark/v1/RelationshipsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/RelationshipsRelation.scala
@@ -3,7 +3,7 @@ package cognite.spark.v1
 import cats.Id
 import cats.effect.IO
 import cognite.spark.v1.PushdownUtilities._
-import cognite.spark.v1.SparkSchemaHelper.{asRow, fromRow, structType}
+import cognite.spark.compiletime.macros.SparkSchemaHelper.{asRow, fromRow, structType}
 import com.cognite.sdk.scala.common.WithRequiredExternalId
 import com.cognite.sdk.scala.v1._
 import com.cognite.sdk.scala.v1.resources.Relationships
@@ -19,7 +19,7 @@ class RelationshipsRelation(config: RelationConfig)(val sqlContext: SQLContext)
     extends SdkV1Relation[RelationshipsReadSchema, String](config, "relationships")
     with InsertableRelation
     with WritableRelation {
-
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
   override def schema: StructType = structType[RelationshipsReadSchema]()
 
   override def toRow(a: RelationshipsReadSchema): Row = asRow(a)
@@ -141,6 +141,8 @@ class RelationshipsRelation(config: RelationConfig)(val sqlContext: SQLContext)
 }
 
 object RelationshipsRelation {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
+
   val insertSchema: StructType = structType[RelationshipsInsertSchema]()
   val readSchema: StructType = structType[RelationshipsReadSchema]()
   val deleteSchema: StructType = structType[RelationshipsDeleteSchema]()

--- a/src/main/scala/cognite/spark/v1/SequenceRowsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/SequenceRowsRelation.scala
@@ -2,6 +2,7 @@ package cognite.spark.v1
 
 import cats.effect.IO
 import cats.implicits._
+import cognite.spark.compiletime.macros.SparkSchemaHelper
 import com.cognite.sdk.scala.common.CdpApiException
 import com.cognite.sdk.scala.v1._
 import fs2.Stream

--- a/src/main/scala/cognite/spark/v1/SequencesRelation.scala
+++ b/src/main/scala/cognite/spark/v1/SequencesRelation.scala
@@ -3,7 +3,7 @@ package cognite.spark.v1
 import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.implicits._
-import cognite.spark.v1.SparkSchemaHelper.{asRow, fromRow, structType}
+import cognite.spark.compiletime.macros.SparkSchemaHelper.{asRow, fromRow, structType}
 import com.cognite.sdk.scala.common.{SetValue, Setter, WithExternalId, WithId}
 import com.cognite.sdk.scala.v1._
 import com.cognite.sdk.scala.v1.resources.SequencesResource
@@ -21,6 +21,7 @@ class SequencesRelation(config: RelationConfig)(val sqlContext: SQLContext)
     extends SdkV1Relation[SequenceReadSchema, Long](config, "sequences")
     with InsertableRelation
     with WritableRelation {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
   override def getStreams(filters: Array[Filter])(
       client: GenericClient[IO],
       limit: Option[Int],
@@ -214,6 +215,8 @@ class SequencesRelation(config: RelationConfig)(val sqlContext: SQLContext)
 }
 
 object SequenceRelation extends UpsertSchema {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
+
   val upsertSchema: StructType = structType[SequenceUpsertSchema]()
   val insertSchema: StructType = structType[SequenceInsertSchema]()
   val readSchema: StructType = structType[SequenceReadSchema]()

--- a/src/main/scala/cognite/spark/v1/StringDataPointsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/StringDataPointsRelation.scala
@@ -6,7 +6,7 @@ import cognite.spark.v1.PushdownUtilities.{
   pushdownToParameters,
   toPushdownFilterExpression
 }
-import cognite.spark.v1.SparkSchemaHelper.{asRow, fromRow, structType}
+import cognite.spark.compiletime.macros.SparkSchemaHelper.{asRow, fromRow, structType}
 import com.cognite.sdk.scala.common.StringDataPoint
 import fs2.Stream
 import org.apache.spark.rdd.RDD
@@ -100,6 +100,7 @@ class StringDataPointsRelationV1(config: RelationConfig)(override val sqlContext
 }
 
 object StringDataPointsRelation extends UpsertSchema {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
   // We should use StringDataPointsItem here, but doing that gives the error: "constructor Timestamp encapsulates
   // multiple overloaded alternatives and cannot be treated as a method. Consider invoking
   // `<offending symbol>.asTerm.alternatives` and manually picking the required method" in StructTypeEncoder, probably

--- a/src/main/scala/cognite/spark/v1/ThreeDModelRevisionMappingsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/ThreeDModelRevisionMappingsRelation.scala
@@ -1,7 +1,7 @@
 package cognite.spark.v1
 
 import cats.effect.IO
-import cognite.spark.v1.SparkSchemaHelper._
+import cognite.spark.compiletime.macros.SparkSchemaHelper._
 import com.cognite.sdk.scala.v1.{GenericClient, ThreeDAssetMapping}
 import fs2.Stream
 import org.apache.spark.sql.sources.Filter
@@ -11,6 +11,8 @@ import org.apache.spark.sql.{Row, SQLContext}
 class ThreeDModelRevisionMappingsRelation(config: RelationConfig, modelId: Long, revisionId: Long)(
     val sqlContext: SQLContext)
     extends SdkV1Relation[ThreeDAssetMapping, String](config, "3dmodelrevisionmappings") {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
+
   override def schema: StructType = structType[ThreeDAssetMapping]()
 
   override def toRow(t: ThreeDAssetMapping): Row = asRow(t)

--- a/src/main/scala/cognite/spark/v1/ThreeDModelRevisionNodesRelation.scala
+++ b/src/main/scala/cognite/spark/v1/ThreeDModelRevisionNodesRelation.scala
@@ -1,7 +1,7 @@
 package cognite.spark.v1
 
 import cats.effect.IO
-import cognite.spark.v1.SparkSchemaHelper._
+import cognite.spark.compiletime.macros.SparkSchemaHelper._
 import com.cognite.sdk.scala.v1.{GenericClient, ThreeDNode}
 import fs2.Stream
 import org.apache.spark.sql.sources.Filter
@@ -11,6 +11,8 @@ import org.apache.spark.sql.{Row, SQLContext}
 class ThreeDModelRevisionNodesRelation(config: RelationConfig, modelId: Long, revisionId: Long)(
     val sqlContext: SQLContext)
     extends SdkV1Relation[ThreeDNode, Long](config, "3dmodelrevisionnodes") {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
+
   override def schema: StructType = structType[ThreeDNode]()
 
   override def toRow(t: ThreeDNode): Row = asRow(t)

--- a/src/main/scala/cognite/spark/v1/ThreeDModelRevisionsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/ThreeDModelRevisionsRelation.scala
@@ -1,7 +1,7 @@
 package cognite.spark.v1
 
 import cats.effect.IO
-import cognite.spark.v1.SparkSchemaHelper._
+import cognite.spark.compiletime.macros.SparkSchemaHelper._
 import com.cognite.sdk.scala.v1.{GenericClient, ThreeDRevision}
 import fs2.Stream
 import org.apache.spark.sql.sources.Filter
@@ -24,6 +24,8 @@ final case class ModelRevisionItem(
 
 class ThreeDModelRevisionsRelation(config: RelationConfig, modelId: Long)(val sqlContext: SQLContext)
     extends SdkV1Relation[ThreeDRevision, Long](config, "3dmodelrevision") {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
+
   override def schema: StructType = structType[ThreeDRevision]()
 
   override def toRow(t: ThreeDRevision): Row = asRow(t)

--- a/src/main/scala/cognite/spark/v1/ThreeDModelsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/ThreeDModelsRelation.scala
@@ -1,7 +1,7 @@
 package cognite.spark.v1
 
 import cats.effect.IO
-import cognite.spark.v1.SparkSchemaHelper._
+import cognite.spark.compiletime.macros.SparkSchemaHelper._
 import com.cognite.sdk.scala.v1.{GenericClient, ThreeDModel}
 import fs2.Stream
 import org.apache.spark.sql.sources.Filter
@@ -12,7 +12,7 @@ final case class ModelItem(id: Long, name: String, createdTime: Long)
 
 class ThreeDModelsRelation(config: RelationConfig)(val sqlContext: SQLContext)
     extends SdkV1Relation[ThreeDModel, Long](config, "threeDModels.read") {
-
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
   override def schema: StructType = structType[ThreeDModel]()
 
   override def toRow(t: ThreeDModel): Row = asRow(t)

--- a/src/main/scala/cognite/spark/v1/TimeSeriesRelation.scala
+++ b/src/main/scala/cognite/spark/v1/TimeSeriesRelation.scala
@@ -2,7 +2,7 @@ package cognite.spark.v1
 
 import cats.effect.IO
 import cognite.spark.v1.PushdownUtilities._
-import cognite.spark.v1.SparkSchemaHelper._
+import cognite.spark.compiletime.macros.SparkSchemaHelper._
 import com.cognite.sdk.scala.common.WithId
 import com.cognite.sdk.scala.v1._
 import com.cognite.sdk.scala.v1.resources.TimeSeriesResource
@@ -18,6 +18,7 @@ class TimeSeriesRelation(config: RelationConfig)(val sqlContext: SQLContext)
     extends SdkV1Relation[TimeSeries, Long](config, "timeseries")
     with WritableRelation
     with InsertableRelation {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
   override def insert(rows: Seq[Row]): IO[Unit] =
     getFromRowsAndCreate(rows, doUpsert = false)
 
@@ -92,6 +93,8 @@ class TimeSeriesRelation(config: RelationConfig)(val sqlContext: SQLContext)
     )
 }
 object TimeSeriesRelation extends UpsertSchema {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
+
   val upsertSchema: StructType = structType[TimeSeriesUpsertSchema]()
   val insertSchema: StructType = structType[TimeSeriesInsertSchema]()
   val readSchema: StructType = structType[TimeSeriesReadSchema]()

--- a/src/test/scala/cognite/spark/v1/AssetHierarchyBuilderTest.scala
+++ b/src/test/scala/cognite/spark/v1/AssetHierarchyBuilderTest.scala
@@ -1,7 +1,7 @@
 package cognite.spark.v1
 
 import cognite.spark.v1.CdpConnector.ioRuntime
-import cognite.spark.v1.SparkSchemaHelper.fromRow
+import cognite.spark.compiletime.macros.SparkSchemaHelper.fromRow
 import com.cognite.sdk.scala.common.CdpApiException
 import com.cognite.sdk.scala.v1.{AssetCreate, CogniteExternalId}
 import org.apache.spark.sql.{DataFrame, Row}

--- a/src/test/scala/cognite/spark/v1/DataSetsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/DataSetsRelationTest.scala
@@ -1,6 +1,6 @@
 package cognite.spark.v1
 
-import cognite.spark.v1.SparkSchemaHelper.fromRow
+import cognite.spark.compiletime.macros.SparkSchemaHelper.fromRow
 import com.cognite.sdk.scala.v1.DataSet
 import org.apache.spark.sql.Row
 import org.scalatest.{FlatSpec, Inspectors, Matchers, ParallelTestExecution}

--- a/src/test/scala/cognite/spark/v1/EventsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/EventsRelationTest.scala
@@ -1,5 +1,6 @@
 package cognite.spark.v1
 
+import cognite.spark.compiletime.macros.SparkSchemaHelper
 import cognite.spark.v1.CdpConnector.ioRuntime
 import com.cognite.sdk.scala.common.CdpApiException
 import com.cognite.sdk.scala.v1.EventCreate

--- a/src/test/scala/cognite/spark/v1/LabelsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/LabelsRelationTest.scala
@@ -1,7 +1,7 @@
 package cognite.spark.v1
 
 import cognite.spark.v1.CdpConnector.ioRuntime
-import cognite.spark.v1.SparkSchemaHelper.fromRow
+import cognite.spark.compiletime.macros.SparkSchemaHelper.fromRow
 import com.cognite.sdk.scala.v1.{DataSet, DataSetCreate, Label, LabelCreate, LabelsFilter}
 import org.apache.spark.sql.DataFrame
 import org.scalatest.{FlatSpec, Inspectors, Matchers, ParallelTestExecution}

--- a/src/test/scala/cognite/spark/v1/RelationshipsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/RelationshipsRelationTest.scala
@@ -1,7 +1,7 @@
 package cognite.spark.v1
 
 import cognite.spark.v1.CdpConnector.ioRuntime
-import cognite.spark.v1.SparkSchemaHelper.fromRow
+import cognite.spark.compiletime.macros.SparkSchemaHelper.fromRow
 import com.cognite.sdk.scala.v1.{CogniteExternalId, RelationshipCreate}
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{DataFrame, Row}

--- a/src/test/scala/cognite/spark/v1/SdkV1RddTest.scala
+++ b/src/test/scala/cognite/spark/v1/SdkV1RddTest.scala
@@ -7,7 +7,7 @@ import fs2.{Chunk, Stream}
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.Row
 import org.scalatest.{FlatSpec, Matchers, ParallelTestExecution}
-import cognite.spark.v1.SparkSchemaHelper.asRow
+import cognite.spark.compiletime.macros.SparkSchemaHelper.asRow
 import sttp.client3._
 
 import scala.concurrent.duration._

--- a/src/test/scala/cognite/spark/v1/SparkSchemaHelperTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkSchemaHelperTest.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
 import org.scalatest.{FlatSpec, Matchers, ParallelTestExecution}
-import SparkSchemaHelper._
+import cognite.spark.compiletime.macros.SparkSchemaHelper._
 
 final case class TestTypeBasic(a: Int, b: Double, c: Byte, d: Float, x: Map[String, String], g: Long, f: Seq[Long], s: String)
 final case class TestTypeOption(a: Option[Int], b: Option[Double], c: Option[Byte],
@@ -14,6 +14,8 @@ final case class TestTypeOption(a: Option[Int], b: Option[Double], c: Option[Byt
 final case class TestTypeOptionalField(a: OptionalField[Int], b: OptionalField[Double], c: OptionalField[Byte])
 
 class SparkSchemaHelperTest extends FlatSpec with ParallelTestExecution with Matchers {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
+
   "SparkSchemaHelper structType" should "generate StructType from basic case class" in {
     structType[TestTypeBasic]() should be (StructType(Seq(
       StructField("a", DataTypes.IntegerType, false),

--- a/src/test/scala/cognite/spark/v1/TimeSeriesRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/TimeSeriesRelationTest.scala
@@ -1,5 +1,7 @@
 package cognite.spark.v1
 
+import cognite.spark.compiletime.macros.SparkSchemaHelper
+
 import com.cognite.sdk.scala.common.CdpApiException
 import io.scalaland.chimney.dsl._
 import org.apache.spark.SparkException

--- a/src/test/scala/cognite/spark/v1/wdl/RowToJsonTest.scala
+++ b/src/test/scala/cognite/spark/v1/wdl/RowToJsonTest.scala
@@ -7,9 +7,11 @@ import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.types._
 import org.scalatest.{FlatSpec, Matchers, ParallelTestExecution}
 
-import cognite.spark.v1.SparkSchemaHelper._
+import cognite.spark.compiletime.macros.SparkSchemaHelper._
 
 class RowToJsonTest extends FlatSpec with Matchers with ParallelTestExecution {
+  import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
+
   it should "convert a Row with number types into a JsonObject" in {
     val schema = new StructType()
       .add("double", DoubleType)

--- a/struct_type/src/main/scala/cognite/spark/v1/OptionalField.scala
+++ b/struct_type/src/main/scala/cognite/spark/v1/OptionalField.scala
@@ -1,0 +1,53 @@
+package cognite.spark.v1
+
+import cats.Monad
+import io.scalaland.chimney.Transformer
+
+import scala.annotation.tailrec
+
+sealed trait OptionalField[+T] {
+  def toOption: Option[T]
+  def flatMap[B](f: T => OptionalField[B]): OptionalField[B]
+  def map[B](f: T => B): OptionalField[B]
+  @inline
+  final def getOrElse[B >: T](default: => B): B = toOption.getOrElse(default)
+}
+final case class FieldSpecified[+T](value: T) extends OptionalField[T] {
+  override def toOption: Option[T] =
+    if (value == null) { throw new Exception("FieldSpecified(null) observed, that's bad. Please reach out to Cognite support.") } else { Some(value) }
+  override def flatMap[B](f: T => OptionalField[B]): OptionalField[B] = f(value)
+  override def map[B](f: T => B): OptionalField[B] = FieldSpecified(f(value))
+}
+case object FieldNotSpecified extends OptionalField[Nothing] {
+  override def toOption: Option[Nothing] = None
+  override def flatMap[B](f: Nothing => OptionalField[B]): OptionalField[B] = this
+  override def map[B](f: Nothing => B): OptionalField[B] = this
+}
+case object FieldNull extends OptionalField[Nothing] {
+  override def toOption: Option[Nothing] = None
+  override def flatMap[B](f: Nothing => OptionalField[B]): OptionalField[B] = this
+  override def map[B](f: Nothing => B): OptionalField[B] = this
+}
+
+object OptionalField {
+  implicit def fieldToOption[T]: Transformer[OptionalField[T], Option[T]] =
+    new Transformer[OptionalField[T], Option[T]] {
+      override def transform(src: OptionalField[T]): Option[T] = src.toOption
+    }
+
+  implicit val monad: Monad[OptionalField] = new Monad[OptionalField] {
+    override def flatMap[A, B](fa: OptionalField[A])(f: A => OptionalField[B]): OptionalField[B] = fa.flatMap(f)
+
+    @tailrec
+    override def tailRecM[A, B](a: A)(f: A => OptionalField[Either[A, B]]): OptionalField[B] =
+      f(a) match {
+        case FieldNull => FieldNull
+        case FieldNotSpecified => FieldNotSpecified
+        case FieldSpecified(Right(x)) => pure(x)
+        case FieldSpecified(Left(x)) => tailRecM(x)(f)
+      }
+
+    override def pure[A](x: A): OptionalField[A] = FieldSpecified(x)
+  }
+}
+

--- a/struct_type/src/main/scala/cognite/spark/v1/StructTypeEncoder.scala
+++ b/struct_type/src/main/scala/cognite/spark/v1/StructTypeEncoder.scala
@@ -1,0 +1,7 @@
+package cognite.spark.v1
+
+import org.apache.spark.sql.types.StructType
+
+trait StructTypeEncoder[T] {
+  def structType(): StructType
+}


### PR DESCRIPTION
Splitting macro library into compile-time macro and runtime helper classes,
publishing runtime classes as a library for non-fatjar artifact.

Moving compile-time macros to `cognite.spark.compiletime.macros` package, also
extracted OptionalField to a separate file.

Verified that compile-time part isn't referenced in artifact
```console
sbt package

for x in `jar tf target/scala-2.12/cdf-spark-datasource_2.12-3.0.0-SNAPSHOT.jar | grep "\.class$" | sed -e 's/\.class$//'`; do
  echo "processing $x";
  javap -c -p -cp target/scala-2.12/cdf-spark-datasource_2.12-3.0.0-SNAPSHOT.jar "$x";
done | grep cognite.spark.compiletime
```

Not adding this a CI check as it is fairly slow and macros part isn't changed too frequently
