### PR TITLE
CDF-19461: tune per-resource metric name

### DIFF
--- a/src/main/scala/cognite/spark/v1/CdpConnector.scala
+++ b/src/main/scala/cognite/spark/v1/CdpConnector.scala
@@ -95,7 +95,7 @@ object CdpConnector {
                 incMetrics(metricsPrefix, "", maybeStatus) *>
                   tags
                     .get(GenericClient.RESOURCE_TYPE_TAG)
-                    .map(service => incMetrics(metricsPrefix, service.toString, maybeStatus))
+                    .map(service => incMetrics(metricsPrefix, s"${service.toString}.", maybeStatus))
                     .getOrElse(IO.unit)
             }
         ))


### PR DESCRIPTION
Add "." to render not as `SEQUENCESrequests` but as `SEQUENCES.requests`

[CDF-19461]