### PR TITLE
Celo/cdf 21249/attempt number metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,13 @@ lazy val commonSettings = Seq(
   description := "Spark data source for the Cognite Data Platform.",
   licenses := List("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt")),
   homepage := Some(url("https://github.com/cognitedata/cdp-spark-datasource")),
-  scalacOptions ++= Seq("-Xlint:unused", "-language:higherKinds", "-deprecation", "-feature"),
+  scalacOptions ++= Seq("-Xlint:unused", "-language:higherKinds", "-deprecation", "-feature") ++ (CrossVersion.partialVersion(scalaVersion.value) match {
+    // We use JavaConverters to remain backwards compatible with Scala 2.12,
+    // and to avoid a dependency on scala-collection-compat
+    case Some((2, 13)) => Seq("-Wconf:src=src/main/scala/cognite/spark/v1/MetricsSource.scala&cat=deprecation:i")
+    case _ => Seq.empty
+  }),
+  // scalacOptions ++= Seq("-Xlint:unused", "-language:higherKinds", "-deprecation", "-feature", "-Wconf:src=src/main/scala/cognite/spark/v1/MetricsSource.scala&cat=deprecation:i"),
   resolvers ++= Resolver.sonatypeOssRepos("releases"),
   developers := List(
     Developer(

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,6 @@ lazy val commonSettings = Seq(
     case Some((2, 13)) => Seq("-Wconf:src=src/main/scala/cognite/spark/v1/MetricsSource.scala&cat=deprecation:i")
     case _ => Seq.empty
   }),
-  // scalacOptions ++= Seq("-Xlint:unused", "-language:higherKinds", "-deprecation", "-feature", "-Wconf:src=src/main/scala/cognite/spark/v1/MetricsSource.scala&cat=deprecation:i"),
   resolvers ++= Resolver.sonatypeOssRepos("releases"),
   developers := List(
     Developer(

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ lazy val commonSettings = Seq(
   scalacOptions ++= Seq("-Xlint:unused", "-language:higherKinds", "-deprecation", "-feature") ++ (CrossVersion.partialVersion(scalaVersion.value) match {
     // We use JavaConverters to remain backwards compatible with Scala 2.12,
     // and to avoid a dependency on scala-collection-compat
-    case Some((2, 13)) => Seq("-Wconf:src=src/main/scala/cognite/spark/v1/MetricsSource.scala&cat=deprecation:i")
+    case Some((2, 13)) => Seq("-Wconf:src=src/test/scala/cognite/spark/v1/SparkTest.scala&cat=deprecation:i")
     case _ => Seq.empty
   }),
   resolvers ++= Resolver.sonatypeOssRepos("releases"),

--- a/src/main/scala/cognite/spark/v1/CdfRelation.scala
+++ b/src/main/scala/cognite/spark/v1/CdfRelation.scala
@@ -12,20 +12,18 @@ abstract class CdfRelation(config: RelationConfig, shortNameStr: String)
     extends BaseRelation
     with Serializable {
   protected val shortName: String = shortNameStr
-  @transient lazy protected val itemsRead: Counter =
-    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"$shortName.read")
-  @transient lazy protected val itemsCreated: Counter =
-    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"$shortName.created")
-  @transient lazy protected val itemsUpdated: Counter =
-    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"$shortName.updated")
-  @transient lazy protected val itemsDeleted: Counter =
-    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"$shortName.deleted")
+  protected def itemsRead: Counter = getOrCreateCounter("read")
+  protected def itemsCreated: Counter = getOrCreateCounter("created")
+  protected def itemsUpdated: Counter = getOrCreateCounter("updated")
+  protected def itemsDeleted: Counter = getOrCreateCounter("deleted")
   // We are not aware if it is `created` or `updated in flexible data modelling case
-  @transient lazy protected val itemsUpserted: Counter =
-    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"$shortName.upserted")
+  protected def itemsUpserted: Counter = getOrCreateCounter("upserted")
 
   @transient lazy val client: GenericClient[IO] =
     CdpConnector.clientFromConfig(config)
+
+  private def getOrCreateCounter(action: String): Counter =
+    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"$shortName.$action")
 
   def incMetrics(counter: Counter, count: Int): IO[Unit] =
     IO(

--- a/src/main/scala/cognite/spark/v1/MetricsSource.scala
+++ b/src/main/scala/cognite/spark/v1/MetricsSource.scala
@@ -10,9 +10,10 @@ class MetricsSource {
   // Keeps track of all the Metric instances that are being published
   val metricsMap = new ConcurrentHashMap[String, Eval[Counter]]
 
-  def getOrCreateCounter(metricNamespace: String, name: String): Counter = {
-    val ctx = Option(TaskContext.get())
-
+  def getOrCreateAttemptTrackingCounter(
+      metricNamespace: String,
+      name: String,
+      ctx: Option[TaskContext]): Counter = {
     def getNumberOrEmpty(getter: TaskContext => Long): String =
       ctx.map(getter).map(_.toString()).getOrElse("")
 

--- a/src/main/scala/cognite/spark/v1/MetricsSource.scala
+++ b/src/main/scala/cognite/spark/v1/MetricsSource.scala
@@ -87,6 +87,9 @@ class MetricsSource {
     }
   }
 
+  /**
+    * For tests only. Combines all metrics for a given target resource
+    */
   def getAggregatedCount(metricNamespace: String, resource: String): Option[Long] = {
     val counters = metricsMap.asScala
       .filterKeys(key => key.startsWith(metricNamespace) && key.endsWith(resource))

--- a/src/main/scala/cognite/spark/v1/MetricsSource.scala
+++ b/src/main/scala/cognite/spark/v1/MetricsSource.scala
@@ -2,16 +2,14 @@ package org.apache.spark.datasource
 
 import cats.Eval
 import com.codahale.metrics._
-import java.util.concurrent.ConcurrentHashMap
-import java.util.{Timer, TimerTask}
 import org.apache.spark._
-import scala.concurrent.duration._
-import scala.language.postfixOps
+
+import java.util.concurrent.ConcurrentHashMap
 
 class MetricsSource {
   // Add metricNamespace to differentiate with spark system metrics.
   // Keeps track of all the Metric instances that are being published
-  val metricsMap = new ConcurrentHashMap[String, Eval[ExpiringCounter]]
+  val metricsMap = new ConcurrentHashMap[String, Eval[Counter]]
 
   def getOrCreateCounter(metricNamespace: String, name: String): Counter = {
     val ctx = Option(TaskContext.get())
@@ -31,8 +29,8 @@ class MetricsSource {
 
     val wrapped = Eval.later {
       val counter = new Counter
-      val source = registerMetricSource(metricNamespace, metricName, counter)
-      new ExpiringCounter(key, source)
+      registerMetricSource(metricNamespace, metricName, counter)
+      counter
     }
 
     metricsMap.putIfAbsent(key, wrapped)
@@ -49,11 +47,9 @@ class MetricsSource {
     * @param metricName name of the Metric
     * @param metric com.codahale.metrics.Metric instance to be published
     */
-  private def registerMetricSource(
-      metricNamespace: String,
-      metricName: String,
-      metric: Metric): Source = {
-    val source =
+  def registerMetricSource(metricNamespace: String, metricName: String, metric: Metric): Unit = {
+    val env = SparkEnv.get
+    env.metricsSystem.registerSource(
       new Source {
         override val sourceName = s"${metricNamespace}"
         override def metricRegistry: MetricRegistry = {
@@ -62,53 +58,9 @@ class MetricsSource {
           metrics
         }
       }
-
-    SparkEnv.get.metricsSystem.registerSource(source)
-
-    source
-  }
-
-  def deregisterMetricSource(key: String, source: Source): Unit = {
-    metricsMap.remove(key)
-    SparkEnv.get.metricsSystem.removeSource(source)
+    )
   }
 }
 
 // Singleton to make sure each metric is only registered once.
 object MetricsSource extends MetricsSource
-
-class ExpiringCounter(key: String, source: Source) extends Counter {
-  private var (deathTimer, deathTimerTask): (Timer, TimerTask) = createTimer
-
-  private def createTimer = {
-    val task = new TimerTask {
-      override def run =
-        MetricsSource.deregisterMetricSource(key, source)
-    }
-
-    val timer = new Timer(key)
-    timer.schedule(task, (1 hour).toMillis)
-
-    (timer, task)
-  }
-
-  private def resetTimer() = {
-    deathTimerTask.cancel()
-    deathTimer.cancel()
-
-    val (timer, task) = createTimer
-    deathTimer = timer
-    deathTimerTask = task
-  }
-
-  override def inc(n: Long): Unit = {
-    resetTimer()
-    super.inc(n)
-  }
-
-  override def dec(n: Long): Unit = {
-    resetTimer()
-    super.dec(n)
-  }
-
-}

--- a/src/main/scala/cognite/spark/v1/MetricsSource.scala
+++ b/src/main/scala/cognite/spark/v1/MetricsSource.scala
@@ -13,14 +13,14 @@ class MetricsSource {
   def getOrCreateCounter(metricNamespace: String, name: String): Counter = {
     val ctx = Option(TaskContext.get())
 
-    def getNumberOrEmpty(getter: TaskContext => AnyVal): String =
+    def getNumberOrEmpty(getter: TaskContext => Long): String =
       ctx.map(getter).map(_.toString()).getOrElse("")
 
     // The number of fields in the name should be consistent, even if there is no value for
     // the attempt numbers
-    val stageId = getNumberOrEmpty(_.stageId())
-    val stageAttempt = getNumberOrEmpty(_.stageAttemptNumber())
-    val partitionId = getNumberOrEmpty(_.partitionId())
+    val stageId = getNumberOrEmpty(_.stageId().toLong)
+    val stageAttempt = getNumberOrEmpty(_.stageAttemptNumber().toLong)
+    val partitionId = getNumberOrEmpty(_.partitionId().toLong)
     val taskAttempt = getNumberOrEmpty(_.taskAttemptId())
 
     val metricName = s"<$stageId>[$stageAttempt]#<$partitionId>[$taskAttempt]#$name"

--- a/src/main/scala/cognite/spark/v1/MetricsSource.scala
+++ b/src/main/scala/cognite/spark/v1/MetricsSource.scala
@@ -24,7 +24,7 @@ class MetricsSource {
     val partitionId = getNumberOrEmpty(_.partitionId().toLong)
     val taskAttempt = getNumberOrEmpty(_.taskAttemptId())
 
-    val metricName = s"<$stageId>[$stageAttempt]#<$partitionId>[$taskAttempt]#$name"
+    val metricName = s":sid:$stageId:sat:$stageAttempt:pid:$partitionId:tat:$taskAttempt:$name"
     val key = s"$metricNamespace.$metricName"
 
     val wrapped = Eval.later {
@@ -63,4 +63,6 @@ class MetricsSource {
 }
 
 // Singleton to make sure each metric is only registered once.
-object MetricsSource extends MetricsSource
+object MetricsSource extends MetricsSource {
+  val metricNameRegex = "^(?::sid:([^:]*):sat:([^:]*):pid:([^:]*):tat:([^:]*):)?(.*)$".r
+}

--- a/src/main/scala/cognite/spark/v1/MetricsSource.scala
+++ b/src/main/scala/cognite/spark/v1/MetricsSource.scala
@@ -25,7 +25,7 @@ class MetricsSource {
     val partitionId = getNumberOrEmpty(_.partitionId())
     val taskAttempt = getNumberOrEmpty(_.taskAttemptId())
 
-    val metricName = s"$stageId.$stageAttempt.$partitionId.$taskAttempt.$name"
+    val metricName = s"<$stageId>[$stageAttempt]#<$partitionId>[$taskAttempt]#$name"
     val key = s"$metricNamespace.$metricName"
 
     val wrapped = Eval.later {

--- a/src/main/scala/cognite/spark/v1/MetricsSource.scala
+++ b/src/main/scala/cognite/spark/v1/MetricsSource.scala
@@ -86,6 +86,21 @@ class MetricsSource {
         })
     }
   }
+
+  def getAggregatedCount(metricNamespace: String, resource: String): Option[Long] = {
+    val counters = metricsMap.asScala
+      .filterKeys(key => key.startsWith(metricNamespace) && key.endsWith(resource))
+      .values
+
+    if (counters.isEmpty) {
+      Option.empty
+    } else {
+      Some(
+        counters
+          .map(v => v.value.counter.getCount)
+          .sum)
+    }
+  }
 }
 
 // Singleton to make sure each metric is only registered once.

--- a/src/main/scala/cognite/spark/v1/MetricsSource.scala
+++ b/src/main/scala/cognite/spark/v1/MetricsSource.scala
@@ -2,11 +2,10 @@ package org.apache.spark.datasource
 
 import cats.Eval
 import com.codahale.metrics._
+import java.util.concurrent.ConcurrentHashMap
 import org.apache.spark._
 import org.log4s._
 import scala.collection.JavaConverters._
-
-import java.util.concurrent.ConcurrentHashMap
 
 class MetricsSource {
   // Add metricNamespace to differentiate with spark system metrics.

--- a/src/main/scala/cognite/spark/v1/MetricsSource.scala
+++ b/src/main/scala/cognite/spark/v1/MetricsSource.scala
@@ -63,6 +63,31 @@ class MetricsSource {
 }
 
 // Singleton to make sure each metric is only registered once.
-object MetricsSource extends MetricsSource {
-  val metricNameRegex = "^(?::sid:([^:]*):sat:([^:]*):pid:([^:]*):tat:([^:]*):)?(.*)$".r
+object MetricsSource extends MetricsSource {}
+
+case class AttemptTrackingMetricName(
+    stageId: Option[String],
+    stageAttempt: Option[String],
+    partitionId: Option[String],
+    taskAttempt: Option[String],
+    name: String) {}
+
+object AttemptTrackingMetricName {
+  private val regex = "^(?::sid:([^:]*):sat:([^:]*):pid:([^:]*):tat:([^:]*):)?(.*)$".r
+
+  def parse(name: String): AttemptTrackingMetricName =
+    name match {
+      case regex(stageId, stageAttempt, partitionId, taskAttempt, name) => {
+        AttemptTrackingMetricName(
+          Option(stageId).filterNot(_.isEmpty),
+          Option(stageAttempt).filterNot(_.isEmpty),
+          Option(partitionId).filterNot(_.isEmpty),
+          Option(taskAttempt).filterNot(_.isEmpty),
+          name
+        )
+      }
+      case _ => {
+        AttemptTrackingMetricName(None, None, None, None, name)
+      }
+    }
 }

--- a/src/main/scala/cognite/spark/v1/RawTableRelation.scala
+++ b/src/main/scala/cognite/spark/v1/RawTableRelation.scala
@@ -42,9 +42,9 @@ class RawTableRelation(
 
   // TODO: check if we need to sanitize the database and table names, or if they are reasonably named
   private def rowsCreated: Counter =
-    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"raw.$database.$table.rows.read")
-  private def rowsRead: Counter =
     MetricsSource.getOrCreateCounter(config.metricsPrefix, s"raw.$database.$table.rows.created")
+  private def rowsRead: Counter =
+    MetricsSource.getOrCreateCounter(config.metricsPrefix, s"raw.$database.$table.rows.read")
 
   override val schema: StructType = userSchema.getOrElse {
     if (inferSchema) {

--- a/src/test/scala/cognite/spark/v1/EventsRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/EventsRelationTest.scala
@@ -891,7 +891,7 @@ class EventsRelationTest extends FlatSpec with Matchers
       eventsCreated = getNumberOfRowsCreated(metricsPrefix, "events")
       _ = assert (eventsCreated == 1)
 
-      _ = a[NullPointerException] should be thrownBy getNumberOfRowsUpdated(metricsPrefix, "events")
+      _ = a[NoSuchElementException] should be thrownBy getNumberOfRowsUpdated(metricsPrefix, "events")
 
       // We need to add endTime as well, otherwise Spark is clever enough to remove duplicates
       // on its own, it seems.

--- a/src/test/scala/cognite/spark/v1/MetricsSourceTest.scala
+++ b/src/test/scala/cognite/spark/v1/MetricsSourceTest.scala
@@ -1,0 +1,76 @@
+package org.apache.spark.datasource
+
+import org.scalatest.{FlatSpec, Matchers, ParallelTestExecution}
+
+class MetricsSourceTest extends FlatSpec with Matchers with ParallelTestExecution {
+
+  behavior.of("A metric source")
+
+  it should "detect attempt parameters from the name" in {
+    val name = ":sid:1:sat:22:pid:333:tat:4444:my.name:goes.here"
+
+    name match {
+      case MetricsSource.metricNameRegex(stageId, stageAttempt, partitionId, taskAttempt, name) => {
+        assert(stageId === "1")
+        assert(stageAttempt === "22")
+        assert(partitionId === "333")
+        assert(taskAttempt === "4444")
+        assert(name === "my.name:goes.here")
+      }
+      case _ => {
+        fail("Regex did not capture the expected fields")
+      }
+    }
+  }
+
+  it should "detect accept empty parameters from the name" in {
+    val name = ":sid::sat::pid::tat::my.name:goes.here"
+
+    name match {
+      case MetricsSource.metricNameRegex(stageId, stageAttempt, partitionId, taskAttempt, name) => {
+        assert(stageId.isEmpty)
+        assert(stageAttempt.isEmpty)
+        assert(partitionId.isEmpty)
+        assert(taskAttempt.isEmpty)
+        assert(name === "my.name:goes.here")
+      }
+      case _ => {
+        fail("Regex did not capture the expected fields")
+      }
+    }
+  }
+
+  it should "work with old name format" in {
+    val name = "my.name:goes.here"
+
+    name match {
+      case MetricsSource.metricNameRegex(stageId, stageAttempt, partitionId, taskAttempt, name) => {
+        assert(stageId === null)
+        assert(stageAttempt === null)
+        assert(partitionId === null)
+        assert(taskAttempt === null)
+        assert(name === "my.name:goes.here")
+      }
+      case _ => {
+        fail("Regex did not capture the expected fields")
+      }
+    }
+  }
+
+  it should "not get confused with names that resemble attempt tracking" in {
+    val name = ":sid:1:my:name:goes:here:"
+
+    name match {
+      case MetricsSource.metricNameRegex(stageId, stageAttempt, partitionId, taskAttempt, name) => {
+        assert(stageId === null)
+        assert(stageAttempt === null)
+        assert(partitionId === null)
+        assert(taskAttempt === null)
+        assert(name === ":sid:1:my:name:goes:here:")
+      }
+      case _ => {
+        fail("Regex did not capture the expected fields")
+      }
+    }
+  }
+}

--- a/src/test/scala/cognite/spark/v1/MetricsSourceTest.scala
+++ b/src/test/scala/cognite/spark/v1/MetricsSourceTest.scala
@@ -9,68 +9,48 @@ class MetricsSourceTest extends FlatSpec with Matchers with ParallelTestExecutio
   it should "detect attempt parameters from the name" in {
     val name = ":sid:1:sat:22:pid:333:tat:4444:my.name:goes.here"
 
-    name match {
-      case MetricsSource.metricNameRegex(stageId, stageAttempt, partitionId, taskAttempt, name) => {
-        assert(stageId === "1")
-        assert(stageAttempt === "22")
-        assert(partitionId === "333")
-        assert(taskAttempt === "4444")
-        assert(name === "my.name:goes.here")
-      }
-      case _ => {
-        fail("Regex did not capture the expected fields")
-      }
-    }
+    val parsed = AttemptTrackingMetricName.parse(name);
+
+    assert(parsed.stageId === Some("1"))
+    assert(parsed.stageAttempt === Some("22"))
+    assert(parsed.partitionId === Some("333"))
+    assert(parsed.taskAttempt === Some("4444"))
+    assert(parsed.name === "my.name:goes.here")
   }
 
   it should "detect accept empty parameters from the name" in {
     val name = ":sid::sat::pid::tat::my.name:goes.here"
 
-    name match {
-      case MetricsSource.metricNameRegex(stageId, stageAttempt, partitionId, taskAttempt, name) => {
-        assert(stageId.isEmpty)
-        assert(stageAttempt.isEmpty)
-        assert(partitionId.isEmpty)
-        assert(taskAttempt.isEmpty)
-        assert(name === "my.name:goes.here")
-      }
-      case _ => {
-        fail("Regex did not capture the expected fields")
-      }
-    }
+    val parsed = AttemptTrackingMetricName.parse(name);
+
+    assert(parsed.stageId.isEmpty)
+    assert(parsed.stageAttempt.isEmpty)
+    assert(parsed.partitionId.isEmpty)
+    assert(parsed.taskAttempt.isEmpty)
+    assert(parsed.name === "my.name:goes.here")
   }
 
   it should "work with old name format" in {
     val name = "my.name:goes.here"
 
-    name match {
-      case MetricsSource.metricNameRegex(stageId, stageAttempt, partitionId, taskAttempt, name) => {
-        assert(stageId === null)
-        assert(stageAttempt === null)
-        assert(partitionId === null)
-        assert(taskAttempt === null)
-        assert(name === "my.name:goes.here")
-      }
-      case _ => {
-        fail("Regex did not capture the expected fields")
-      }
-    }
+    val parsed = AttemptTrackingMetricName.parse(name);
+
+    assert(parsed.stageId.isEmpty)
+    assert(parsed.stageAttempt.isEmpty)
+    assert(parsed.partitionId.isEmpty)
+    assert(parsed.taskAttempt.isEmpty)
+    assert(parsed.name === "my.name:goes.here")
   }
 
   it should "not get confused with names that resemble attempt tracking" in {
     val name = ":sid:1:my:name:goes:here:"
 
-    name match {
-      case MetricsSource.metricNameRegex(stageId, stageAttempt, partitionId, taskAttempt, name) => {
-        assert(stageId === null)
-        assert(stageAttempt === null)
-        assert(partitionId === null)
-        assert(taskAttempt === null)
-        assert(name === ":sid:1:my:name:goes:here:")
-      }
-      case _ => {
-        fail("Regex did not capture the expected fields")
-      }
-    }
+    val parsed = AttemptTrackingMetricName.parse(name);
+
+    assert(parsed.stageId.isEmpty)
+    assert(parsed.stageAttempt.isEmpty)
+    assert(parsed.partitionId.isEmpty)
+    assert(parsed.taskAttempt.isEmpty)
+    assert(parsed.name === ":sid:1:my:name:goes:here:")
   }
 }

--- a/src/test/scala/cognite/spark/v1/RawTableRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/RawTableRelationTest.scala
@@ -759,7 +759,7 @@ class RawTableRelationTest
     assert(df.count() == 0)
 
     // No rows should have been read, so the metric should not exist.
-    a[NullPointerException] should be thrownBy getNumberOfRowsRead(
+    a[NoSuchElementException] should be thrownBy getNumberOfRowsRead(
       metricsPrefix,
       s"raw.spark-test-database.$tableName.rows")
   }

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -271,12 +271,13 @@ trait SparkTest {
   private def getCounterSafe(metricName: String): Option[Long] =
     Option(MetricsSource.metricsMap
       .get(metricName))
-      .map(_.value.getCount)
+      .map(_.value.counter.getCount)
 
   private def getCounter(metricName: String): Long =
     MetricsSource.metricsMap
       .get(metricName)
       .value
+      .counter
       .getCount
 
   def getNumberOfRowsRead(metricsPrefix: String, resourceType: String): Long =

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -44,9 +44,11 @@ trait SparkTest {
   object OIDCWrite {
     val clientId = sys.env("TEST_CLIENT_ID2")
     val clientSecret = sys.env("TEST_CLIENT_SECRET2")
-    val tokenUri: String = sys.env.get("TEST_TOKEN_URL2")
+    val tokenUri: String = sys.env
+      .get("TEST_TOKEN_URL2")
       .orElse(
-        sys.env.get("TEST_AAD_TENANT2")
+        sys.env
+          .get("TEST_AAD_TENANT2")
           .map(tenant => s"https://login.microsoftonline.com/$tenant/oauth2/v2.0/token"))
       .getOrElse("https://sometokenurl")
     val project = sys.env("TEST_PROJECT2")
@@ -157,9 +159,11 @@ trait SparkTest {
   val testClientSecret: String = sys.env("TEST_CLIENT_SECRET")
   val testCluster: String = sys.env("TEST_CLUSTER")
   val testProject: String = sys.env("TEST_PROJECT")
-  val testTokenUriStr: String = sys.env.get("TEST_TOKEN_URL")
+  val testTokenUriStr: String = sys.env
+    .get("TEST_TOKEN_URL")
     .orElse(
-      sys.env.get("TEST_AAD_TENANT")
+      sys.env
+        .get("TEST_AAD_TENANT")
         .map(tenant => s"https://login.microsoftonline.com/$tenant/oauth2/v2.0/token"))
     .getOrElse("https://sometokenurl")
   val testTokenUri = uri"$testTokenUriStr"
@@ -189,9 +193,8 @@ trait SparkTest {
 
   def shortRandomString(): String = UUID.randomUUID().toString.substring(0, 8)
 
-  class RetryException(private val message: String,
-                       private val cause: Throwable = None.orNull)
-    extends Exception(message, cause) {}
+  class RetryException(private val message: String, private val cause: Throwable = None.orNull)
+      extends Exception(message, cause) {}
 
   // scalastyle:off cyclomatic.complexity
   def retryWithBackoff[A](
@@ -222,20 +225,23 @@ trait SparkTest {
     retryWithBackoff(
       for {
         actionValue <- action
-        _ <- IO.delay { if (shouldRetry(actionValue)) {
-          throw new RetryException(
-            s"Retry needed at ${pos.fileName}:${pos.lineNumber}, value = ${prettifier(actionValue)}")
-        } }
+        _ <- IO.delay {
+          if (shouldRetry(actionValue)) {
+            throw new RetryException(
+              s"Retry needed at ${pos.fileName}:${pos.lineNumber}, value = ${prettifier(actionValue)}")
+          }
+        }
       } yield actionValue,
       1.second,
       20
     )
 
   def retryWhile[A](action: => A, shouldRetry: A => Boolean)(
-    implicit prettifier: Prettifier,
-    pos: source.Position): A =
+      implicit prettifier: Prettifier,
+      pos: source.Position): A =
     retryWhileIO(IO.unit.map(_ => action), shouldRetry)
-      .unsafeRunTimed(5.minutes).getOrElse(throw new RuntimeException("Test timed out during retries"))
+      .unsafeRunTimed(5.minutes)
+      .getOrElse(throw new RuntimeException("Test timed out during retries"))
 
   val updateAndUpsert: TableFor1[String] = Table(heading = "mode", "upsert", "update")
 
@@ -268,46 +274,36 @@ trait SparkTest {
       useSharedThrottle = false
     )
 
-  private def getCounterSafe(metricName: String): Option[Long] =
-    Option(MetricsSource.metricsMap
-      .get(metricName))
-      .map(_.value.counter.getCount)
+  private def getCounterSafe(metricsNamespace: String, resource: String): Option[Long] =
+    MetricsSource.getAggregatedCount(metricsNamespace, resource)
 
-  private def getCounter(metricName: String): Long =
-    MetricsSource.metricsMap
-      .get(metricName)
-      .value
-      .counter
-      .getCount
+  private def getCounter(metricsNamespace: String, resource: String): Long =
+    getCounterSafe(metricsNamespace, resource).get
 
   def getNumberOfRowsRead(metricsPrefix: String, resourceType: String): Long =
-    getCounter(s"$metricsPrefix.$resourceType.read")
+    getCounter(metricsPrefix, s"$resourceType.read")
 
   def getNumberOfRowsReadSafe(metricsPrefix: String, resourceType: String): Option[Long] =
-    getCounterSafe(s"$metricsPrefix.$resourceType.read")
+    getCounterSafe(metricsPrefix, s"$resourceType.read")
 
   def getNumberOfRowsCreated(metricsPrefix: String, resourceType: String): Long =
-    getCounter(s"$metricsPrefix.$resourceType.created")
+    getCounter(metricsPrefix, s"$resourceType.created")
 
   def getNumberOfRowsUpserted(metricsPrefix: String, resourceType: String): Long =
-    getCounter(s"$metricsPrefix.$resourceType.upserted")
+    getCounter(metricsPrefix, s"$resourceType.upserted")
 
   def getNumberOfRequests(metricsPrefix: String): Long =
-    getCounter(s"$metricsPrefix.requestsWithoutRetries")
+    getCounter(metricsPrefix, "requestsWithoutRetries")
 
   def getNumberOfRowsDeleted(metricsPrefix: String, resourceType: String): Long =
-    getCounter(s"$metricsPrefix.$resourceType.deleted")
+    getCounter(metricsPrefix, s"$resourceType.deleted")
 
   def getNumberOfRowsUpdated(metricsPrefix: String, resourceType: String): Long =
-    getCounter(s"$metricsPrefix.$resourceType.updated")
+    getCounter(metricsPrefix, s"$resourceType.updated")
 
   def getPartitionSize(metricsPrefix: String, resourceType: String, partitionIndex: Long): Long = {
-    val metricName = s"$metricsPrefix.$resourceType.$partitionIndex.partitionSize"
-    if (MetricsSource.metricsMap.containsKey(metricName)) {
-      getCounter(metricName)
-    } else {
-      0
-    }
+    val resource = s"$resourceType.$partitionIndex.partitionSize"
+    getCounterSafe(metricsPrefix, resource).getOrElse(0)
   }
 
   def sparkIntercept(f: => Any)(implicit pos: source.Position): Throwable =

--- a/src/test/scala/cognite/spark/v1/TimeSeriesRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/TimeSeriesRelationTest.scala
@@ -85,7 +85,7 @@ class TimeSeriesRelationTest
     assert(df.count() == 0)
 
     // Metrics counter does not create a Map key until reading the first row
-    assertThrows[NullPointerException](getNumberOfRowsRead(metricsPrefix, "timeseries"))
+    assertThrows[NoSuchElementException](getNumberOfRowsRead(metricsPrefix, "timeseries"))
   }
 
   it should "not fetch all items if filter on id" taggedAs WriteTest in {
@@ -184,8 +184,8 @@ class TimeSeriesRelationTest
         .load()
       df.createOrReplaceTempView("destinationTimeSeriesInsertAndUpdate")
 
-      a[NullPointerException] should be thrownBy getNumberOfRowsCreated(metricsPrefix, "timeseries")
-      a[NullPointerException] should be thrownBy getNumberOfRowsUpdated(metricsPrefix, "timeseries")
+      a[NoSuchElementException] should be thrownBy getNumberOfRowsCreated(metricsPrefix, "timeseries")
+      a[NoSuchElementException] should be thrownBy getNumberOfRowsUpdated(metricsPrefix, "timeseries")
 
       val randomSuffix = shortRandomString()
       // Insert new time series test data
@@ -212,7 +212,7 @@ class TimeSeriesRelationTest
         .write
         .insertInto("destinationTimeSeriesInsertAndUpdate")
 
-      a[NullPointerException] should be thrownBy getNumberOfRowsUpdated(metricsPrefix, "timeseries")
+      a[NoSuchElementException] should be thrownBy getNumberOfRowsUpdated(metricsPrefix, "timeseries")
       val rowsCreated = getNumberOfRowsCreated(metricsPrefix, "timeseries")
       assert(rowsCreated == 5)
 
@@ -327,7 +327,7 @@ class TimeSeriesRelationTest
         .option("metricsPrefix", metricsPrefix)
         .save()
 
-      a[NullPointerException] should be thrownBy getNumberOfRowsUpdated(metricsPrefix, "timeseries")
+      a[NoSuchElementException] should be thrownBy getNumberOfRowsUpdated(metricsPrefix, "timeseries")
       val rowsCreated = getNumberOfRowsCreated(metricsPrefix, "timeseries")
       assert(rowsCreated == 7)
 
@@ -354,7 +354,7 @@ class TimeSeriesRelationTest
       assert(insertCdpApiException.code == 409)
       val rowsCreatedAfterAbort = getNumberOfRowsCreated(metricsPrefix, "timeseries")
       assert(rowsCreatedAfterAbort == 7)
-      assertThrows[NullPointerException](getNumberOfRowsUpdated(metricsPrefix, "timeseries"))
+      assertThrows[NoSuchElementException](getNumberOfRowsUpdated(metricsPrefix, "timeseries"))
     } finally {
       try {
         cleanUpTimeSeriesTestDataByUnit(abortUnit)


### PR DESCRIPTION
### Add attempt number to metric names

By adding the attempt number to the metrics it will be possible to get
the highest attempt for each stage and task and allowing ignoring
metrics coming from failed/retried tasks. A good example would be the
effective number of rows added.

Though, the metrics don't allow labels, and instead uses dot-delimited
fields such as job id.
By keeping always a consistent number of fields, these can be extracted
while aggregating the metrics. Therefore, it is the responsibility of
the MetricSource to enforce this consistency.