### PR TITLE
CDF-19653: make EventsRelationTest less flaky

### DIFF
--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -21,7 +21,6 @@ import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row, SQLContext, SaveMode}
 import sttp.model.Uri
-import scala.reflect.classTag
 
 import scala.reflect.classTag
 

--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row, SQLContext, SaveMode}
 import sttp.model.Uri
+import scala.reflect.classTag
 
 class DefaultSource
     extends RelationProvider
@@ -292,6 +293,7 @@ class DefaultSource
 }
 
 object DefaultSource {
+  val sparkFormatString: String = classTag[DefaultSource].runtimeClass.getCanonicalName
 
   private def toBoolean(
       parameters: Map[String, String],

--- a/src/main/scala/cognite/spark/v1/PushdownUtilities.scala
+++ b/src/main/scala/cognite/spark/v1/PushdownUtilities.scala
@@ -121,10 +121,12 @@ object PushdownUtilities {
           "Unexpected error, seems that Spark query optimizer is misbehaving. Please contact support@cognite.com and tell them.")
       case EqualTo(colName, value) => PushdownFilter(colName, toStr(value))
       case EqualNullSafe(colName, value) => PushdownFilter(colName, toStr(value))
+      // TODO: GreaterThan -> min conversion broadens the condition here
       case GreaterThan(colName, value) =>
         PushdownFilter("min" + colName.capitalize, toStr(value))
       case GreaterThanOrEqual(colName, value) =>
         PushdownFilter("min" + colName.capitalize, toStr(value))
+      // TODO: LessThan -> max conversion broadens the condition here
       case LessThan(colName, value) =>
         PushdownFilter("max" + colName.capitalize, toStr(value))
       case LessThanOrEqual(colName, value) =>

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -250,6 +250,11 @@ trait SparkTest {
       rawEnsureParent = false
     )
 
+  private def getCounterSafe(metricName: String): Option[Long] =
+    Option(MetricsSource.metricsMap
+      .get(metricName))
+      .map(_.value.getCount)
+
   private def getCounter(metricName: String): Long =
     MetricsSource.metricsMap
       .get(metricName)
@@ -258,6 +263,9 @@ trait SparkTest {
 
   def getNumberOfRowsRead(metricsPrefix: String, resourceType: String): Long =
     getCounter(s"$metricsPrefix.$resourceType.read")
+
+  def getNumberOfRowsReadSafe(metricsPrefix: String, resourceType: String): Option[Long] =
+    getCounterSafe(s"$metricsPrefix.$resourceType.read")
 
   def getNumberOfRowsCreated(metricsPrefix: String, resourceType: String): Long =
     getCounter(s"$metricsPrefix.$resourceType.created")


### PR DESCRIPTION
Substaintial rewrite of EventsRelationTest but it should
preserve most of its meaning.
    
- explicitly create all items used by test
- introduce extra helper methods and checks
- use randomized event.source for test scope isolation
- un-ignore ignored tests
- some tests may change slightly but intent is to keep
  scenarios approximately the same
    
Extra notes:
- PushdownUtilities convert `> x` to `min(x)` aka `>= x` which
  should ideally be changed to `min(succ(x))` but for later.
  It seems that it doesn't lead to wrong results currently,
  we pushdown broader than needed condition down but afterwards
  spark still applies original exact filter
- adding SparkTest safe counter access which has fallback from
  missing metric to 0 which is useful for retry conditions in tests
  which shouldn't throw if missing metric is a valid scenario part
  and it will appear at subsequent tries.
  In some tests it's still useful to assert that metric exists
  even if it is expected to be 0, so opt-in for now.

[CDF-19653]


[CDF-19653]: https://cognitedata.atlassian.net/browse/CDF-19653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ