### PR TITLE
Control attempt tracking from config

### DIFF
--- a/src/main/scala/cognite/spark/v1/CdfRelation.scala
+++ b/src/main/scala/cognite/spark/v1/CdfRelation.scala
@@ -16,6 +16,7 @@ abstract class CdfRelation(config: RelationConfig, shortNameStr: String)
 
   private def getOrCreateCounter(action: String): Counter =
     MetricsSource.getOrCreateAttemptTrackingCounter(
+      config.metricsTrackAttempts,
       config.metricsPrefix,
       s"$shortName.$action",
       Option(TaskContext.get()))

--- a/src/main/scala/cognite/spark/v1/CdpConnector.scala
+++ b/src/main/scala/cognite/spark/v1/CdpConnector.scala
@@ -104,6 +104,7 @@ object CdpConnector {
     new BackpressureThrottleBackend[IO, Any](sttpBackend, makeQueueOf1.unsafeRunSync(), 800.milliseconds)
   }
 
+  // scalastyle:off method.length
   def retryingSttpBackend(
       metricsTrackAttempts: Boolean,
       maxRetries: Int,
@@ -163,6 +164,7 @@ object CdpConnector {
       )
     )
   }
+  // scalastyle:on method.length
 
   def clientFromConfig(config: RelationConfig, cdfVersion: Option[String] = None): GenericClient[IO] = {
     val metricsPrefix = if (config.collectMetrics) {

--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -411,6 +411,7 @@ object DefaultSource {
       case Some(prefix) => s"$prefix"
       case None => ""
     }
+    val metricsTrackAttempts = toBoolean(parameters, "metricsTrackAttempts")
     val collectMetrics = toBoolean(parameters, "collectMetrics")
     val collectTestMetrics = toBoolean(parameters, "collectTestMetrics")
 
@@ -459,6 +460,7 @@ object DefaultSource {
       collectMetrics = collectMetrics,
       collectTestMetrics = collectTestMetrics,
       metricsPrefix = metricsPrefix,
+      metricsTrackAttempts = metricsTrackAttempts,
       baseUrl = baseUrl,
       onConflict = saveMode,
       applicationId = Option(sqlContext).map(_.sparkContext.applicationId).getOrElse("CDF"),

--- a/src/main/scala/cognite/spark/v1/MetricsSource.scala
+++ b/src/main/scala/cognite/spark/v1/MetricsSource.scala
@@ -14,8 +14,7 @@ class MetricsSource {
       trackAttempts: Boolean,
       metricNamespace: String,
       name: String,
-      ctx: Option[TaskContext],
-  ): Counter = {
+      ctx: Option[TaskContext]): Counter = {
 
     val metricName = if (trackAttempts) {
       def getNumberOrEmpty(getter: TaskContext => Long): String =

--- a/src/main/scala/cognite/spark/v1/RawTableRelation.scala
+++ b/src/main/scala/cognite/spark/v1/RawTableRelation.scala
@@ -44,11 +44,13 @@ class RawTableRelation(
   // TODO: check if we need to sanitize the database and table names, or if they are reasonably named
   @transient lazy private val rowsCreated: Counter =
     MetricsSource.getOrCreateAttemptTrackingCounter(
+      config.metricsTrackAttempts,
       config.metricsPrefix,
       s"raw.$database.$table.rows.created",
       Option(TaskContext.get()))
   @transient lazy private val rowsRead: Counter =
     MetricsSource.getOrCreateAttemptTrackingCounter(
+      config.metricsTrackAttempts,
       config.metricsPrefix,
       s"raw.$database.$table.rows.read",
       Option(TaskContext.get()))
@@ -160,6 +162,7 @@ class RawTableRelation(
           @transient lazy val partitionSize =
             MetricsSource
               .getOrCreateAttemptTrackingCounter(
+                config.metricsTrackAttempts,
                 config.metricsPrefix,
                 s"raw.$database.$table.${partitionIndex.getOrElse(0)}.partitionSize",
                 Option(TaskContext.get()))

--- a/src/main/scala/cognite/spark/v1/RelationConfig.scala
+++ b/src/main/scala/cognite/spark/v1/RelationConfig.scala
@@ -15,6 +15,7 @@ final case class RelationConfig(
     collectMetrics: Boolean,
     collectTestMetrics: Boolean,
     metricsPrefix: String,
+    metricsTrackAttempts: Boolean,
     baseUrl: String,
     onConflict: OnConflictOption,
     applicationId: String,

--- a/src/test/scala/cognite/spark/v1/DefaultSourceTest.scala
+++ b/src/test/scala/cognite/spark/v1/DefaultSourceTest.scala
@@ -8,7 +8,7 @@ import sttp.client3.{SttpBackend, UriContext}
 
 class DefaultSourceTest extends WordSpec with Matchers {
 
-  implicit val backend: SttpBackend[IO, Any] = CdpConnector.retryingSttpBackend(3, 5)
+  implicit val backend: SttpBackend[IO, Any] = CdpConnector.retryingSttpBackend(false, 3, 5)
 
   "DefaultSource" should {
     "parseAuth and fall back in order" should {
@@ -47,8 +47,7 @@ class DefaultSourceTest extends WordSpec with Matchers {
           }
         DefaultSource.parseAuth(params) shouldBe Some(
           CdfSparkAuth.OAuth2Sessions(OAuth2
-            .Session("https://value-field.cognitedata.com", 123, "value-SessionKey",
-              "value-Project"))
+            .Session("https://value-field.cognitedata.com", 123, "value-SessionKey", "value-Project"))
         )
       }
 
@@ -103,13 +102,16 @@ class DefaultSourceTest extends WordSpec with Matchers {
         DefaultSource.parseCogniteIds("\"[123,456]\"") shouldBe List(CogniteExternalId("[123,456]"))
       }
       "parse arrays according to their contents" in {
-        DefaultSource.parseCogniteIds("""[123, "123"]""") shouldBe List(CogniteInternalId(123), CogniteExternalId("123"))
+        DefaultSource.parseCogniteIds("""[123, "123"]""") shouldBe List(
+          CogniteInternalId(123),
+          CogniteExternalId("123"))
       }
       "parse other valid json as externalId" in {
-        DefaultSource.parseCogniteIds("""{"key": 123}""") shouldBe List(CogniteExternalId("""{"key": 123}"""))
-        DefaultSource.parseCogniteIds("""[123, "123", {"abc": 0} ]""") shouldBe List(CogniteExternalId("""[123, "123", {"abc": 0} ]"""))
+        DefaultSource.parseCogniteIds("""{"key": 123}""") shouldBe List(
+          CogniteExternalId("""{"key": 123}"""))
+        DefaultSource.parseCogniteIds("""[123, "123", {"abc": 0} ]""") shouldBe List(
+          CogniteExternalId("""[123, "123", {"abc": 0} ]"""))
       }
     }
   }
 }
-

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -67,7 +67,7 @@ trait SparkTest {
     audience = Some(OIDCWrite.audience),
     cdfProjectName = OIDCWrite.project,
   )
-  implicit val sttpBackend: SttpBackend[IO, Any] = CdpConnector.retryingSttpBackend(15, 30)
+  implicit val sttpBackend: SttpBackend[IO, Any] = CdpConnector.retryingSttpBackend(false, 15, 30)
 
   val writeAuthProvider =
     OAuth2.ClientCredentialsProvider[IO](writeCredentials).unsafeRunTimed(1.second).get
@@ -260,6 +260,7 @@ trait SparkTest {
       initialRetryDelayMillis = Constants.DefaultInitialRetryDelay.toMillis.toInt,
       collectMetrics = false,
       collectTestMetrics = false,
+      metricsTrackAttempts = false,
       metricsPrefix = "",
       baseUrl = Constants.DefaultBaseUrl,
       onConflict = OnConflictOption.Abort,


### PR DESCRIPTION
Let the driver control the attempt tracking of metrics
Will default to `false`