### PR TITLE
Introduce SdkV1InsertableRelation subclass

### DIFF
--- a/src/main/scala/cognite/spark/v1/AssetsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/AssetsRelation.scala
@@ -9,16 +9,16 @@ import com.cognite.sdk.scala.v1.resources.Assets
 import fs2.Stream
 import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.dsl._
-import org.apache.spark.sql.sources.{Filter, InsertableRelation}
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Row, SQLContext}
 
 import java.time.Instant
+import scala.annotation.unused
 
 class AssetsRelation(config: RelationConfig, subtreeIds: Option[List[CogniteId]] = None)(
     val sqlContext: SQLContext)
-    extends SdkV1Relation[AssetsReadSchema, Long](config, "assets")
-    with InsertableRelation
+    extends SdkV1InsertableRelation[AssetsReadSchema, Long](config, "assets")
     with WritableRelation {
   import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
 
@@ -98,7 +98,7 @@ class AssetsRelation(config: RelationConfig, subtreeIds: Option[List[CogniteId]]
     )
   }
 
-  override def getFromRowsAndCreate(rows: Seq[Row], doUpsert: Boolean = true): IO[Unit] = {
+  override def getFromRowsAndCreate(rows: Seq[Row], @unused doUpsert: Boolean = true): IO[Unit] = {
     val assetsUpserts = rows.map(fromRow[AssetsUpsertSchema](_))
     val assets = assetsUpserts.map(_.transformInto[AssetCreate])
     createOrUpdateByExternalId[Asset, AssetUpdate, AssetCreate, AssetCreate, Option, Assets[IO]](

--- a/src/main/scala/cognite/spark/v1/CdfRelation.scala
+++ b/src/main/scala/cognite/spark/v1/CdfRelation.scala
@@ -8,9 +8,10 @@ import io.scalaland.chimney.Transformer
 import org.apache.spark.datasource.MetricsSource
 import org.apache.spark.sql.sources.BaseRelation
 
-abstract class CdfRelation(config: RelationConfig, shortName: String)
+abstract class CdfRelation(config: RelationConfig, shortNameStr: String)
     extends BaseRelation
     with Serializable {
+  protected val shortName: String = shortNameStr
   @transient lazy protected val itemsRead: Counter =
     MetricsSource.getOrCreateCounter(config.metricsPrefix, s"$shortName.read")
   @transient lazy protected val itemsCreated: Counter =

--- a/src/main/scala/cognite/spark/v1/DataSetsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/DataSetsRelation.scala
@@ -7,7 +7,7 @@ import com.cognite.sdk.scala.common.WithId
 import com.cognite.sdk.scala.v1.resources.DataSets
 import com.cognite.sdk.scala.v1.{DataSet, DataSetCreate, DataSetFilter, DataSetUpdate, GenericClient}
 import io.scalaland.chimney.Transformer
-import org.apache.spark.sql.sources.{Filter, InsertableRelation}
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{DataTypes, StructType}
 import org.apache.spark.sql.{Row, SQLContext}
 
@@ -15,7 +15,6 @@ import java.time.Instant
 
 class DataSetsRelation(config: RelationConfig)(val sqlContext: SQLContext)
     extends SdkV1Relation[DataSet, String](config, "datasets")
-    with InsertableRelation
     with WritableRelation {
 
   import cognite.spark.compiletime.macros.StructTypeEncoderMacro._

--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -289,15 +289,15 @@ class DefaultSource
         val maxParallelism = Math.max(1, config.partitions / numberOfPartitions)
         val batches = Stream.fromIterator[IO](rows, chunkSize = batchSize).chunks
 
-        val operation = config.onConflict match {
+        val operation: Seq[Row] => IO[Unit] = config.onConflict match {
           case OnConflictOption.Abort =>
-            relation.insert(_)
+            relation.insert
           case OnConflictOption.Upsert =>
-            relation.upsert(_)
+            relation.upsert
           case OnConflictOption.Update =>
-            relation.update(_)
+            relation.update
           case OnConflictOption.Delete =>
-            relation.delete(_)
+            relation.delete
         }
 
         batches

--- a/src/main/scala/cognite/spark/v1/EventsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/EventsRelation.scala
@@ -7,15 +7,15 @@ import com.cognite.sdk.scala.common.{WithExternalIdGeneric, WithId}
 import com.cognite.sdk.scala.v1._
 import com.cognite.sdk.scala.v1.resources.Events
 import fs2.Stream
-import org.apache.spark.sql.sources.{Filter, InsertableRelation}
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{DataTypes, StructType}
 import org.apache.spark.sql.{Row, SQLContext}
 
 import java.time.Instant
+import scala.annotation.unused
 
 class EventsRelation(config: RelationConfig)(val sqlContext: SQLContext)
-    extends SdkV1Relation[Event, Long](config, "events")
-    with InsertableRelation
+    extends SdkV1InsertableRelation[Event, Long](config, "events")
     with WritableRelation {
   import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
   override def getStreams(sparkFilters: Array[Filter])(
@@ -73,7 +73,7 @@ class EventsRelation(config: RelationConfig)(val sqlContext: SQLContext)
       client.events)
   }
 
-  override def getFromRowsAndCreate(rows: Seq[Row], doUpsert: Boolean = true): IO[Unit] = {
+  override def getFromRowsAndCreate(rows: Seq[Row], @unused doUpsert: Boolean = true): IO[Unit] = {
     val events = rows.map(fromRow[EventCreate](_))
 
     createOrUpdateByExternalId[Event, EventUpdate, EventCreate, EventCreate, Option, Events[IO]](

--- a/src/main/scala/cognite/spark/v1/FilesRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FilesRelation.scala
@@ -16,15 +16,14 @@ import com.cognite.sdk.scala.v1.{
 import fs2.Stream
 import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.dsl._
-import org.apache.spark.sql.sources.{Filter, InsertableRelation}
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Row, SQLContext}
 
 import java.time.Instant
 
 class FilesRelation(config: RelationConfig)(val sqlContext: SQLContext)
-    extends SdkV1Relation[FilesReadSchema, Long](config, "files")
-    with InsertableRelation
+    extends SdkV1InsertableRelation[FilesReadSchema, Long](config, "files")
     with WritableRelation {
   import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
   override def getFromRowsAndCreate(rows: Seq[Row], doUpsert: Boolean = true): IO[Unit] = {

--- a/src/main/scala/cognite/spark/v1/LabelsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/LabelsRelation.scala
@@ -3,7 +3,7 @@ package cognite.spark.v1
 import cats.effect.IO
 import cognite.spark.compiletime.macros.SparkSchemaHelper._
 import com.cognite.sdk.scala.v1.{GenericClient, Label, LabelCreate, LabelsFilter}
-import org.apache.spark.sql.sources.{Filter, InsertableRelation}
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Row, SQLContext}
 
@@ -11,7 +11,6 @@ import java.time.Instant
 
 class LabelsRelation(config: RelationConfig)(val sqlContext: SQLContext)
     extends SdkV1Relation[Label, String](config, "labels")
-    with InsertableRelation
     with WritableRelation {
   import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
   override def schema: StructType = structType[Label]()

--- a/src/main/scala/cognite/spark/v1/RelationshipsRelation.scala
+++ b/src/main/scala/cognite/spark/v1/RelationshipsRelation.scala
@@ -9,7 +9,7 @@ import com.cognite.sdk.scala.v1._
 import com.cognite.sdk.scala.v1.resources.Relationships
 import fs2.Stream
 import io.scalaland.chimney.Transformer
-import org.apache.spark.sql.sources.{Filter, InsertableRelation}
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Row, SQLContext}
 
@@ -17,7 +17,6 @@ import java.time.Instant
 
 class RelationshipsRelation(config: RelationConfig)(val sqlContext: SQLContext)
     extends SdkV1Relation[RelationshipsReadSchema, String](config, "relationships")
-    with InsertableRelation
     with WritableRelation {
   import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
   override def schema: StructType = structType[RelationshipsReadSchema]()
@@ -137,7 +136,6 @@ class RelationshipsRelation(config: RelationConfig)(val sqlContext: SQLContext)
       case (_, None) => Some(ConfidenceRange(min = Some(minConfidence.get.toDouble), max = None))
       case _ => Some(ConfidenceRange(min = None, max = Some(maxConfidence.get.toDouble)))
     }
-
 }
 
 object RelationshipsRelation {

--- a/src/main/scala/cognite/spark/v1/SdkV1InsertableRelation.scala
+++ b/src/main/scala/cognite/spark/v1/SdkV1InsertableRelation.scala
@@ -1,0 +1,26 @@
+package cognite.spark.v1
+
+import cats.effect.IO
+import cats.implicits._
+import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.sources.InsertableRelation
+
+import scala.annotation.unused
+
+abstract class SdkV1InsertableRelation[A <: Product, I](config: RelationConfig, shortName: String)
+    extends SdkV1Relation[A, I](config, shortName)
+    with Serializable
+    with InsertableRelation {
+  def getFromRowsAndCreate(rows: Seq[Row], doUpsert: Boolean = true): IO[Unit]
+
+  override def insert(data: DataFrame, @unused overwrite: Boolean): Unit =
+    data.foreachPartition((rows: Iterator[Row]) => {
+      import CdpConnector._
+      val batches =
+        rows.grouped(config.batchSize.getOrElse(cognite.spark.v1.Constants.DefaultBatchSize)).toVector
+      batches
+        .parTraverse_(getFromRowsAndCreate(_))
+        .unsafeRunSync()
+    })
+
+}

--- a/src/main/scala/cognite/spark/v1/SequencesRelation.scala
+++ b/src/main/scala/cognite/spark/v1/SequencesRelation.scala
@@ -10,16 +10,17 @@ import com.cognite.sdk.scala.v1.resources.SequencesResource
 import fs2.Stream
 import io.scalaland.chimney.Transformer
 import io.scalaland.chimney.dsl._
-import org.apache.spark.sql.sources.{Filter, InsertableRelation}
+import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{DataTypes, StructType}
 import org.apache.spark.sql.{Row, SQLContext}
-import java.time.Instant
 
+import java.time.Instant
 import cognite.spark.v1.CdpConnector.ioRuntime
 
+import scala.annotation.unused
+
 class SequencesRelation(config: RelationConfig)(val sqlContext: SQLContext)
-    extends SdkV1Relation[SequenceReadSchema, Long](config, "sequences")
-    with InsertableRelation
+    extends SdkV1InsertableRelation[SequenceReadSchema, Long](config, "sequences")
     with WritableRelation {
   import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
   override def getStreams(filters: Array[Filter])(
@@ -187,7 +188,7 @@ class SequencesRelation(config: RelationConfig)(val sqlContext: SQLContext)
   }
 
   // scalastyle:off method.length
-  override def getFromRowsAndCreate(rows: Seq[Row], doUpsert: Boolean = true): IO[Unit] = {
+  override def getFromRowsAndCreate(rows: Seq[Row], @unused doUpsert: Boolean = true): IO[Unit] = {
     val sequences =
       rows
         .map(fromRow[SequenceUpsertSchema](_))

--- a/src/main/scala/cognite/spark/v1/TimeSeriesRelation.scala
+++ b/src/main/scala/cognite/spark/v1/TimeSeriesRelation.scala
@@ -15,9 +15,8 @@ import org.apache.spark.sql.{Row, SQLContext}
 import java.time.Instant
 
 class TimeSeriesRelation(config: RelationConfig)(val sqlContext: SQLContext)
-    extends SdkV1Relation[TimeSeries, Long](config, "timeseries")
-    with WritableRelation
-    with InsertableRelation {
+    extends SdkV1InsertableRelation[TimeSeries, Long](config, "timeseries")
+    with WritableRelation {
   import cognite.spark.compiletime.macros.StructTypeEncoderMacro._
   override def insert(rows: Seq[Row]): IO[Unit] =
     getFromRowsAndCreate(rows, doUpsert = false)


### PR DESCRIPTION
OOP overrides hell consequences.
- `SdkV1Relation` was defining an `insert(data, overwrite)` method
  but didn't extend spark's `InsertableRelation`
- `SdkV1Relation` was defining a by-default-throwing `getFromRowsAndCreate`
  that is used by `insert` method above
- some subclasses were defining `getFromRowsAndCreate` and extending
  `InsertableRelation` which would pick up `insert` method in a side-channel
  manner from `SdkV1Relation` (no direct and simple way to see that that
  `insert` was actually meant for `InsertableRelation`)

Let's move insertable part to a dedicated subclass which doesn't have unsafe
fallback and does inherit-override the insert method.

This will remove `InsertableRelation` interface from some of classes,
but only from those that were throwing on using it anyway.

TODO for later:
- relation between `SdkV1InsertableRelation.insert` vs `WritableRelation.insert`
- ignored `overwrite/doUpdate` paramater in some of implementations
