### PR TITLE
Cleanup unused withFieldComputed

### DIFF
--- a/src/main/scala/cognite/spark/v1/SdkV1Relation.scala
+++ b/src/main/scala/cognite/spark/v1/SdkV1Relation.scala
@@ -81,7 +81,7 @@ abstract class SdkV1Relation[A <: Product, I](config: RelationConfig, shortName:
     }
     val updateExternalIds = if (updatesByExternalId.isEmpty) { IO.unit } else {
       val updatesByExternalIdMap = updatesByExternalId
-        .map(u => u.getExternalId.get -> u.into[U].withFieldComputed(_.externalId, _ => None).transform)
+        .map(u => u.getExternalId.get -> u.transformInto[U])
         .toMap
 
       resource
@@ -132,8 +132,7 @@ abstract class SdkV1Relation[A <: Product, I](config: RelationConfig, shortName:
       resource
         .updateByExternalId(
           resourcesToUpdate
-            .map(u =>
-              u.getExternalId.get -> u.into[U].withFieldComputed(_.externalId, _ => None).transform)
+            .map(u => u.getExternalId.get -> u.transformInto[U])
             .toMap)
         .flatTap(_ => incMetrics(itemsUpdated, resourcesToUpdate.size))
         .map(_ => ())


### PR DESCRIPTION
36b9900c83d795d04689136e4474458fb937b19d introduced it when doing some other change,
it doesn't look like setting `externalId` to `None` is the intent in that code either before or in the change.

One of library maintainers mentioned it in
https://github.com/cognitedata/cdp-spark-datasource/pull/933/files#r1611561212
and that it will be rejected in newer library versions.

Let's make this change in isolation to make update to `1.0.0` more clean
