### PR TITLE
CDF-20827: make FilesRelationTest less flaky

### DIFF
--- a/src/test/scala/cognite/spark/v1/FilesRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/FilesRelationTest.scala
@@ -1,107 +1,174 @@
 package cognite.spark.v1
 
-import cognite.spark.v1.CdpConnector.ioRuntime
+import cats.effect.{IO, Resource}
+import com.cognite.sdk.scala.v1.{File, FileCreate, Label, LabelCreate}
 import io.scalaland.chimney.dsl._
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{DataFrame, DataFrameReader, Row}
 import org.apache.spark.sql.functions.col
 import org.scalatest.{FlatSpec, Matchers, ParallelTestExecution}
 
-import scala.util.control.NonFatal
-
 class FilesRelationTest extends FlatSpec with Matchers with ParallelTestExecution with SparkTest {
-  val sourceDf = dataFrameReaderUsingOidc
-    .option("type", "files")
-    .load()
+  val testSource = s"FilesRelationTest-${shortRandomString()}"
 
-  sourceDf.createOrReplaceTempView("sourceFiles")
+  private def makeDestinationDf(): Resource[IO, (DataFrame, String, String)] = {
+    val targetView = s"destinationFile_${shortRandomString()}"
+    val metricsPrefix = s"test.${shortRandomString()}"
+    Resource.make {
+      IO.blocking {
+        val destinationDf: DataFrame = spark.read
+          .format(DefaultSource.sparkFormatString)
+          .useOIDCWrite
+          .option("type", "files")
+          .option("collectMetrics", "true")
+          .option("metricsPrefix", metricsPrefix)
+          .load()
+        destinationDf.createOrReplaceTempView(targetView)
+        (destinationDf, targetView, metricsPrefix)
+      }
+    } {
+      case (_, targetView, _) => IO.blocking {
+        spark
+          .sql(s"""select * from ${targetView} where source = '${testSource}'""")
+          .write
+          .format(DefaultSource.sparkFormatString)
+          .useOIDCWrite
+          .option("type", "files")
+          .option("onconflict", "delete")
+          .save()
+      }
+    }
+  }
 
-  val destinationDf = spark.read
-    .format(DefaultSource.sparkFormatString)
-    .useOIDCWrite
-    .option("type", "files")
-    .load()
+  private def runIOTest[A](test: Resource[IO, A]): Unit =
+    test.use(_ => IO.unit).unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
-  destinationDf.createOrReplaceTempView("destinationFiles")
+  private def makeLabels(externalIds: Seq[String]): Resource[IO, Seq[Label]] = {
+    Resource.make {
+      writeClient.labels.create(externalIds.map(externalId => LabelCreate(
+        description = Some("cdp-spark-connector FilesRelationTest"),
+        name = "for tests",
+        externalId = externalId,
+        dataSetId = None)))
+    } { _ => writeClient.labels.deleteByExternalIds(externalIds) }
+  }
+
+  private def makeFiles(toCreate: Seq[FileCreate]): Resource[IO, Seq[File]] = {
+    assert(toCreate.forall(_.source.isEmpty), "file.source is reserved for test setup")
+    Resource.make {
+      writeClient.files.create(toCreate.map(_.copy(source = Some(testSource))))
+    } { createdFiles => writeClient.files.deleteByIds(createdFiles.map(_.id)) }
+      .evalTap(createdFiles => IO.delay({
+        assert(createdFiles.length == toCreate.length, "all files should be created")
+        assert(createdFiles.forall(_.source.contains(testSource)), "all created files have source")
+      }))
+  }
+
+  private def getDfReader(): DataFrameReader =
+    spark.read
+      .format(DefaultSource.sparkFormatString)
+      .option("type", "files")
+      .useOIDCWrite
+
 
   "FilesRelation" should "read files" taggedAs ReadTest in {
-    val res = spark.sqlContext
-      .sql("select * from sourceFiles")
-      .collect()
-    assert(res.length == 18)
+    runIOTest(for {
+      _ <- makeFiles(Seq.fill(4)(FileCreate(name = "file")))
+      sourceView = s"sourceFiles_${shortRandomString()}"
+      sourceDf = getDfReader().load()
+      _ = sourceDf.createOrReplaceTempView(sourceView)
+      res <- Resource.eval(retryWhileIO[Array[Row]](IO.blocking {
+         spark.sqlContext
+          .sql(s"select * from ${sourceView} where source = '${testSource}'")
+          .collect()
+      }, _.length < 4))
+      _ = assert(res.length == 4)
+    } yield ())
   }
 
   it should "respect the limit option" taggedAs ReadTest in {
-    val df = dataFrameReaderUsingOidc
-      .option("type", "files")
-      .option("limitPerPartition", "5")
-      .option("partitions", "1")
-      .load()
-
-    assert(df.count() == 5)
+    runIOTest(for {
+      _ <- makeFiles(Seq.fill(10)(FileCreate(name = "file")))
+      res <- Resource.eval(retryWhileIO[Array[Row]](IO.blocking {
+        val df = getDfReader()
+          .option("limitPerPartition", "5")
+          .option("partitions", "1")
+          .load()
+        val view = s"files_${shortRandomString()}"
+        df.createTempView(view)
+        spark.sqlContext
+          .sql(s"select * from ${view} where source = '$testSource'")
+          .collect()
+      }, _.length < 5))
+      _ = assert(res.length == 5)
+    } yield ())
   }
 
   it should "use cursors when necessary" taggedAs ReadTest in {
-    val df = dataFrameReaderUsingOidc
-      .option("type", "files")
-      .option("batchSize", "2")
-      .load()
-
-    assert(df.count() >= 11)
+    runIOTest(for {
+      _ <- makeFiles(Seq.fill(10)(FileCreate(name = "file")))
+      res <- Resource.eval(retryWhileIO[Array[Row]](IO.blocking {
+        val df = getDfReader()
+          .option("batchSize", "2")
+          .load()
+        val view = s"files_${shortRandomString()}"
+        df.createTempView(view)
+        spark.sqlContext
+          .sql(s"select * from ${view} where source = '$testSource'")
+          .collect()
+      }, _.length < 10))
+      _ = assert(res.length == 10)
+    } yield ())
   }
 
   it should "support creating files using insertInto" taggedAs WriteTest in {
-    val source = s"create-using-insertInto-${shortRandomString()}"
-
-    try {
-      spark
-        .sql(s"""
-                |select "name-$source" as name,
-                |null as id,
-                |null as directory,
-                |'$source' as source,
-                |'externalId-$source' as externalId,
-                |null as mimeType,
-                |null as metadata,
-                |null as assetIds,
-                |null as datasetId,
-                |null as sourceCreatedTime,
-                |null as sourceModifiedTime,
-                |null as securityCategories,
-                |array('scala-sdk-relationships-test-label1', 'scala-sdk-relationships-test-label2') as labels,
-                |null as uploaded,
-                |null as createdTime,
-                |null as lastUpdatedTime,
-                |null as uploadedTime,
-                |null as uploadUrl
+    runIOTest(for {
+      _ <- makeLabels(Seq(s"test-label-1-${testSource}", s"test-label-2-${testSource}"))
+      (_, targetView, _) <- makeDestinationDf()
+      sourceDf = dataFrameReaderUsingOidc
+        .option("type", "files")
+        .load()
+      _ = spark
+        .sql(
+          s"""
+             |select "name-$testSource" as name,
+             |null as id,
+             |null as directory,
+             |'$testSource' as source,
+             |'externalId-$testSource' as externalId,
+             |null as mimeType,
+             |null as metadata,
+             |null as assetIds,
+             |null as datasetId,
+             |null as sourceCreatedTime,
+             |null as sourceModifiedTime,
+             |null as securityCategories,
+             |array('test-label-1-${testSource}', 'test-label-2-${testSource}') as labels,
+             |null as uploaded,
+             |null as createdTime,
+             |null as lastUpdatedTime,
+             |null as uploadedTime,
+             |null as uploadUrl
      """.stripMargin)
         .select(sourceDf.columns.map(col).toIndexedSeq: _*)
         .write
-        .insertInto("destinationFiles")
-
-      val rows = retryWhile[Array[Row]](
-        spark.sql(s"select * from destinationFiles where source = '$source'").collect(),
+        .insertInto(targetView)
+      rows = retryWhile[Array[Row]](
+        spark.sql(s"select * from $targetView where source = '$testSource'").collect(),
         rows => rows.length < 1)
-      assert(rows.length == 1)
-    } finally {
-      try {
-        cleanupFiles(source)
-      } catch {
-        case NonFatal(_) => // ignore
-      }
-    }
+      _ = assert (rows.length == 1)
+    } yield ())
   }
 
   it should "support updates using id and externalId" taggedAs WriteTest in {
-    val source = s"update-${shortRandomString()}"
-    val metricsPrefix = "updates.files"
-
-    try {
-      spark
-        .sql(s"""
-                |select "name-$source" as name,
-                |null as id,
-                |'$source' as source,
-                |'externalId-$source' as externalId
+    runIOTest(for {
+      (_, targetView, metricsPrefix) <- makeDestinationDf()
+      _ = spark
+        .sql(
+          s"""
+             |select "name-$testSource" as name,
+             |null as id,
+             |'$testSource' as source,
+             |'externalId-$testSource' as externalId
      """.stripMargin)
         .write
         .format(DefaultSource.sparkFormatString)
@@ -110,115 +177,98 @@ class FilesRelationTest extends FlatSpec with Matchers with ParallelTestExecutio
         .option("collectMetrics", "true")
         .option("metricsPrefix", metricsPrefix)
         .save()
-
-      val rows = retryWhile[Array[Row]](
-        spark.sql(s"""select * from destinationFiles where source = "$source"""").collect(),
+      rows = retryWhile[Array[Row]](
+        spark.sql(s"""select * from ${targetView} where source = "$testSource"""").collect(),
         rows => rows.length < 1)
-      assert(rows.length == 1)
-
-      assert(getNumberOfRowsCreated(metricsPrefix, "files") == 1)
-
-      val id = writeClient.files.retrieveByExternalId(s"externalId-$source").unsafeRunSync().id
-
+      _ = assert (rows.length == 1)
+      _ = assert(getNumberOfRowsCreated(metricsPrefix, "files") == 1)
+      id <- Resource.eval(writeClient.files.retrieveByExternalId(s"externalId-$testSource")).map(_.id)
       //Update using id
-      spark
-        .sql(s"""
-                |select ${id.toString} as id,
-                |'$source' as source,
-                |'updatedById-externalId-$source' as externalId
-     """.stripMargin)
-        .write
-        .format(DefaultSource.sparkFormatString)
-        .useOIDCWrite
-        .option("type", "files")
-        .option("onconflict", "update")
-        .option("collectMetrics", "true")
-        .option("metricsPrefix", metricsPrefix)
-        .save()
-
-      assert(getNumberOfRowsCreated(metricsPrefix, "files") == 1)
-      assert(getNumberOfRowsUpdated(metricsPrefix, "files") == 1)
-
-      val updatedById =
+      _ = spark
+    .sql(s"""
+            |select ${id.toString} as id,
+            |'$testSource' as source,
+            |'updatedById-externalId-$testSource' as externalId
+      """.stripMargin)
+          .write
+            .format(DefaultSource.sparkFormatString)
+          .useOIDCWrite
+            .option("type", "files")
+          .option("onconflict", "update")
+          .option("collectMetrics", "true")
+          .option("metricsPrefix", metricsPrefix)
+          .save()
+      _ = assert (getNumberOfRowsCreated(metricsPrefix, "files") == 1)
+      _ = assert (getNumberOfRowsUpdated(metricsPrefix, "files") == 1)
+      updatedById =
         retryWhile[Array[Row]](
           spark
-            .sql(s"select * from destinationFiles where externalId = 'updatedById-externalId-$source'")
+            .sql(s"select * from ${targetView} where externalId = 'updatedById-externalId-$testSource'")
             .collect(),
           df => df.length < 1)
-      assert(updatedById.length == 1)
+      _ = assert (updatedById.length == 1)
 
       //Update using externalId
-      spark
-        .sql(s"""
-                |select 'updatedById-externalId-$source' as externalId,
-                |'updatedByExternalId-$source' as source
-     """.stripMargin)
-        .write
-        .format(DefaultSource.sparkFormatString)
-        .useOIDCWrite
-        .option("type", "files")
-        .option("onconflict", "update")
-        .option("collectMetrics", "true")
-        .option("metricsPrefix", metricsPrefix)
-        .save()
-
-      assert(getNumberOfRowsCreated(metricsPrefix, "files") == 1)
-      assert(getNumberOfRowsUpdated(metricsPrefix, "files") == 2)
-
-      val updatedByExternalId =
+      _ = spark
+            .sql(s"""
+                    |select 'updatedById-externalId-$testSource' as externalId,
+                    |'updatedByExternalId-$testSource' as source
+        """.stripMargin)
+            .write
+              .format(DefaultSource.sparkFormatString)
+            .useOIDCWrite
+              .option("type", "files")
+            .option("onconflict", "update")
+            .option("collectMetrics", "true")
+            .option("metricsPrefix", metricsPrefix)
+            .save()
+      _ = assert (getNumberOfRowsCreated(metricsPrefix, "files") == 1)
+      _ = assert (getNumberOfRowsUpdated(metricsPrefix, "files") == 2)
+      updatedByExternalId =
         retryWhile[Array[Row]](
           spark
-            .sql(s"select * from destinationFiles where source = 'updatedByExternalId-$source'")
+            .sql(s"select * from ${targetView} where source = 'updatedByExternalId-$testSource'")
             .collect(),
           df => df.length < 1)
-      assert(updatedByExternalId.length == 1)
-
-    } finally {
-      try {
-        cleanupFiles(s"updatedByExternalId-$source")
-      } catch {
-        case NonFatal(_) => // ignore
-      }
-    }
+      _ = assert (updatedByExternalId.length == 1)
+    } yield ())
   }
 
   it should "support upserts" taggedAs WriteTest in {
-    val source = s"upsert-${shortRandomString()}"
-
-    try {
+    runIOTest(for {
+      (_, targetView, _) <- makeDestinationDf()
       //insert data
-      spark
-        .sql(s"""
-             |select "upsert-example" as name,
-             |'$source' as source,
-             |'externalId-$source' as externalId,
-             |null as id,
-             |null as mimeType
-     """.stripMargin)
-        .write
-        .format(DefaultSource.sparkFormatString)
-        .useOIDCWrite
-        .option("type", "files")
-        .option("onconflict", "upsert")
-        .save()
-
-      val id = writeClient.files.retrieveByExternalId(s"externalId-$source").unsafeRunSync().id
-
-      val insertWithUpsertIds =
+      _ = spark
+          .sql(s"""
+                  |select "upsert-example" as name,
+                  |'$testSource' as source,
+                  |'externalId-$testSource' as externalId,
+                  |null as id,
+                  |null as mimeType
+      """.stripMargin)
+          .write
+            .format(DefaultSource.sparkFormatString)
+          .useOIDCWrite
+            .option("type", "files")
+          .option("onconflict", "upsert")
+          .save()
+      id <- Resource.eval(writeClient.files.retrieveByExternalId(s"externalId-$testSource")).map(_.id)
+      insertWithUpsertIds =
         retryWhile[Array[Row]](
           spark
-            .sql(s"select * from destinationFiles where source = '$source'")
+            .sql(s"select * from ${targetView} where source = '$testSource'")
             .collect(),
           df => df.length < 1)
-      assert(insertWithUpsertIds.length == 1)
+      _ = assert(insertWithUpsertIds.length == 1)
 
       //update data
-      spark
-        .sql(s"""
+      _ = spark
+        .sql(
+          s"""
              |select ${id.toString} as id,
-             |'text/plain-$source' as mimeType,
-             |'upserted-$source' as source
-     """.stripMargin)
+             |'text/plain-$testSource' as mimeType,
+             |'upserted-$testSource' as source
+""".stripMargin)
         .write
         .format(DefaultSource.sparkFormatString)
         .useOIDCWrite
@@ -227,78 +277,64 @@ class FilesRelationTest extends FlatSpec with Matchers with ParallelTestExecutio
         .save()
 
       //check updated data
-      val updatedWithUpsert =
+      updatedWithUpsert =
         retryWhile[Array[Row]](
           spark
             .sql(
-              s"select * from destinationFiles where mimeType = 'text/plain-$source' and source = 'upserted-$source'")
+              s"select * from ${targetView} where mimeType = 'text/plain-$testSource' and source = 'upserted-$testSource'")
             .collect(),
           df => df.length < 1)
-      assert(updatedWithUpsert.length == 1)
+      _ = assert (updatedWithUpsert.length == 1)
 
       //original data doesn't exist
-      val updated = retryWhile[Array[Row]](
+      updated = retryWhile[Array[Row]](
         spark
-          .sql(s"select * from destinationFiles where source = '$source'")
+          .sql(s"select * from ${targetView} where source = '$testSource'")
           .collect(),
         df => df.length > 0)
-      assert(updated.isEmpty)
-    } finally {
-      try {
-        cleanupFiles(s"upserted-$source")
-      } catch {
-        case NonFatal(_) => // ignore
-      }
-    }
-
+      _ = assert (updated.isEmpty)
+    } yield ())
   }
 
   it should "support deletes" taggedAs WriteTest in {
-    val source = s"delete-${shortRandomString()}"
-
-    try {
-      spark
+    runIOTest(for {
+      (_, targetView, _) <- makeDestinationDf()
+      _ = spark
         .sql(s"""
-                |select "name-$source" as name,
+                |select "name-$testSource" as name,
                 |null as id,
-                |'$source' as source,
-                |'externalId-$source' as externalId
-     """.stripMargin)
+                |'$testSource' as source,
+                |'externalId-$testSource' as externalId
+    """.stripMargin)
         .write
-        .format(DefaultSource.sparkFormatString)
+          .format(DefaultSource.sparkFormatString)
         .useOIDCWrite
-        .option("type", "files")
+          .option("type", "files")
         .save()
 
-      val rows = retryWhile[Array[Row]](
-        spark.sql(s"select id from destinationFiles where source = '$source'").collect(),
+      rows = retryWhile[Array[Row]](
+        spark.sql(s"select id from ${targetView} where source = '$testSource'").collect(),
         rows => rows.length < 1)
-      assert(rows.length == 1)
+      _ = assert (rows.length == 1)
 
       //Delete using id
-      spark
+      _ = spark
         .sql(s"select ${rows.head.getLong(0)} as id")
         .write
-        .format(DefaultSource.sparkFormatString)
+          .format(DefaultSource.sparkFormatString)
         .useOIDCWrite
-        .option("type", "files")
+          .option("type", "files")
         .option("onconflict", "delete")
         .save()
 
-      val idsAfterDelete =
-        retryWhile[Array[Row]](
-          spark
-            .sql(s"select id from destinationFiles where source = '$source'")
-            .collect(),
+      idsAfterDelete =
+          retryWhile[Array[Row]] (
+            spark
+            .sql(s"select id from ${targetView} where source = '$testSource'")
+        .collect(),
           df => df.length > 0)
-      assert(idsAfterDelete.isEmpty)
-    } finally {
-      try {
-        cleanupFiles(source)
-      } catch {
-        case NonFatal(_) => // ignore
-      }
-    }
+      _ = assert(idsAfterDelete.isEmpty)
+    } yield ())
   }
 
   it should "correctly have insert < read and upsert < read schema hierarchy" in {
@@ -310,60 +346,47 @@ class FilesRelationTest extends FlatSpec with Matchers with ParallelTestExecutio
   }
 
   it should "support pushdown filters on labels" taggedAs WriteTest in {
-    val filesTestSource = s"files-relation-test-filter-labels-${shortRandomString()}"
-    try {
-      spark
-        .sql(s"""select '${filesTestSource}-externalId' as externalId,
-              |null as id,
-              |null as directory,
-              |'name-$filesTestSource' as name,
-              |'${filesTestSource}' as source,
-              |array('scala-sdk-relationships-test-label2') as labels""".stripMargin)
+    runIOTest(for {
+      (_, targetView, _) <- makeDestinationDf()
+      _ <- makeLabels(Seq(s"test-label-${testSource}"))
+      _ = spark
+        .sql(s"""select '${testSource}-externalId' as externalId,
+                |null as id,
+                |null as directory,
+                |'name-$testSource' as name,
+                |'${testSource}' as source,
+                |array('test-label-${testSource}') as labels""".stripMargin)
         .write
-        .format(DefaultSource.sparkFormatString)
+          .format(DefaultSource.sparkFormatString)
         .option("type", "files")
         .useOIDCWrite
-        .save()
-
-      val res1 = retryWhile[Array[Row]](
-        spark.sql(s"""select * from destinationFiles
-                   |where labels = array('scala-sdk-relationships-test-label2')
-                   |and source='${filesTestSource}'""".stripMargin).collect(),
+          .save()
+      res1 = retryWhile[Array[Row]](
+        spark.sql(
+          s"""select * from ${targetView}
+             |where labels = array('test-label-${testSource}')
+             |and source='${testSource}'""".stripMargin).collect(),
         df => df.length != 1
       )
-      res1.length shouldBe 1
+      _ = res1.length shouldBe 1
 
-      val res2 = retryWhile[Array[Row]](
-        spark.sql(s"""select * from destinationFiles
-                   |where labels in(array('scala-sdk-relationships-test-label2'), NULL)
-                   |and source='${filesTestSource}'""".stripMargin).collect(),
+      res2 = retryWhile[Array[Row]](
+        spark.sql(
+          s"""select * from ${targetView}
+             |where labels in(array('test-label-${testSource}'), NULL)
+             |and source='${testSource}'""".stripMargin).collect(),
         df => df.length != 1
       )
-      res2.length shouldBe 1
+      _ = res2.length shouldBe 1
 
-      val res3 = retryWhile[Array[Row]](
-        spark.sql(s"""select * from destinationFiles
-                   |where labels in(array('nonExistingLabel'), NULL)
-                   |and source='${filesTestSource}'""".stripMargin).collect(),
+      res3 = retryWhile[Array[Row]](
+        spark.sql(
+          s"""select * from ${targetView}
+             |where labels in(array('nonExistingLabel'), NULL)
+             |and source='${testSource}'""".stripMargin).collect(),
         df => df.length != 0
       )
-      res3.length shouldBe 0
-    } finally {
-      try {
-        cleanupFiles(filesTestSource)
-      } catch {
-        case NonFatal(_) => // ignore
-      }
-    }
+      _ = res3.length shouldBe 0
+    } yield ())
   }
-
-  def cleanupFiles(source: String): Unit =
-    spark
-      .sql(s"""select id from files where source = '$source'""")
-      .write
-      .format(DefaultSource.sparkFormatString)
-      .useOIDCWrite
-      .option("type", "files")
-      .option("onconflict", "delete")
-      .save()
 }


### PR DESCRIPTION
Create all files (&labels) that test expects to see as part of test setup,
cleanup afterwards. Should make this test work in any project.

Changes are similar to EventRelationTest

Overall setup isn't super-pretty yet, but that's a task for another day.
For now it should fix tests in `master` and not depend on state of data in test project.

[CDF-20827]


[CDF-20827]: https://cognitedata.atlassian.net/browse/CDF-20827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ