### PR TITLE
Request view data to go down on other deserialization path in SDK

### DIFF
--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelation.scala
@@ -123,7 +123,7 @@ private[spark] class FlexibleDataModelCorePropertyRelation(
         limit = config.limitPerPartition,
         cursor = None,
         sources = viewReference.map(r => Vector(InstanceSource(r))),
-        includeTyping = Some(false)
+        includeTyping = Some(true)
       )
     }
 


### PR DESCRIPTION
specific error reported here (https://cognitedata.slack.com/archives/C053BKT7TJ8/p1709579684024929)  happens on the deserialization path used when we do not request views

also [CDF-21080]

[CDF-21080]: https://cognitedata.atlassian.net/browse/CDF-21080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ