### PR TITLE
CDF-20103: make RawTableRelationTest less flaky

### DIFF
--- a/src/test/scala/cognite/spark/v1/RawTableRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/RawTableRelationTest.scala
@@ -1,7 +1,7 @@
 package cognite.spark.v1
 
 import cats.effect.IO
-import cats.implicits.toTraverseOps
+import cats.implicits._
 import cognite.spark.v1.CdpConnector.ioRuntime
 import com.cognite.sdk.scala.common.CdpApiException
 import com.cognite.sdk.scala.v1.{RawDatabase, RawRow, RawTable}
@@ -155,7 +155,7 @@ class RawTableRelationTest
           "sourceId" -> s"test id $i",
           "subtype" -> "past",
           "type" -> "test type"
-        ).mapValues(Json.fromString))
+        ).map { case (k, v) => (k, Json.fromString(v)) })
       })),
       TestTable("bigTable", (1 to 1000).map(i =>
         RawRow(i.toString, Map("i" -> Json.fromString("exist")))

--- a/src/test/scala/cognite/spark/v1/RawTableRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/RawTableRelationTest.scala
@@ -1,5 +1,7 @@
 package cognite.spark.v1
 
+import cats.effect.IO
+import cats.implicits.toTraverseOps
 import cognite.spark.v1.CdpConnector.ioRuntime
 import com.cognite.sdk.scala.common.CdpApiException
 import com.cognite.sdk.scala.v1.{RawDatabase, RawRow, RawTable}
@@ -10,7 +12,17 @@ import org.apache.spark.sql.types._
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, LoneElement, Matchers, ParallelTestExecution}
 
 import java.lang.{Long => JavaLong}
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, LocalDateTime, ZoneId}
+import java.util.UUID
 import scala.reflect.ClassTag
+
+object RawTableRelationTest {
+  // With ParallelTestExecution it's not trivial to have before/after hooks
+  // do the shared setup as each thread gets own test class instance
+  // Namely we should have shared random part, quick hack it to put it statically here
+  val randomDbNameForTests = s"spark-test-database-${UUID.randomUUID().toString.substring(0, 8)}"
+}
 
 class RawTableRelationTest
     extends FlatSpec
@@ -106,34 +118,81 @@ class RawTableRelationTest
     RawRow("k3", Map("bool" -> Json.fromBoolean(false)))
   )
 
-  override def beforeAll(): Unit = {
-    val db = "spark-test-database"
-    val tables = Seq(
-      ("without-key", dataWithoutKey),
-      ("with-key", dataWithKey),
-      ("with-many-keys", dataWithManyKeys),
-      ("without-lastUpdatedTime", dataWithoutlastUpdatedTime),
-      ("with-lastUpdatedTime", dataWithlastUpdatedTime),
-      ("with-many-lastUpdatedTime", dataWithManylastUpdatedTime),
-      ("with-nesting", dataWithSimpleNestedStruct),
-      ("with-byte-empty-str", dataWithEmptyStringInByteField),
-      ("with-short-empty-str", dataWithEmptyStringInShortField),
-      ("with-integer-empty-str", dataWithEmptyStringInIntegerField),
-      ("with-long-empty-str", dataWithEmptyStringInLongField),
-      ("with-number-empty-str", dataWithEmptyStringInDoubleField),
-      ("with-boolean-empty-str", dataWithEmptyStringInBooleanField)
-    )
-    if (!writeClient.rawDatabases.list().compile.toVector.unsafeRunSync().exists(_.name == db)) {
-      writeClient.rawDatabases.createOne(RawDatabase(db)).unsafeRunSync()
-    }
-    writeClient.rawTables(db).list().compile.toVector.unsafeRunSync().map(_.name).foreach {
-      writeClient.rawTables(db).deleteById(_).unsafeRunSync()
-    }
-    writeClient.rawTables(db).create(tables.map(t => RawTable(t._1))).unsafeRunSync()
+  case class TestTable(name: String, data: Seq[RawRow])
+  case class TestData(dbName: String, tables: Seq[TestTable])
 
-    for ((n, data) <- tables) {
-      writeClient.rawRows(db, n).create(data).unsafeRunSync()
-    }
+  private val testData = TestData(
+    dbName = RawTableRelationTest.randomDbNameForTests,
+    tables = Seq(
+      TestTable("without-key", dataWithoutKey),
+      TestTable("with-key", dataWithKey),
+      TestTable("with-many-keys", dataWithManyKeys),
+      TestTable("without-lastUpdatedTime", dataWithoutlastUpdatedTime),
+      TestTable("with-lastUpdatedTime", dataWithlastUpdatedTime),
+      TestTable("with-many-lastUpdatedTime", dataWithManylastUpdatedTime),
+      TestTable("with-nesting", dataWithSimpleNestedStruct),
+      TestTable("with-byte-empty-str", dataWithEmptyStringInByteField),
+      TestTable("with-short-empty-str", dataWithEmptyStringInShortField),
+      TestTable("with-integer-empty-str", dataWithEmptyStringInIntegerField),
+      TestTable("with-long-empty-str", dataWithEmptyStringInLongField),
+      TestTable("with-number-empty-str", dataWithEmptyStringInDoubleField),
+      TestTable("with-boolean-empty-str", dataWithEmptyStringInBooleanField),
+      TestTable("cryptoAssets", (1 to 500).map(i =>
+        RawRow(i.toString, Map("i" -> Json.fromString("exist")))
+      )),
+      TestTable("future-event", (1 to 100).map(i => {
+        val time = if (i >= 20 && i < 30) {
+            Instant.from(DateTimeFormatter.ISO_INSTANT.parse("2019-06-21T11:48:01.000Z")).atZone(ZoneId.of("UTC"))
+          } else {
+            LocalDateTime.now().atZone(ZoneId.of("UTC"))
+          }
+        RawRow(i.toString, Map(
+          "key" -> i.toString,
+          "startTime" -> s"${time.plusDays(1).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)}",
+          "endTime" -> s"${time.plusDays(2).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)}",
+          "description" -> s"event $i",
+          "source" -> "generator",
+          "sourceId" -> s"test id $i",
+          "subtype" -> "past",
+          "type" -> "test type"
+        ).mapValues(Json.fromString))
+      })),
+      TestTable("bigTable", (1 to 1000).map(i =>
+        RawRow(i.toString, Map("i" -> Json.fromString("exist")))
+      )),
+      TestTable("raw-write-test", Seq.empty), // used for writes
+      TestTable("MegaColumnTable", Seq(
+        RawRow("rowkey", (1 to 384).map(i =>
+          (i.toString -> Json.fromString("value"))).toMap
+        )
+      )),
+      TestTable("MegaColumnTableDuplicate", Seq(
+        RawRow("rowkey", (1 to 384).map(i =>
+          (i.toString -> Json.fromString("value"))).toMap
+        )
+      )),
+      TestTable("MegaColumnTableDuplicate2", Seq.empty) // used for writes
+    )
+  )
+
+  def createTestData: IO[Unit] = for {
+    _ <- writeClient.rawDatabases.createOne(RawDatabase(testData.dbName))
+    _ <- writeClient.rawTables(testData.dbName).create(testData.tables.map(_.name).map(RawTable))
+    _ <- testData.tables.filterNot(_.data.isEmpty).toList.traverse(t =>
+      writeClient.rawRows(testData.dbName, t.name).create(t.data))
+  } yield ()
+
+  def cleanupTestData: IO[Unit] = for {
+    _ <- writeClient.rawTables(testData.dbName).deleteByIds(testData.tables.map(_.name))
+    _ <- writeClient.rawDatabases.deleteById(testData.dbName)
+  } yield ()
+
+  override def beforeAll(): Unit = {
+    createTestData.unsafeRunSync()
+  }
+
+  override def afterAll(): Unit = {
+    cleanupTestData.unsafeRunSync()
   }
 
   lazy private val dfWithoutKey = rawRead("without-key")
@@ -154,18 +213,18 @@ class RawTableRelationTest
   lazy private val dfWithEmptyStringInBooleanField = rawRead("with-boolean-empty-str")
 
   it should "smoke test raw" taggedAs WriteTest in {
-    val limit = 100L
-    val partitions = 10L
+    val limit = 7L
+    val partitions = 1L
     val df = spark.read
       .format(DefaultSource.sparkFormatString)
       .useOIDCWrite
       .option("type", "raw")
       .option("limitPerPartition", limit)
       .option("partitions", partitions)
-      .option("database", "testdb")
+      .option("database", testData.dbName)
       .option("table", "cryptoAssets")
       .option("inferSchema", "true")
-      .option("inferSchemaLimit", "100")
+      .option("inferSchemaLimit", "7")
       .load()
     df.createTempView("raw")
     val res = spark.sqlContext
@@ -330,7 +389,7 @@ class RawTableRelationTest
 
   "Infer Schema" should "use a different limit for infer schema" in {
     val metricsPrefix = "infer_schema_1"
-    val database = "testdb"
+    val database = testData.dbName
     val table = "future-event"
     val inferSchemaLimit = 1L
     val partitions = 10L
@@ -361,7 +420,7 @@ class RawTableRelationTest
       .format(DefaultSource.sparkFormatString)
       .useOIDCWrite
       .option("type", "raw")
-      .option("database", "testdb")
+      .option("database", testData.dbName)
       .option("table", "raw-write-test")
       .option("inferSchema", false)
       .load()
@@ -383,12 +442,26 @@ class RawTableRelationTest
       .format(DefaultSource.sparkFormatString)
       .useOIDCWrite
       .option("type", "raw")
-      .option("database", "testdb")
+      .option("database", testData.dbName)
       .option("table", "future-event")
       .option("inferSchema", true)
       .option("partitions", "5")
       .load()
-      .where(s"lastUpdatedTime >= timestamp('2019-06-21 11:48:00.000Z') and lastUpdatedTime <= timestamp('2019-06-21 11:50:00.000Z')")
+      .where(s"lastUpdatedTime >= timestamp('2019-06-21 11:48:00.000Z')")
+    assert(df.count() == 100)
+  }
+
+  it should "test that startTime filters are handled correctly" taggedAs (ReadTest) in {
+    val df = spark.read
+      .format(DefaultSource.sparkFormatString)
+      .useOIDCWrite
+      .option("type", "raw")
+      .option("database", testData.dbName)
+      .option("table", "future-event")
+      .option("inferSchema", true)
+      .option("partitions", "5")
+      .load()
+      .where(s"startTime >= timestamp('2019-06-22 11:48:00.000Z') and startTime <= timestamp('2019-06-22 11:50:00.000Z')")
     assert(df.count() == 10)
   }
 
@@ -396,7 +469,7 @@ class RawTableRelationTest
     val shortRand = shortRandomString()
     val metricsPrefix = s"partitionSizeTest$shortRand"
     val tablename = "bigTable"
-    val resourceType = s"raw.testdb.$tablename"
+    val resourceType = s"raw.${RawTableRelationTest.randomDbNameForTests}.$tablename"
     val partitions = 10L
 
     val df = spark.read
@@ -405,7 +478,7 @@ class RawTableRelationTest
       .option("type", "raw")
       .option("metricsPrefix", metricsPrefix)
       .option("partitions", partitions)
-      .option("database", "testdb")
+      .option("database", testData.dbName)
       .option("table", tablename)
       .option("inferSchema", "true")
       .option("collectTestMetrics", true)
@@ -430,13 +503,13 @@ class RawTableRelationTest
         .format(DefaultSource.sparkFormatString)
         .useOIDCWrite
         .option("type", "raw")
-        .option("database", "testdb")
+        .option("database", testData.dbName)
         .option("table", "future-event")
         .option("inferSchema", true)
         .option("partitions", partitions)
         .load()
-        .where(s"lastUpdatedTime >= timestamp('2019-06-21 11:48:00.000Z') and lastUpdatedTime <= timestamp('2019-06-21 11:50:00.000Z')")
-      assert(df.count() == 10)
+        .where(s"startTime >= timestamp('2019-06-21 11:48:00.000Z')")
+      assert(df.count() == 100)
     }
   }
 
@@ -445,7 +518,7 @@ class RawTableRelationTest
       .format(DefaultSource.sparkFormatString)
       .useOIDCWrite
       .option("type", "raw")
-      .option("database", "testdb")
+      .option("database", testData.dbName)
       .option("table", "future-event")
       .option("inferSchema", true)
       .load()
@@ -459,7 +532,7 @@ class RawTableRelationTest
   }
 
   it should "write nested struct values" in {
-    val database = "testdb"
+    val database = testData.dbName
     val table = "struct-test"
 
     try {
@@ -534,8 +607,8 @@ class RawTableRelationTest
   }
 
   it should "create the table with ensureParent option" in {
-    val database = "testdb"
-    val table = "ensureParent-test-" + shortRandomString()
+    val database = testData.dbName
+    val table = "ensureParent-test"
 
     // remove the DB to be sure
     try {
@@ -580,7 +653,7 @@ class RawTableRelationTest
       .format(DefaultSource.sparkFormatString)
       .useOIDCWrite
       .option("type", "raw")
-      .option("database", "testdb")
+      .option("database", testData.dbName)
       .option("table", "MegaColumnTable")
       .option("inferSchema", "true")
       .option("inferSchemaLimit", "100")
@@ -591,7 +664,7 @@ class RawTableRelationTest
       .schema(source.schema)
       .useOIDCWrite
       .option("type", "raw")
-      .option("database", "testdb")
+      .option("database", testData.dbName)
       .option("table", "MegaColumnTableDuplicate")
       .option("inferSchema", "true")
       .option("inferSchemaLimit", "100")
@@ -611,7 +684,7 @@ class RawTableRelationTest
       .format(DefaultSource.sparkFormatString)
       .useOIDCWrite
       .option("type", "raw")
-      .option("database", "testdb")
+      .option("database", testData.dbName)
       .option("table", "MegaColumnTable")
       .option("inferSchema", "true")
       .option("inferSchemaLimit", "100")
@@ -622,7 +695,7 @@ class RawTableRelationTest
       .schema(source.schema)
       .useOIDCWrite
       .option("type", "raw")
-      .option("database", "testdb")
+      .option("database", testData.dbName)
       .option("table", "MegaColumnTableDuplicate2")
       .option("inferSchema", "true")
       .option("inferSchemaLimit", "100")


### PR DESCRIPTION
Making the test create all the data it expects to exist so that it can be
run in any project.

Small change in behavior is `lastUpdatedTime` range test, ideally we should
be able to test that too, but we don't control the value when ingesting into
raw. So let's for now have slightly weaker test using `lastUpdatedTime(now) >= somewhere in the past`
and more strong test using range of `startTime`. Should be good enough for now,
plus there are other pushdown tests.

[CDF-20103]


[CDF-20103]: https://cognitedata.atlassian.net/browse/CDF-20103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ