### PR TITLE
Add deregistering of metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,12 @@ lazy val commonSettings = Seq(
   description := "Spark data source for the Cognite Data Platform.",
   licenses := List("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt")),
   homepage := Some(url("https://github.com/cognitedata/cdp-spark-datasource")),
-  scalacOptions ++= Seq("-Xlint:unused", "-language:higherKinds", "-deprecation", "-feature"),
+  scalacOptions ++= Seq("-Xlint:unused", "-language:higherKinds", "-deprecation", "-feature") ++ (CrossVersion.partialVersion(scalaVersion.value) match {
+    // We use JavaConverters to remain backwards compatible with Scala 2.12,
+    // and to avoid a dependency on scala-collection-compat
+    case Some((2, 13)) => Seq("-Wconf:src=src/main/scala/cognite/spark/v1/MetricsSource.scala&cat=deprecation:i")
+    case _ => Seq.empty
+  }),
   resolvers ++= Resolver.sonatypeOssRepos("releases"),
   developers := List(
     Developer(

--- a/src/test/scala/cognite/spark/v1/MetricsSourceTest.scala
+++ b/src/test/scala/cognite/spark/v1/MetricsSourceTest.scala
@@ -32,16 +32,16 @@ class MetricsSourceTest extends FlatSpec with Matchers {
     MetricsSource.getOrCreateCounter("removePrefix.jobId", "name")
     MetricsSource.getOrCreateCounter("removePrefix.otherJobId", "name")
 
-    Option(MetricsSource.metricsMap.get("removePrefix.jobId.name")) shouldBe 'defined
-    Option(MetricsSource.metricsMap.get("removePrefix.otherJobId.name")) shouldBe 'defined
+    Option(MetricsSource.metricsMap.get("removePrefix.jobId.name")).isDefined shouldBe true
+    Option(MetricsSource.metricsMap.get("removePrefix.otherJobId.name")).isDefined shouldBe true
     SparkEnv.get.metricsSystem.getSourcesByName("removePrefix.jobId").size should equal(1)
     SparkEnv.get.metricsSystem.getSourcesByName("removePrefix.otherJobId").size should equal(1)
 
-    MetricsSource.removeJobMetrics("removePrefix", "jobId")
+    MetricsSource.removeJobMetrics("removePrefix.jobId")
 
-    Option(MetricsSource.metricsMap.get("removePrefix.jobId.name")) shouldBe 'empty
-    Option(MetricsSource.metricsMap.get("removePrefix.otherJobId.name")) shouldBe 'defined
-    SparkEnv.get.metricsSystem.getSourcesByName("removePrefix.jobId") shouldBe 'empty
+    Option(MetricsSource.metricsMap.get("removePrefix.jobId.name")).isDefined shouldBe false
+    Option(MetricsSource.metricsMap.get("removePrefix.otherJobId.name")).isDefined shouldBe true
+    SparkEnv.get.metricsSystem.getSourcesByName("removePrefix.jobId").size should equal(0)
     SparkEnv.get.metricsSystem.getSourcesByName("removePrefix.otherJobId").size should equal(1)
   }
 }

--- a/src/test/scala/cognite/spark/v1/MetricsSourceTest.scala
+++ b/src/test/scala/cognite/spark/v1/MetricsSourceTest.scala
@@ -1,0 +1,47 @@
+package org.apache.spark.datasource
+
+import org.scalatest.{FlatSpec, Matchers}
+import org.apache.spark.SparkEnv
+import org.apache.spark.sql.SparkSession
+
+class MetricsSourceTest extends FlatSpec with Matchers {
+  val spark: SparkSession = SparkSession
+    .builder()
+    .master("local[*]")
+    .config("spark.ui.enabled", "false") // comment this out to use Spark UI during tests, on https://localhost:4040 by default
+    // https://medium.com/@mrpowers/how-to-cut-the-run-time-of-a-spark-sbt-test-suite-by-40-52d71219773f
+    .config("spark.sql.shuffle.partitions", "1")
+    .config("spark.sql.storeAssignmentPolicy", "legacy")
+    .config("spark.app.id", this.getClass.getName + math.floor(math.random() * 1000).toLong.toString)
+    .getOrCreate()
+
+  "A MetricsSource" should "register a new metric only once" in {
+    val metric = MetricsSource.getOrCreateCounter("prefix", "name")
+    val sameMetric = MetricsSource.getOrCreateCounter("prefix", "name")
+
+    metric.getCount() should equal(0)
+    sameMetric.getCount() should equal(0)
+
+    metric.inc()
+
+    metric.getCount() should equal(1)
+    sameMetric.getCount() should equal(1)
+  }
+
+  it should "deregister a metric only once" in {
+    MetricsSource.getOrCreateCounter("removePrefix.jobId", "name")
+    MetricsSource.getOrCreateCounter("removePrefix.otherJobId", "name")
+
+    Option(MetricsSource.metricsMap.get("removePrefix.jobId.name")) shouldBe 'defined
+    Option(MetricsSource.metricsMap.get("removePrefix.otherJobId.name")) shouldBe 'defined
+    SparkEnv.get.metricsSystem.getSourcesByName("removePrefix.jobId").size should equal(1)
+    SparkEnv.get.metricsSystem.getSourcesByName("removePrefix.otherJobId").size should equal(1)
+
+    MetricsSource.removeJobMetrics("removePrefix", "jobId")
+
+    Option(MetricsSource.metricsMap.get("removePrefix.jobId.name")) shouldBe 'empty
+    Option(MetricsSource.metricsMap.get("removePrefix.otherJobId.name")) shouldBe 'defined
+    SparkEnv.get.metricsSystem.getSourcesByName("removePrefix.jobId") shouldBe 'empty
+    SparkEnv.get.metricsSystem.getSourcesByName("removePrefix.otherJobId").size should equal(1)
+  }
+}

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -271,12 +271,13 @@ trait SparkTest {
   private def getCounterSafe(metricName: String): Option[Long] =
     Option(MetricsSource.metricsMap
       .get(metricName))
-      .map(_.value.getCount)
+      .map(_.value.counter.getCount)
 
   private def getCounter(metricName: String): Long =
     MetricsSource.metricsMap
       .get(metricName)
       .value
+      .counter
       .getCount
 
   def getNumberOfRowsRead(metricsPrefix: String, resourceType: String): Long =


### PR DESCRIPTION
Upon job end, the driver may call a method to both clean the tracking hashmap and deregister the source from the MetricsSystem.

The new method will remove all metrics belonging to a given job UUID.