### PR TITLE
Cleanup redundant maybeCacheToken

### DIFF
--- a/src/test/scala/cognite/spark/v1/AssetHierarchyBuilderTest.scala
+++ b/src/test/scala/cognite/spark/v1/AssetHierarchyBuilderTest.scala
@@ -1110,10 +1110,11 @@ class AssetHierarchyBuilderTest
     ingest(key, grandkids, batchSize = 1000, metricsPrefix = Some(s"ingest.tree.grandkids.$key"))
 
     getNumberOfRowsCreated(s"ingest.tree.grandkids.$key", "assethierarchy") shouldBe 1100
+    // 1 for access token
     // 2 for fetching root parents (for validation)
     // 2 for fetching the roots
     // 2 for creating the roots
-    getNumberOfRequests(s"ingest.tree.grandkids.$key") shouldBe 6
+    getNumberOfRequests(s"ingest.tree.grandkids.$key") shouldBe 7
 
     val grandkidsUpdate = (1 to 1100).map(
       k =>
@@ -1129,10 +1130,11 @@ class AssetHierarchyBuilderTest
     ingest(key, grandkidsUpdate, batchSize = 1000, metricsPrefix = Some(s"ingest.tree.grandkidsU.$key"))
 
     getNumberOfRowsUpdated(s"ingest.tree.grandkidsU.$key", "assethierarchy") shouldBe 1100
+    // 1 for access token
     // 2 for fetching root parents (for validation)
     // 2 for fetching the roots
     // 2 for updating the roots
-    getNumberOfRequests(s"ingest.tree.grandkidsU.$key") shouldBe 6
+    getNumberOfRequests(s"ingest.tree.grandkidsU.$key") shouldBe 7
 
     cleanDB(key)
   }

--- a/src/test/scala/cognite/spark/v1/SdkV1RddTest.scala
+++ b/src/test/scala/cognite/spark/v1/SdkV1RddTest.scala
@@ -30,11 +30,9 @@ class SdkV1RddTest extends FlatSpec with Matchers with ParallelTestExecution wit
     val toRow = (_: String, _: Option[Int]) => Row.empty
     val uniqueId = (_: String) => "1"
 
-    implicit val implicitBackend: SttpBackend[IO, Any] = CdpConnector.retryingSttpBackend(3, 5)
-
     val sdkRdd = {
       val relationConfig = getDefaultConfig(
-        CdfSparkAuth.OAuth2ClientCredentials(readOidcCredentials)(implicitBackend),
+        CdfSparkAuth.OAuth2ClientCredentials(readOidcCredentials),
         readOidcCredentials.cdfProjectName
       )
       SdkV1Rdd[String, String](


### PR DESCRIPTION
`maybeCacheToken` has a misleading name, it actually is only an
optional initial token which will be used until it expires

https://github.com/cognitedata/cognite-sdk-scala/blob/2c1e74e67b3eba42ca564f53af08021ba146c642/src/main/scala/com/cognite/sdk/scala/common/OAuth2.scala#L173
https://github.com/cognitedata/cognite-sdk-scala/blob/2c1e74e67b3eba42ca564f53af08021ba146c642/src/main/scala/com/cognite/sdk/scala/common/OAuth2.scala#L200

But after it expires or if it wasn't provided normal path would be
used to fetch a new token and persist it via `CachedResource` and
invalidate-refresh as needed in `commonGetAuth`
https://github.com/cognitedata/cognite-sdk-scala/blob/2c1e74e67b3eba42ca564f53af08021ba146c642/src/main/scala/com/cognite/sdk/scala/common/OAuth2.scala#L133

The intent is to be able to have single seed token for multiple auth instances.

Here initial token was supplied out of normal path so exactly the same path
as expire-refresh, so removing manually setting initial token would only
save some eager requests and extra expiration checks on each refresh
(current version of fetching token checks old initial token expiration
every single call even after it has expired long time ago)

To address separately in scala sdk later (in https://github.com/cognitedata/cognite-sdk-scala/pull/666):
- maybe unwrap `F[Option[initial token]]` back to `Option[initial token]`
- rename `maybeCacheToken` to something like `maybeInitialToken`
- add support for initial token in sdk to avoid having to hijack
  refresh path in consumer code each time
