### PR TITLE
Fix too strict pattern match on dms view references

### DIFF
--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelRelationFactory.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelRelationFactory.scala
@@ -6,6 +6,7 @@ import cats.implicits._
 import com.cognite.sdk.scala.v1.GenericClient
 import com.cognite.sdk.scala.v1.fdm.common.{DataModelReference, Usage}
 import com.cognite.sdk.scala.v1.fdm.common.properties.PropertyDefinition.ConnectionDefinition
+import com.cognite.sdk.scala.v1.fdm.datamodels.DataModelViewReference
 import com.cognite.sdk.scala.v1.fdm.views.{ViewDefinition, ViewReference}
 import org.apache.spark.sql.SQLContext
 
@@ -86,7 +87,7 @@ object FlexibleDataModelRelationFactory {
         case _ => IO.pure(None)
       }
       .flatMap {
-        case Some(vc: ViewDefinition) =>
+        case Some(vc: DataModelViewReference) =>
           IO.delay(
             new FlexibleDataModelCorePropertyRelation(
               config,


### PR DESCRIPTION
Not sure why there's no warning in current setup but in another draft PR
it starts to complain that the patterns aren't exhaustive.
And they aren't, looking at previous .flatMap outputs.

Let's fix the expected type, semantically base type of reference seems
to fit&compile
