### PR TITLE
POC for multi-output

### DIFF
--- a/src/main/scala/cognite/spark/v1/AssetsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/AssetsRelation.scala
@@ -66,9 +66,10 @@ class AssetsRelation(config: RelationConfig, subtreeIds: Option[List[CogniteId]]
       _.into[AssetCreate]
         .withFieldComputed(_.labels, u => stringSeqToCogniteExternalIdSeq(u.labels))
         .transform)
-    client.assets
+    val x = client.assets
       .create(assets)
       .flatTap(_ => incMetrics(itemsCreated, assets.size)) *> IO.unit
+    x
   }
 
   private def isUpdateEmpty(u: AssetUpdate): Boolean = u == AssetUpdate()

--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -129,7 +129,9 @@ class DefaultSource
     val config = parseRelationConfig(parameters, sqlContext)
 
     resourceType match {
-      case MultiSpec(_) => throw new NotImplementedException("Multiple types")
+      case MultiSpec(MultiSpec(types)) => new MultiRelation(config, types.map { case (name, relationType) =>
+        name -> createRelation(sqlContext, parameters + ("type" -> relationType), schema)
+      })(sqlContext)
       case "datapoints" =>
         new NumericDataPointsRelationV1(config)(sqlContext)
       case "stringdatapoints" =>

--- a/src/main/scala/cognite/spark/v1/MultiRelation.scala
+++ b/src/main/scala/cognite/spark/v1/MultiRelation.scala
@@ -3,12 +3,13 @@ package cognite.spark.v1
 import cats.effect.IO
 import cats.implicits.catsSyntaxParallelTraverse_
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
-import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation, TableScan}
+import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation}
 import org.apache.spark.sql.types.{StructField, StructType}
-class MultiRelation(config: RelationConfig, relations: Map[String, BaseRelation with WritableRelation])(
+class MultiRelation(config: RelationConfig, relations: Map[String, BaseRelation])(
     val sqlContext: SQLContext)
     extends BaseRelation
-    with InsertableRelation {
+    with InsertableRelation
+    with Serializable {
   override def insert(data: DataFrame, overwrite: Boolean): Unit =
     data.foreachPartition((rows: Iterator[Row]) => {
       import CdpConnector._
@@ -18,14 +19,16 @@ class MultiRelation(config: RelationConfig, relations: Map[String, BaseRelation 
     })
 
   private def getFromRowsAndCreate(rows: Seq[Row]): IO[Unit] = relations.toVector.parTraverse_ {
-    case (name, relation) =>
+    case (name, relation: WritableRelation) =>
       val rs = rows.map(row => {
         row.getAs[Row](name)
       })
       relation.insert(rs)
+    case _ => throw new CdfSparkException("Relation is not writable")
   }
 
-  override val schema: StructType = StructType(relations.map { case (name, rel) =>
-    StructField(name, rel.schema, nullable = false)
+  override val schema: StructType = StructType(relations.map {
+    case (name, rel) =>
+      StructField(name, rel.schema, nullable = false)
   }.toSeq)
 }

--- a/src/main/scala/cognite/spark/v1/MultiRelation.scala
+++ b/src/main/scala/cognite/spark/v1/MultiRelation.scala
@@ -1,0 +1,31 @@
+package cognite.spark.v1
+
+import cats.effect.IO
+import cats.implicits.catsSyntaxParallelTraverse_
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation, TableScan}
+import org.apache.spark.sql.types.{StructField, StructType}
+class MultiRelation(config: RelationConfig, relations: Map[String, BaseRelation with WritableRelation])(
+    val sqlContext: SQLContext)
+    extends BaseRelation
+    with InsertableRelation {
+  override def insert(data: DataFrame, overwrite: Boolean): Unit =
+    data.foreachPartition((rows: Iterator[Row]) => {
+      import CdpConnector._
+      val batches =
+        rows.grouped(config.batchSize.getOrElse(cognite.spark.v1.Constants.DefaultBatchSize)).toVector
+      batches.parTraverse_(getFromRowsAndCreate).unsafeRunSync()
+    })
+
+  private def getFromRowsAndCreate(rows: Seq[Row]): IO[Unit] = relations.toVector.parTraverse_ {
+    case (name, relation) =>
+      val rs = rows.map(row => {
+        row.getAs[Row](name)
+      })
+      relation.insert(rs)
+  }
+
+  override val schema: StructType = StructType(relations.map { case (name, rel) =>
+    StructField(name, rel.schema, nullable = false)
+  }.toSeq)
+}

--- a/src/test/scala/cognite/spark/v1/AssetsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/AssetsRelationTest.scala
@@ -62,7 +62,7 @@ class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecuti
       .option("limitPerPartition", "1000")
       .option("partitions", "1")
       .load()
-      .where("name = '23-TT-92604B'")
+      .where("metadata = map('hei', 'der')")
 
     assert(df.count() == 1)
 

--- a/src/test/scala/cognite/spark/v1/AssetsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/AssetsRelationTest.scala
@@ -374,7 +374,6 @@ class AssetsRelationTest extends FlatSpec with Matchers with ParallelTestExecuti
                |$testDataSetId as dataSetId
              |) as e
       """.stripMargin)
-        .select("a", "e")
         .write
         .insertInto("createAssetsAndEvents")
 


### PR DESCRIPTION
This is proof of concept for how we might support multiple outputs from a single transformation.

The idea is that you write sql like
```sql
select
struct(fields for asset) as a,
struct(fields for event) as e
from...
```
and then in the `type` relation option, you specify the types of those names like `a:asset,e:event`. This would be passed in a more structured json way to the jetfire-backend, but we have to flatten it to a string in spark.

Internally, we parse out the names and types, and then create a relation for each of them. Specific options to each source can be passed by prefixing the options with `${name}:`, i.e., an option named `a:assetSubTreeIds` would be passed to the asset relation.

See the new test in `AssetTests` for a proof that this works in a simple case. Unfortunately, we have to give all fields in the correct order and explicitly cast all null fields for this to typecheck in spark. Hopefully this can be alleviated in some way.

This is just a POC. Ideas / criticisms are welcome!