### PR TITLE
Add some explicit override-s

### DIFF
--- a/src/main/scala/cognite/spark/v1/DataModelInstancesRelation.scala
+++ b/src/main/scala/cognite/spark/v1/DataModelInstancesRelation.scala
@@ -114,7 +114,7 @@ class DataModelInstanceRelation(
       }
     }
 
-  def insert(rows: Seq[Row]): IO[Unit] =
+  override def insert(rows: Seq[Row]): IO[Unit] =
     throw new CdfSparkException(
       "Create (abort) is not supported for data model instances. Use upsert instead.")
 
@@ -296,7 +296,7 @@ class DataModelInstanceRelation(
     }
   }
 
-  def update(rows: Seq[Row]): IO[Unit] =
+  override def update(rows: Seq[Row]): IO[Unit] =
     throw new CdfSparkException("Update is not supported for data model instances. Use upsert instead.")
 
   def getIndexedPropertyList(rSchema: StructType): Array[(Int, String, DataModelPropertyDefinition)] =

--- a/src/main/scala/cognite/spark/v1/NumericDataPointsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/NumericDataPointsRelation.scala
@@ -152,7 +152,7 @@ class NumericDataPointsRelationV1(config: RelationConfig)(sqlContext: SQLContext
     new GenericRow(indicesOfRequiredFields.map(idx => rowOfAllFields.get(idx)))
   }
 
-  def insertRowIterator(rows: Iterator[Row]): IO[Unit] = {
+  override def insertRowIterator(rows: Iterator[Row]): IO[Unit] = {
     // we basically use Stream.fromIterator instead of Seq.grouped, because it's significantly more efficient
     val dataPoints = Stream.fromIterator[IO](
       rows.map(r => fromRow[InsertDataPointsItem](r)),

--- a/src/main/scala/cognite/spark/v1/SequenceRowsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/SequenceRowsRelation.scala
@@ -200,19 +200,19 @@ class SequenceRowsRelation(config: RelationConfig, sequenceId: CogniteId)(val sq
     (columns.map(_._2), parseRow)
   }
 
-  def delete(rows: Seq[Row]): IO[Unit] = {
+  override def delete(rows: Seq[Row]): IO[Unit] = {
     val deletes = rows.map(r => SparkSchemaHelper.fromRow[SequenceRowDeleteSchema](r))
     client.sequenceRows
       .delete(sequenceId, deletes.map(_.rowNumber))
       .flatTap(_ => incMetrics(itemsDeleted, rows.length))
   }
-  def insert(rows: Seq[Row]): IO[Unit] =
+  override def insert(rows: Seq[Row]): IO[Unit] =
     throw new CdfSparkException("Insert not supported for sequencerows. Use upsert instead.")
 
-  def update(rows: Seq[Row]): IO[Unit] =
+  override def update(rows: Seq[Row]): IO[Unit] =
     throw new CdfSparkException("Update not supported for sequencerows. Use upsert instead.")
 
-  def upsert(rows: Seq[Row]): IO[Unit] =
+  override def upsert(rows: Seq[Row]): IO[Unit] =
     if (rows.isEmpty) {
       IO.unit
     } else {

--- a/src/main/scala/cognite/spark/v1/StringDataPointsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/StringDataPointsRelation.scala
@@ -43,7 +43,7 @@ class StringDataPointsRelationV1(config: RelationConfig)(override val sqlContext
   override def update(rows: Seq[Row]): IO[Unit] =
     throw new CdfSparkException("Update not supported for stringdatapoints. Please use upsert instead.")
 
-  def toRow(a: StringDataPointsItem): Row = asRow(a)
+  override def toRow(a: StringDataPointsItem): Row = asRow(a)
 
   override def schema: StructType =
     StructType(
@@ -54,7 +54,7 @@ class StringDataPointsRelationV1(config: RelationConfig)(override val sqlContext
         StructField("value", StringType, nullable = false)
       ))
 
-  def insertRowIterator(rows: Iterator[Row]): IO[Unit] = {
+  override def insertRowIterator(rows: Iterator[Row]): IO[Unit] = {
     // we basically use Stream.fromIterator instead of Seq.grouped, because it's significantly more efficient
     val dataPoints = Stream.fromIterator[IO](
       rows.map(r => fromRow[StringDataPointsInsertItem](r)),


### PR DESCRIPTION
Seeing if method is doing an override or not is quite helpful when
doing refactorings. Those that do override have to be kept as is
or refactored along with the interface, while non-overriding ones
are safe to change in any suitable way.

Sadly didn't manage to persist a linter for this
- scalafix + https://github.com/xplosunn/ForceOverrides doesn't work
  because that extension is outdated and not compatible with recent scalafix
- https://github.com/wartremover/wartremover-contrib#missingoverride
  produces warning also for `val` overrides (that's ok) but also seemingly
  some false positives at places that aren't even declarations but rather fn calls
