### PR TITLE
Update Chimney to 1.0.0, provide TransformerConfiguration to keep the old behavior…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,7 @@ lazy val structType = (project in file("struct_type"))
     name := "cdf-spark-datasource-struct-type",
     crossScalaVersions := supportedScalaVersions,
     libraryDependencies ++= Seq(
-      "io.scalaland" %% "chimney" % "0.6.1",
+      "io.scalaland" %% "chimney" % "1.0.0",
       "org.typelevel" %% "cats-core" % "2.9.0",
       "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,
     ),
@@ -134,8 +134,8 @@ lazy val library = (project in file("."))
     crossScalaVersions := supportedScalaVersions,
     libraryDependencies ++= Seq(
       "com.cognite" %% "cognite-sdk-scala" % cogniteSdkVersion changing(),
-      "io.scalaland" %% "chimney" % "0.6.1"
-        // scala-collection-compat is used in TransformerF, but we don't use that,
+      "io.scalaland" %% "chimney" % "1.0.0"
+        // scala-collection-compat is used in stdlib collections conversion,
         // and this dependency causes issues with Livy.
         exclude("org.scala-lang.modules", "scala-collection-compat_2.12")
         exclude("org.scala-lang.modules", "scala-collection-compat_2.13"),

--- a/build.scala-2.12.sbt.lock
+++ b/build.scala-2.12.sbt.lock
@@ -1,6 +1,6 @@
 {
   "lockVersion" : 1,
-  "timestamp" : "2024-04-10T11:03:49.660918394Z",
+  "timestamp" : "2024-05-23T11:38:41.023372Z",
   "configurations" : [
     "compile",
     "optional",
@@ -1100,12 +1100,29 @@
     },
     {
       "org" : "io.scalaland",
+      "name" : "chimney-macro-commons_2.12",
+      "version" : "1.0.0",
+      "artifacts" : [
+        {
+          "name" : "chimney-macro-commons_2.12.jar",
+          "hash" : "sha1:0746159d5095ca157b3342b9ce570e39bab64080"
+        }
+      ],
+      "configurations" : [
+        "compile",
+        "provided",
+        "runtime",
+        "test"
+      ]
+    },
+    {
+      "org" : "io.scalaland",
       "name" : "chimney_2.12",
-      "version" : "0.6.1",
+      "version" : "1.0.0",
       "artifacts" : [
         {
           "name" : "chimney_2.12.jar",
-          "hash" : "sha1:0549d763679547561ee7bc4d4221f51bec654110"
+          "hash" : "sha1:81448a78773f2cd68b52633954ddc32b094cca05"
         }
       ],
       "configurations" : [

--- a/build.scala-2.13.sbt.lock
+++ b/build.scala-2.13.sbt.lock
@@ -1,6 +1,6 @@
 {
   "lockVersion" : 1,
-  "timestamp" : "2024-04-10T11:03:58.432210166Z",
+  "timestamp" : "2024-05-23T11:39:24.534804Z",
   "configurations" : [
     "compile",
     "optional",
@@ -1100,12 +1100,29 @@
     },
     {
       "org" : "io.scalaland",
+      "name" : "chimney-macro-commons_2.13",
+      "version" : "1.0.0",
+      "artifacts" : [
+        {
+          "name" : "chimney-macro-commons_2.13.jar",
+          "hash" : "sha1:4d0fbb2a1c1f008a8f6cc76f72fbbd1b7a43176b"
+        }
+      ],
+      "configurations" : [
+        "compile",
+        "provided",
+        "runtime",
+        "test"
+      ]
+    },
+    {
+      "org" : "io.scalaland",
       "name" : "chimney_2.13",
-      "version" : "0.6.1",
+      "version" : "1.0.0",
       "artifacts" : [
         {
           "name" : "chimney_2.13.jar",
-          "hash" : "sha1:6798df6d29f006ce65de3aa17aa69e1d7077ccc6"
+          "hash" : "sha1:92728943e6ab7285fb7ed5531c94e8cfc4a7e211"
         }
       ],
       "configurations" : [

--- a/src/main/scala/cognite/spark/v1/package.scala
+++ b/src/main/scala/cognite/spark/v1/package.scala
@@ -3,9 +3,13 @@ package cognite.spark
 import com.cognite.sdk.scala.common.{NonNullableSetter, SdkException, SetNull, SetValue, Setter}
 import com.cognite.sdk.scala.v1.{SequenceColumn, SequenceColumnCreate}
 import io.scalaland.chimney.Transformer
+import io.scalaland.chimney.dsl.TransformerConfiguration
 
 // scalastyle:off
 package object v1 {
+  implicit val chimneyConfiguration =
+    TransformerConfiguration.default.enableMethodAccessors.enableDefaultValues
+
   @SuppressWarnings(
     Array(
       "org.wartremover.warts.Null",


### PR DESCRIPTION
…, fix 2 incorrectly used `u.into[U].withFieldConst(...).transform` where `.withFieldConst` was silently ignored in the presence of an `implicit`