### PR TITLE
CDF-20904: add simple trace propagation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ val supportedScalaVersions = List(scala212, scala213)
 val sparkVersion = "3.3.3"
 val circeVersion = "0.14.6"
 val sttpVersion = "3.5.2"
+val natchezVersion = "0.3.1"
 val Specs2Version = "4.20.3"
 val cogniteSdkVersion = "2.16.786"
 
@@ -28,7 +29,7 @@ lazy val commonSettings = Seq(
   organization := "com.cognite.spark.datasource",
   organizationName := "Cognite",
   organizationHomepage := Some(url("https://cognite.com")),
-  version := "3.6." + patchVersion,
+  version := "3.7." + patchVersion,
   isSnapshot := patchVersion.endsWith("-SNAPSHOT"),
   crossScalaVersions := supportedScalaVersions,
   semanticdbEnabled := true,
@@ -155,7 +156,9 @@ lazy val library = (project in file("."))
         exclude("org.glassfish.hk2.external", "javax.inject"),
       "org.apache.spark" %% "spark-sql" % sparkVersion % Provided
         exclude("org.glassfish.hk2.external", "javax.inject"),
-      "org.log4s" %% "log4s" % log4sVersion
+      "org.log4s" %% "log4s" % log4sVersion,
+      "org.tpolecat" %% "natchez-core" % natchezVersion,
+      "org.tpolecat" %% "natchez-noop" % natchezVersion,
     ),
     coverageExcludedPackages := "com.cognite.data.*",
     buildInfoKeys := Seq[BuildInfoKey](organization, version, organizationName),

--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -1,6 +1,6 @@
 package cognite.spark.v1
 
-import cats.Apply
+import cats.{Apply, Functor}
 import cats.effect.IO
 import cats.implicits._
 import cognite.spark.v1.FlexibleDataModelRelationFactory.{
@@ -16,9 +16,11 @@ import com.cognite.sdk.scala.v1.{CogniteExternalId, CogniteId, CogniteInternalId
 import fs2.Stream
 import io.circe.Decoder
 import io.circe.parser.parse
+import natchez.{Kernel, Trace}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row, SQLContext, SaveMode}
+import org.typelevel.ci.CIString
 import sttp.model.Uri
 
 import scala.reflect.classTag
@@ -281,6 +283,8 @@ class DefaultSource
 object DefaultSource {
   val sparkFormatString: String = classTag[DefaultSource].runtimeClass.getCanonicalName
 
+  val TRACING_PARAMETER_PREFIX: String = "com.cognite.tracing.parameter."
+
   private def toBoolean(
       parameters: Map[String, String],
       parameterName: String,
@@ -358,6 +362,19 @@ object DefaultSource {
       .orElse(session)
       .orElse(clientCredentials)
   }
+
+  def extractTracingHeadersKernel(parameters: Map[String, String]): Kernel =
+    new Kernel(
+      parameters.toSeq
+        .filter(_._1.startsWith(TRACING_PARAMETER_PREFIX))
+        .map(kv => (CIString(kv._1.substring(TRACING_PARAMETER_PREFIX.length)), kv._2))
+        .toMap)
+
+  def saveTracingHeaders(knl: Kernel): Seq[(String, String)] =
+    knl.toHeaders.toList.map(kv => (TRACING_PARAMETER_PREFIX + kv._1, kv._2))
+
+  def saveTracingHeaders[F[_]: Functor: Trace](): F[Seq[(String, String)]] =
+    Trace[F].kernel.map(saveTracingHeaders(_))
 
   def parseRelationConfig(parameters: Map[String, String], sqlContext: SQLContext): RelationConfig = { // scalastyle:off
     val maxRetries = toPositiveInt(parameters, "maxRetries")
@@ -443,7 +460,8 @@ object DefaultSource {
       subtrees = subtreesOption,
       ignoreNullFields = toBoolean(parameters, "ignoreNullFields", defaultValue = true),
       rawEnsureParent = toBoolean(parameters, "rawEnsureParent", defaultValue = true),
-      enableSinglePartitionDeleteAssetHierarchy = enableSinglePartitionDeleteAssetHierarchy
+      enableSinglePartitionDeleteAssetHierarchy = enableSinglePartitionDeleteAssetHierarchy,
+      extractTracingHeadersKernel(parameters)
     )
   }
 

--- a/src/main/scala/cognite/spark/v1/FixedTraceSttpBackend.scala
+++ b/src/main/scala/cognite/spark/v1/FixedTraceSttpBackend.scala
@@ -1,0 +1,21 @@
+package cognite.spark.v1
+
+import natchez.Kernel
+import sttp.capabilities
+import sttp.client3.{Request, Response, SttpBackend}
+import sttp.model.Header
+import sttp.monad.MonadError
+
+class FixedTraceSttpBackend[F[_], +P](delegate: SttpBackend[F, P], kernel: Kernel)
+    extends SttpBackend[F, P] {
+  override def send[T, R >: P with capabilities.Effect[F]](request: Request[T, R]): F[Response[T]] =
+    delegate.send(
+      request.headers(
+        kernel.toHeaders.map { case (k, v) => Header(k.toString, v) }.toSeq: _*
+      )
+    )
+
+  override def close(): F[Unit] = delegate.close()
+
+  override def responseMonad: MonadError[F] = delegate.responseMonad
+}

--- a/src/main/scala/cognite/spark/v1/RelationConfig.scala
+++ b/src/main/scala/cognite/spark/v1/RelationConfig.scala
@@ -1,5 +1,7 @@
 package cognite.spark.v1
 
+import natchez.Kernel
+
 final case class RelationConfig(
     auth: CdfSparkAuth,
     clientTag: Option[String],
@@ -22,7 +24,8 @@ final case class RelationConfig(
     subtrees: AssetSubtreeOption,
     ignoreNullFields: Boolean,
     rawEnsureParent: Boolean,
-    enableSinglePartitionDeleteAssetHierarchy: Boolean // flag to test whether single partition helps avoid NPE in asset hierarchy builder
+    enableSinglePartitionDeleteAssetHierarchy: Boolean, // flag to test whether single partition helps avoid NPE in asset hierarchy builder
+    tracingParent: Kernel
 ) {
 
   /** Desired number of Spark partitions ~= partitions / parallelismPerPartition */

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -3,6 +3,7 @@ package cognite.spark.v1
 import cats.effect.IO
 import com.cognite.sdk.scala.common.OAuth2
 import com.cognite.sdk.scala.v1._
+import natchez.Kernel
 import org.apache.spark.SparkException
 import org.apache.spark.datasource.MetricsSource
 import org.apache.spark.sql.types.StructType
@@ -260,7 +261,8 @@ trait SparkTest {
       subtrees = AssetSubtreeOption.Ingest,
       ignoreNullFields = true,
       rawEnsureParent = false,
-      enableSinglePartitionDeleteAssetHierarchy = false
+      enableSinglePartitionDeleteAssetHierarchy = false,
+      new Kernel(Map.empty)
     )
 
   private def getCounterSafe(metricName: String): Option[Long] =


### PR DESCRIPTION
Adds bare minimum support for trace propagation
- no spans are created in connector itself
- no spans are created by SDK
- no new spans are exported
- no change of `IO` -> `Kleisli[IO, Span[IO], *]` or related changes

But already
- support passing parent span via job parameters
- pass that span on to SDK via headers

Full tracing support with spans created in datasource and exported
from spark workers remains a todo, there were some issues rolling
it out before as it had effect handling & type changes.

Just passing on the header should be safe enough.
Small concern is that we don't introduce spans per operation,
but the receiving end of SDK call would create a span of its
own, datasource would only be seen as proxy in traces ~ same as if
datasource creator would call SDK directly.

[CDF-20904]


[CDF-20904]: https://cognitedata.atlassian.net/browse/CDF-20904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ