### PR TITLE
Submit last (empty) sync cursor to callback

### DIFF
--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -558,10 +558,18 @@ object DefaultSource {
             parameters.get("viewExternalId"),
             parameters.get("viewVersion")
           )(ViewReference.apply)
+
+        val cursorName = parameters.get("cursorName")
+        val jobId = parameters.get("jobId")
+        val syncCursorSaveCallbackUrl = parameters.get("syncCursorSaveCallbackUrl")
+
         FlexibleDataModelRelationFactory.corePropertySyncRelation(
           usageAndCursor._2,
           config = config,
           sqlContext = sqlContext,
+          cursorName = cursorName,
+          jobId = jobId,
+          syncCursorSaveCallbackUrl = syncCursorSaveCallbackUrl,
           viewCorePropConfig = ViewSyncCorePropertyConfig(
             intendedUsage = usage,
             viewReference = viewReference,

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
@@ -252,12 +252,14 @@ private[spark] class FlexibleDataModelCorePropertySyncRelation(
           (nextCursor, items.isEmpty, shouldStopEarly) match {
             case (Some(cursor), true, _) =>
               if (syncCursorSaveCallbackUrl.isDefined && jobId.isDefined && cursorName.isDefined) {
-                SyncCursorCallback.lastCursorCallback(
-                  syncCursorSaveCallbackUrl.get,
-                  cursorName.get,
-                  cursor,
-                  jobId.get
-                )
+                SyncCursorCallback
+                  .lastCursorCallback(
+                    syncCursorSaveCallbackUrl.get,
+                    cursorName.get,
+                    cursor,
+                    jobId.get
+                  )
+                  .unsafeRunSync()
               }
               fs2.Stream.empty
             case (Some(cursor), _, false) =>

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelRelationFactory.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelRelationFactory.scala
@@ -63,8 +63,17 @@ object FlexibleDataModelRelationFactory {
       cursor: String,
       config: RelationConfig,
       sqlContext: SQLContext,
+      cursorName: Option[String],
+      jobId: Option[String],
+      syncCursorSaveCallbackUrl: Option[String],
       viewCorePropConfig: ViewSyncCorePropertyConfig): FlexibleDataModelCorePropertySyncRelation =
-    new FlexibleDataModelCorePropertySyncRelation(cursor, config, viewCorePropConfig)(sqlContext)
+    new FlexibleDataModelCorePropertySyncRelation(
+      cursor,
+      config,
+      cursorName,
+      jobId,
+      syncCursorSaveCallbackUrl,
+      viewCorePropConfig)(sqlContext)
 
   def connectionRelation(
       config: RelationConfig,

--- a/src/main/scala/cognite/spark/v1/SttpClientBackendFactory.scala
+++ b/src/main/scala/cognite/spark/v1/SttpClientBackendFactory.scala
@@ -6,8 +6,7 @@ import org.asynchttpclient.AsyncHttpClient
 import sttp.client3.SttpBackendOptions
 
 object SttpClientBackendFactory {
-  def create(): AsyncHttpClient = {
-    val prefix = "Cdf-Spark"
+  def create(prefix: String = "Cdf-Spark"): AsyncHttpClient = {
     // It's important that the threads made by the async http client is daemon threads,
     // so that we don't hang applications using our library during exit.
     // See for more info https://github.com/cognitedata/cdp-spark-datasource/pull/415/files#r396774391

--- a/src/main/scala/cognite/spark/v1/SyncCursorCallback.scala
+++ b/src/main/scala/cognite/spark/v1/SyncCursorCallback.scala
@@ -61,7 +61,7 @@ object SyncCursorCallback {
       callbackUrl: String,
       cursorName: String,
       cursorValue: String,
-      jobId: String): IncrementalCursorResponse = {
+      jobId: String): IO[IncrementalCursorResponse] = {
     val uri = Uri.parse(s"$callbackUrl/$jobId") match {
       case Left(value) => throw new IllegalArgumentException(s"Failed to parse URI '$value'")
       case Right(value) => value
@@ -82,7 +82,6 @@ object SyncCursorCallback {
         case Right(value) => value
       }
       .send(sttpBackend)
-      .unsafeRunSync()
-      .body
+      .map(_.body)
   }
 }

--- a/src/main/scala/cognite/spark/v1/SyncCursorCallback.scala
+++ b/src/main/scala/cognite/spark/v1/SyncCursorCallback.scala
@@ -1,57 +1,21 @@
 package cognite.spark.v1
 
 import cats.effect.IO
-import cats.effect.unsafe.{IORuntime, IORuntimeConfig}
 import com.cognite.sdk.scala.sttp.GzipBackend
-import com.google.common.util.concurrent.ThreadFactoryBuilder
 import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec
-import org.log4s.getLogger
 import sttp.client3.{SttpBackend, basicRequest}
 import sttp.client3.asynchttpclient.SttpClientBackendFactory
 import sttp.client3.asynchttpclient.cats.AsyncHttpClientCatsBackend
 import sttp.client3.circe.{asJson, circeBodySerializer}
 import sttp.model.{MediaType, Uri}
 
-import java.lang.Thread.UncaughtExceptionHandler
-import java.util.concurrent.Executors
-import scala.concurrent.ExecutionContext
-
 case class IncrementalCursor(name: String, value: String)
 case class IncrementalCursorResponse(name: String, value: String, updated: Boolean)
 
 object SyncCursorCallback {
-  @transient private val logger = getLogger
   @transient private lazy val sttpBackend: SttpBackend[IO, Any] =
     new GzipBackend[IO, Any](AsyncHttpClientCatsBackend.usingClient(SttpClientBackendFactory.create()))
-
-  @transient private lazy val syncCursorCallbackExecutionContext: ExecutionContext =
-    ExecutionContext.fromExecutor(
-      Executors.newFixedThreadPool(
-        2,
-        new ThreadFactoryBuilder()
-          .setDaemon(true)
-          .setUncaughtExceptionHandler(new UncaughtExceptionHandler {
-            override def uncaughtException(t: Thread, e: Throwable): Unit =
-              logger.warn(e)(
-                s"Ignoring uncaught exception when submitting cursor callback: ${e.getMessage}")
-          })
-          .setNameFormat("Cursor-Callback-%d")
-          .build()
-      )
-    )
-
-  @transient private lazy val (blocking, _) =
-    IORuntime.createDefaultBlockingExecutionContext("Cursor-Callback-blocking")
-  @transient private lazy val (scheduler, _) =
-    IORuntime.createDefaultScheduler("Cursor-Callback-scheduler")
-  @transient lazy implicit val ioRuntime: IORuntime = IORuntime(
-    syncCursorCallbackExecutionContext,
-    blocking,
-    scheduler,
-    () => (),
-    IORuntimeConfig()
-  )
 
   implicit val incrementalCursorCodec: Codec[IncrementalCursor] = deriveCodec[IncrementalCursor]
   implicit val incrementalCursorResponseCodec: Codec[IncrementalCursorResponse] =

--- a/src/main/scala/cognite/spark/v1/SyncCursorCallback.scala
+++ b/src/main/scala/cognite/spark/v1/SyncCursorCallback.scala
@@ -1,0 +1,88 @@
+package cognite.spark.v1
+
+import cats.effect.IO
+import cats.effect.unsafe.{IORuntime, IORuntimeConfig}
+import com.cognite.sdk.scala.sttp.GzipBackend
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+import io.circe.Codec
+import io.circe.generic.semiauto.deriveCodec
+import org.log4s.getLogger
+import sttp.client3.{SttpBackend, basicRequest}
+import sttp.client3.asynchttpclient.SttpClientBackendFactory
+import sttp.client3.asynchttpclient.cats.AsyncHttpClientCatsBackend
+import sttp.client3.circe.{asJson, circeBodySerializer}
+import sttp.model.{MediaType, Uri}
+
+import java.lang.Thread.UncaughtExceptionHandler
+import java.util.concurrent.Executors
+import scala.concurrent.ExecutionContext
+
+case class IncrementalCursor(name: String, value: String)
+case class IncrementalCursorResponse(name: String, value: String, updated: Boolean)
+
+object SyncCursorCallback {
+  @transient private val logger = getLogger
+  @transient private lazy val sttpBackend: SttpBackend[IO, Any] =
+    new GzipBackend[IO, Any](AsyncHttpClientCatsBackend.usingClient(SttpClientBackendFactory.create()))
+
+  @transient private lazy val syncCursorCallbackExecutionContext: ExecutionContext =
+    ExecutionContext.fromExecutor(
+      Executors.newFixedThreadPool(
+        2,
+        new ThreadFactoryBuilder()
+          .setDaemon(true)
+          .setUncaughtExceptionHandler(new UncaughtExceptionHandler {
+            override def uncaughtException(t: Thread, e: Throwable): Unit =
+              logger.warn(e)(
+                s"Ignoring uncaught exception when submitting cursor callback: ${e.getMessage}")
+          })
+          .setNameFormat("Cursor-Callback-%d")
+          .build()
+      )
+    )
+
+  @transient private lazy val (blocking, _) =
+    IORuntime.createDefaultBlockingExecutionContext("Cursor-Callback-blocking")
+  @transient private lazy val (scheduler, _) =
+    IORuntime.createDefaultScheduler("Cursor-Callback-scheduler")
+  @transient lazy implicit val ioRuntime: IORuntime = IORuntime(
+    syncCursorCallbackExecutionContext,
+    blocking,
+    scheduler,
+    () => (),
+    IORuntimeConfig()
+  )
+
+  implicit val incrementalCursorCodec: Codec[IncrementalCursor] = deriveCodec[IncrementalCursor]
+  implicit val incrementalCursorResponseCodec: Codec[IncrementalCursorResponse] =
+    deriveCodec[IncrementalCursorResponse]
+
+  def lastCursorCallback(
+      callbackUrl: String,
+      cursorName: String,
+      cursorValue: String,
+      jobId: String): IncrementalCursorResponse = {
+    val uri = Uri.parse(s"$callbackUrl/$jobId") match {
+      case Left(value) => throw new IllegalArgumentException(s"Failed to parse URI '$value'")
+      case Right(value) => value
+    }
+
+    basicRequest
+      .followRedirects(false)
+      .contentType(MediaType.ApplicationJson)
+      .acceptEncoding(MediaType.ApplicationJson.toString())
+      .body(IncrementalCursor(cursorName, cursorValue))
+      .post(uri)
+      .response(asJson[IncrementalCursorResponse])
+      .mapResponse {
+        // We do not fail the whole transformation on a non-submitted cursor, as it is
+        // not critical for this job. Multiple failed runs so that the customer exceeds
+        // its max age, will lead to a fallback to restart.
+        case Left(_) => IncrementalCursorResponse(cursorName, cursorValue, updated = false)
+        case Right(value) => value
+      }
+      .send(sttpBackend)
+      .unsafeRunSync()
+      .body
+  }
+}

--- a/src/main/scala/cognite/spark/v1/SyncCursorCallback.scala
+++ b/src/main/scala/cognite/spark/v1/SyncCursorCallback.scala
@@ -16,7 +16,8 @@ case class IncrementalCursorResponse(name: String, value: String, updated: Boole
 
 object SyncCursorCallback {
   @transient private lazy val sttpBackend: SttpBackend[IO, Any] =
-    new GzipBackend[IO, Any](AsyncHttpClientCatsBackend.usingClient(SttpClientBackendFactory.create()))
+    new GzipBackend[IO, Any](
+      AsyncHttpClientCatsBackend.usingClient(SttpClientBackendFactory.create("Last-Cursor-Submitter")))
 
   @transient private val retryingBackend = new RetryingBackend[IO, Any](
     sttpBackend,


### PR DESCRIPTION
Currently, we return the cursor from the /sync DMS call as part of the rows returned to the Dataframe. This cursor has a max lifespan (currently 3 days), and needs to be refreshed even if there are no rows returned.

As a workaround, for now, we therefore submit the cursor to a configured callback URL when the /sync query returns no entries.