### PR TITLE
Enable two-phase syncing to avoid 408

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ val circeVersion = "0.14.6"
 val sttpVersion = "3.5.2"
 val natchezVersion = "0.3.1"
 val Specs2Version = "4.20.3"
-val cogniteSdkVersion = "2.19.795"
+val cogniteSdkVersion = "2.20.796"
 
 val prometheusVersion = "0.16.0"
 val log4sVersion = "1.10.0"

--- a/build.scala-2.12.sbt.lock
+++ b/build.scala-2.12.sbt.lock
@@ -1,6 +1,6 @@
 {
   "lockVersion" : 1,
-  "timestamp" : "2024-03-11T14:08:45.320033Z",
+  "timestamp" : "2024-03-15T15:48:33.698557Z",
   "configurations" : [
     "compile",
     "optional",
@@ -78,11 +78,11 @@
     {
       "org" : "com.cognite",
       "name" : "cognite-sdk-scala_2.12",
-      "version" : "2.19.795",
+      "version" : "2.20.796",
       "artifacts" : [
         {
           "name" : "cognite-sdk-scala_2.12.jar",
-          "hash" : "sha1:530190896c216e04759c937e9b6736b5d4b28ef6"
+          "hash" : "sha1:cba737b1835ffd9c3c39319fd6881d40cea9e4d5"
         }
       ],
       "configurations" : [

--- a/build.scala-2.13.sbt.lock
+++ b/build.scala-2.13.sbt.lock
@@ -1,6 +1,6 @@
 {
   "lockVersion" : 1,
-  "timestamp" : "2024-03-11T14:11:06.783919Z",
+  "timestamp" : "2024-03-15T15:52:05.012801Z",
   "configurations" : [
     "compile",
     "optional",
@@ -78,11 +78,11 @@
     {
       "org" : "com.cognite",
       "name" : "cognite-sdk-scala_2.13",
-      "version" : "2.19.795",
+      "version" : "2.20.796",
       "artifacts" : [
         {
           "name" : "cognite-sdk-scala_2.13.jar",
-          "hash" : "sha1:da91f98aed0347a2668eb915ff7d21a810cda4e5"
+          "hash" : "sha1:992de9eb926c5fa9652acbca182f595b93d5e95b"
         }
       ],
       "configurations" : [

--- a/macro/build.scala-2.12.sbt.lock
+++ b/macro/build.scala-2.12.sbt.lock
@@ -1,6 +1,6 @@
 {
   "lockVersion" : 1,
-  "timestamp" : "2024-03-11T14:29:55.702735Z",
+  "timestamp" : "2024-03-15T15:52:06.968126Z",
   "configurations" : [
     "compile",
     "optional",
@@ -75,11 +75,11 @@
     {
       "org" : "com.cognite",
       "name" : "cognite-sdk-scala_2.12",
-      "version" : "2.19.795",
+      "version" : "2.20.796",
       "artifacts" : [
         {
           "name" : "cognite-sdk-scala_2.12.jar",
-          "hash" : "sha1:530190896c216e04759c937e9b6736b5d4b28ef6"
+          "hash" : "sha1:cba737b1835ffd9c3c39319fd6881d40cea9e4d5"
         }
       ],
       "configurations" : [

--- a/macro/build.scala-2.13.sbt.lock
+++ b/macro/build.scala-2.13.sbt.lock
@@ -1,6 +1,6 @@
 {
   "lockVersion" : 1,
-  "timestamp" : "2024-03-11T14:29:57.546413Z",
+  "timestamp" : "2024-03-15T15:52:08.801060Z",
   "configurations" : [
     "compile",
     "optional",
@@ -75,11 +75,11 @@
     {
       "org" : "com.cognite",
       "name" : "cognite-sdk-scala_2.13",
-      "version" : "2.19.795",
+      "version" : "2.20.796",
       "artifacts" : [
         {
           "name" : "cognite-sdk-scala_2.13.jar",
-          "hash" : "sha1:da91f98aed0347a2668eb915ff7d21a810cda4e5"
+          "hash" : "sha1:992de9eb926c5fa9652acbca182f595b93d5e95b"
         }
       ],
       "configurations" : [

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
@@ -149,7 +149,7 @@ private[spark] class FlexibleDataModelCorePropertySyncRelation(
             IO.raiseError(
               new IllegalArgumentException("/sync response must have " +
                 "nextCursor"))
-          case Some(nextCursor) => IO.pure(nextCursor, cursors.isEmpty)
+          case Some(nextCursor) => IO.pure((nextCursor, cursors.isEmpty))
         }
       }
       .redeemWith(

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
@@ -126,7 +126,7 @@ private[spark] class FlexibleDataModelCorePropertySyncRelation(
   }
 
   /**
-    * Generate future items cursor.
+    * Generate future items cursor and validate cursor expiration.
     * If the cursor has expired, generate a new cursor and do a full back fill.
     */
   private def generateFutureItemsCursor(
@@ -140,7 +140,7 @@ private[spark] class FlexibleDataModelCorePropertySyncRelation(
         "sync" -> generateTableExpression(instanceType, FilterDefinition.Not(MatchAll(JsonObject())))),
       select = select)
       .map { sr =>
-        (sr.nextCursor, cursor.isEmpty)
+        (sr.nextCursor, cursors.isEmpty)
       }
       .redeemWith(
         {

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
@@ -124,6 +124,8 @@ private[spark] class FlexibleDataModelCorePropertySyncRelation(
         selectedColumns
       ))
   }
+  // scalastyle:on method.length
+  // scalastyle:on cyclomatic.complexity
 
   private val matchNothingFilter: FilterDefinition =
     FilterDefinition.Not(MatchAll(JsonObject()))
@@ -195,7 +197,6 @@ private[spark] class FlexibleDataModelCorePropertySyncRelation(
       ItemsWithCursor(itemDefinitions, nextCursor)
     }
   }
-  // scalastyle:on cyclomatic.complexity
 
   private def syncOut(
       futureItemsCursor: Option[String],

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
@@ -141,8 +141,7 @@ private[spark] class FlexibleDataModelCorePropertySyncRelation(
     fetchData(
       isBackFill = false,
       cursors = cursors,
-      `with` = Map(
-        "sync" -> generateTableExpression(instanceType, matchNothingFilter)),
+      `with` = Map("sync" -> generateTableExpression(instanceType, matchNothingFilter)),
       select = select)
       .map { sr =>
         (sr.nextCursor, cursors.isEmpty)

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
@@ -127,9 +127,7 @@ private[spark] class FlexibleDataModelCorePropertySyncRelation(
 
   /**
     * Generate future items cursor.
-    * If the cursor has expired, generate a new cursor and do a full backfill.
-    * If the cursor with sync causes 408, then do a backfill, and pray that incremental sync sessions
-    * will not time out.
+    * If the cursor has expired, generate a new cursor and do a full back fill.
     */
   private def generateFutureItemsCursor(
       cursors: Option[Map[String, String]],

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
@@ -190,7 +190,7 @@ private[spark] class FlexibleDataModelCorePropertySyncRelation(
       )
     }
     response.map { qr =>
-      val itemDefinitions = qr.items.getOrElse(Map.empty).get("sync").getOrElse(Vector.empty)
+      val itemDefinitions = qr.items.getOrElse(Map.empty).getOrElse("sync", Vector.empty)
       val nextCursor = qr.nextCursor.getOrElse(Map.empty).get("sync")
       ItemsWithCursor(itemDefinitions, nextCursor)
     }

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
@@ -1,6 +1,6 @@
 package cognite.spark.v1
 
-import cats.effect.{Async, IO}
+import cats.effect.IO
 import cognite.spark.v1.CdpConnector.ioRuntime
 import cognite.spark.v1.FlexibleDataModelBaseRelation.ProjectedFlexibleDataModelInstance
 import cognite.spark.v1.FlexibleDataModelRelationFactory.{

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
@@ -79,6 +79,7 @@ private[spark] class FlexibleDataModelCorePropertySyncRelation(
   }
 
   // scalastyle:off cyclomatic.complexity
+  // scalastyle:off method.length
   override def getStreams(filters: Array[Filter], selectedColumns: Array[String])(
       client: GenericClient[IO]): Seq[Stream[IO, ProjectedFlexibleDataModelInstance]] = {
     val selectedInstanceProps = if (selectedColumns.isEmpty) {

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
@@ -125,6 +125,9 @@ private[spark] class FlexibleDataModelCorePropertySyncRelation(
       ))
   }
 
+  private val matchNothingFilter: FilterDefinition =
+    FilterDefinition.Not(MatchAll(JsonObject()))
+
   /**
     * Generate future items cursor and validate cursor expiration.
     * If the cursor has expired, generate a new cursor and do a full back fill.
@@ -137,7 +140,7 @@ private[spark] class FlexibleDataModelCorePropertySyncRelation(
       isBackFill = false,
       cursors = cursors,
       `with` = Map(
-        "sync" -> generateTableExpression(instanceType, FilterDefinition.Not(MatchAll(JsonObject())))),
+        "sync" -> generateTableExpression(instanceType, matchNothingFilter)),
       select = select)
       .map { sr =>
         (sr.nextCursor, cursors.isEmpty)

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
@@ -20,6 +20,14 @@ import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.{DataTypes, StructField}
 import org.log4s.getLogger
 
+sealed trait SyncMode {}
+
+// /query all items first, report futureItemsCursor as cursor for next run
+final case class BackFillMode(futureItemsSyncCursor: String) extends SyncMode
+
+// sync starting from a non-empty non-expired /sync cursor from a previous run
+final case class StreamMode(syncCursors: Map[String, String]) extends SyncMode
+
 /**
   * Flexible Data Model Relation for syncing Nodes or Edges with properties
   *
@@ -125,12 +133,6 @@ private[spark] class FlexibleDataModelCorePropertySyncRelation(
   }
   // scalastyle:on method.length
   // scalastyle:on cyclomatic.complexity
-
-  sealed trait SyncMode {}
-  // /query all items first, report futureItemsCursor as cursor for next run
-  final case class BackFillMode(futureItemsSyncCursor: String) extends SyncMode
-  // sync starting from a non-empty non-expired /sync cursor from a previous run
-  final case class StreamMode(syncCursors: Map[String, String]) extends SyncMode
 
   private val matchNothingFilter: FilterDefinition =
     FilterDefinition.Not(MatchAll(JsonObject()))

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
@@ -220,8 +220,7 @@ private[spark] class FlexibleDataModelCorePropertySyncRelation(
       syncMode: SyncMode,
       `with`: Map[String, TableExpression],
       select: Map[String, SelectExpression],
-      selectedProps: Array[String])(
-      implicit F: Async[IO]): Stream[IO, ProjectedFlexibleDataModelInstance] = {
+      selectedProps: Array[String]): Stream[IO, ProjectedFlexibleDataModelInstance] = {
     val (isBackFill, cursors, toProjectedCursor) = syncMode match {
       case StreamMode(syncCursors) =>
         (false, Some(syncCursors), (nextCursor: Option[String]) => nextCursor)

--- a/src/test/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelationTest.scala
@@ -636,6 +636,33 @@ class FlexibleDataModelCorePropertyRelationTest
     syncedNodes3.length shouldBe 0
   }
 
+  it should "sync with old cursor " in {
+    // Let us see what happens when this cursor gets more than 3 days..
+    val oldCursorValue = "\"Z0FBQUFBQmw0RjJXenpCbHl3Ny02MzRRN21lTEVkdm5hU3hpQTM4d05ERkwxV2xNSG5" +
+      "wa2ltOHhXMXloWC05akN6TDEzWGExMkkwZlpocGVhdVZXSDBGMVpEdmIwSTlzVDhQQUVhOHBNV2pCNUFNMFBsREg" +
+      "4WjlEU3RacFFMbS1MM3hZaGVkV3ZFcVhoUy13R0NlODEzaEhlZUhUbVoxeTZ3bWVCX0tnSWdXRkphcjJIS2hfemh" +
+      "pM216WktROG9RdjdqVmRWeFRMdDZ5TVdVNG1iNGo2X3J1VVVVRy10ZnowYUozSnV0R2ozZjd6YU1mMjBNVnc1eWN" +
+      "tX1hmbF80RmY0RkdVRk5DVTI0UE9scW5rbkF1MEZIUHBKUklERDVnRDJ5ZWhXVGVwNE4wcVBpeVV1amdGSDZKeTd" +
+      "nanhkRTNiZ2QtUTdWdGdhbUpHakdEWXpQRmNueEFGdGd3UTBHdHZpY3hZdnpHdk16QVBlNE8wSlZzUGk0d2hOV01" +
+      "jRUFQdjNPNE9mQ0g0MG11S1NYMzJyWnczRkhBWG00WWJCRU1jUT09\""
+
+    val (viewDefinition, modifiedExternalIds) = setupSyncTest.unsafeRunSync()
+    val view = viewDefinition.toSourceReference
+    val syncDf = syncRows(
+      instanceType = InstanceType.Node,
+      viewSpaceExternalId = spaceExternalId,
+      viewExternalId = view.externalId,
+      viewVersion = view.version,
+      cursor = oldCursorValue
+    )
+
+    syncDf.createTempView(s"sync_old_cursor")
+    val syncedNodes = spark.sql("select * from sync_old_cursor").collect()
+    val syncedExternalIds = toExternalIds(syncedNodes)
+
+    (syncedExternalIds should contain).allElementsOf(modifiedExternalIds)
+  }
+
   it should "succeed when filtering instances by properties" in {
     val (view, instanceExtIds) = setupFilteringByPropertiesTest.unsafeRunSync()
 

--- a/src/test/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelationTest.scala
@@ -636,33 +636,6 @@ class FlexibleDataModelCorePropertyRelationTest
     syncedNodes3.length shouldBe 0
   }
 
-  it should "sync with old cursor " in {
-    // Let us see what happens when this cursor gets more than 3 days..
-    val oldCursorValue = "\"Z0FBQUFBQmw0RjJXenpCbHl3Ny02MzRRN21lTEVkdm5hU3hpQTM4d05ERkwxV2xNSG5" +
-      "wa2ltOHhXMXloWC05akN6TDEzWGExMkkwZlpocGVhdVZXSDBGMVpEdmIwSTlzVDhQQUVhOHBNV2pCNUFNMFBsREg" +
-      "4WjlEU3RacFFMbS1MM3hZaGVkV3ZFcVhoUy13R0NlODEzaEhlZUhUbVoxeTZ3bWVCX0tnSWdXRkphcjJIS2hfemh" +
-      "pM216WktROG9RdjdqVmRWeFRMdDZ5TVdVNG1iNGo2X3J1VVVVRy10ZnowYUozSnV0R2ozZjd6YU1mMjBNVnc1eWN" +
-      "tX1hmbF80RmY0RkdVRk5DVTI0UE9scW5rbkF1MEZIUHBKUklERDVnRDJ5ZWhXVGVwNE4wcVBpeVV1amdGSDZKeTd" +
-      "nanhkRTNiZ2QtUTdWdGdhbUpHakdEWXpQRmNueEFGdGd3UTBHdHZpY3hZdnpHdk16QVBlNE8wSlZzUGk0d2hOV01" +
-      "jRUFQdjNPNE9mQ0g0MG11S1NYMzJyWnczRkhBWG00WWJCRU1jUT09\""
-
-    val (viewDefinition, modifiedExternalIds) = setupSyncTest.unsafeRunSync()
-    val view = viewDefinition.toSourceReference
-    val syncDf = syncRows(
-      instanceType = InstanceType.Node,
-      viewSpaceExternalId = spaceExternalId,
-      viewExternalId = view.externalId,
-      viewVersion = view.version,
-      cursor = oldCursorValue
-    )
-
-    syncDf.createTempView(s"sync_old_cursor")
-    val syncedNodes = spark.sql("select * from sync_old_cursor").collect()
-    val syncedExternalIds = toExternalIds(syncedNodes)
-
-    (syncedExternalIds should contain).allElementsOf(modifiedExternalIds)
-  }
-
   it should "succeed when filtering instances by properties" in {
     val (view, instanceExtIds) = setupFilteringByPropertiesTest.unsafeRunSync()
 


### PR DESCRIPTION
General idea is to do syncing in two phases:

Phase 1: list out items with cursor on internal node id in DMS

Phase 2: sync out incremental changes that happened since phase 1

We will initialise a cursor for phase 1 when we start it.