### PR TITLE
Remove CMSClassUnloadingEnabled from build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -210,4 +210,4 @@ lazy val fatJarShaded = project
 
 addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1")
 
-javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:+CMSClassUnloadingEnabled")
+javaOptions ++= Seq("-Xms512M", "-Xmx2048M")


### PR DESCRIPTION
Can lead to failure to run `sbt test` on `openjdk-17.0.6+10`
```
Unrecognized VM option 'CMSClassUnloadingEnabled'
```
Looks like it could only be useful for CMS garbage collector and
option got removed in jdk14+ along with CMS collector.
