### PR TITLE
Improve filters

### DIFF
--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
@@ -364,8 +364,8 @@ abstract class FlexibleDataModelBaseRelation(config: RelationConfig, sqlContext:
       instanceType: InstanceType,
       attribute: String): Seq[String] =
     //type is a special case, and is reserved for edges only and is an alias of _type
-    if (attribute.equalsIgnoreCase("type")) {
-      Vector(instanceType.productPrefix.toLowerCase(Locale.US), "_type")
+    if (attribute.equalsIgnoreCase("_type")) {
+      Vector(instanceType.productPrefix.toLowerCase(Locale.US), "type")
     } else {
       Vector(instanceType.productPrefix.toLowerCase(Locale.US), attribute)
     }

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
@@ -366,8 +366,9 @@ abstract class FlexibleDataModelBaseRelation(config: RelationConfig, sqlContext:
     //type is a special case, and is reserved for edges only and is an alias of _type
     if (attribute.equalsIgnoreCase("type")) {
       Vector(instanceType.productPrefix.toLowerCase(Locale.US), "_type")
+    } else {
+      Vector(instanceType.productPrefix.toLowerCase(Locale.US), attribute)
     }
-    Vector(instanceType.productPrefix.toLowerCase(Locale.US), attribute)
   }
 
   private def relationReferenceInnerStruct(): StructType =

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
@@ -362,14 +362,13 @@ abstract class FlexibleDataModelBaseRelation(config: RelationConfig, sqlContext:
   // Filter definitions for attributes for nodes & edges
   private def createNodeOrEdgeCommonAttributeRef(
       instanceType: InstanceType,
-      attribute: String): Seq[String] = {
+      attribute: String): Seq[String] =
     //type is a special case, and is reserved for edges only and is an alias of _type
     if (attribute.equalsIgnoreCase("type")) {
       Vector(instanceType.productPrefix.toLowerCase(Locale.US), "_type")
     } else {
       Vector(instanceType.productPrefix.toLowerCase(Locale.US), attribute)
     }
-  }
 
   private def relationReferenceInnerStruct(): StructType =
     DataTypes.createStructType(

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
@@ -363,12 +363,15 @@ abstract class FlexibleDataModelBaseRelation(config: RelationConfig, sqlContext:
   // Filter definitions for attributes for nodes & edges
   private def createNodeOrEdgeCommonAttributeRef(
       instanceType: InstanceType,
-      attribute: String): Seq[String] =
-    if (attribute.equalsIgnoreCase("_type")) {
-      Vector(instanceType.productPrefix.toLowerCase(Locale.US), "type")
-    } else {
-      Vector(instanceType.productPrefix.toLowerCase(Locale.US), attribute)
+      attribute: String): Seq[String] = {
+    val instanceAttribute =  {
+      if(attribute.equalsIgnoreCase("_type"))
+        "type"
+      else
+        attribute
     }
+    Vector(instanceType.productPrefix.toLowerCase(Locale.US), instanceAttribute)
+  }
 
   private def relationReferenceInnerStruct(): StructType =
     DataTypes.createStructType(

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
@@ -59,8 +59,9 @@ abstract class FlexibleDataModelBaseRelation(config: RelationConfig, sqlContext:
 
   private def isReservedAttribute(instanceType: InstanceType, attribute: String) = {
     val alwaysReservedAttributes: Set[String] = Set("space", "externalId", "_type")
-    val edgeReservedAttributes: Set[String] = Set("type", "startNode", "endNode")
+
     // type is supported as an alias to _type for edges for legacy reasons.
+    val edgeReservedAttributes: Set[String] = Set("type", "startNode", "endNode")
     alwaysReservedAttributes.contains(attribute) ||
     (instanceType == InstanceType.Edge && edgeReservedAttributes.contains(attribute))
   }
@@ -363,7 +364,6 @@ abstract class FlexibleDataModelBaseRelation(config: RelationConfig, sqlContext:
   private def createNodeOrEdgeCommonAttributeRef(
       instanceType: InstanceType,
       attribute: String): Seq[String] =
-    //type is a special case, and is reserved for edges only and is an alias of _type
     if (attribute.equalsIgnoreCase("_type")) {
       Vector(instanceType.productPrefix.toLowerCase(Locale.US), "type")
     } else {

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
@@ -81,6 +81,7 @@ abstract class FlexibleDataModelBaseRelation(config: RelationConfig, sqlContext:
   protected def toFilter(
       instanceType: InstanceType,
       sparkFilter: Filter,
+      // viewReference is required for non-reserved attribute filters resolution
       viewReference: Option[ViewReference]
   ): Either[CdfSparkException, FilterDefinition] =
     sparkFilter match {

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
@@ -86,15 +86,15 @@ abstract class FlexibleDataModelBaseRelation(config: RelationConfig, sqlContext:
   ): Either[CdfSparkException, FilterDefinition] =
     sparkFilter match {
       case EqualTo(attribute, _) if isReservedAttribute(instanceType, attribute) =>
-        toNodeOrEdgeAttributeFilter(instanceType, sparkFilter)
+        toReservedAttributeFilter(instanceType, sparkFilter)
       case IsNull(attribute) if isReservedAttribute(instanceType, attribute) =>
-        toNodeOrEdgeAttributeFilter(instanceType, sparkFilter)
+        toReservedAttributeFilter(instanceType, sparkFilter)
       case IsNotNull(attribute) if isReservedAttribute(instanceType, attribute) =>
-        toNodeOrEdgeAttributeFilter(instanceType, sparkFilter)
+        toReservedAttributeFilter(instanceType, sparkFilter)
       case StringStartsWith(attribute, _) if isReservedAttribute(instanceType, attribute) =>
-        toNodeOrEdgeAttributeFilter(instanceType, sparkFilter)
+        toReservedAttributeFilter(instanceType, sparkFilter)
       case In(attribute, _) if isReservedAttribute(instanceType, attribute) =>
-        toNodeOrEdgeAttributeFilter(instanceType, sparkFilter)
+        toReservedAttributeFilter(instanceType, sparkFilter)
       case And(f1, f2) =>
         Vector(f1, f2)
           .traverse(toFilter(instanceType, _, viewReference))
@@ -169,7 +169,7 @@ abstract class FlexibleDataModelBaseRelation(config: RelationConfig, sqlContext:
 
   // Some reserved attributes are not attached to a view but directly to the node/edge
   // This handles filtering on these attributes.
-  private def toNodeOrEdgeAttributeFilter(
+  private def toReservedAttributeFilter(
       instanceType: InstanceType,
       sparkFilter: Filter): Either[CdfSparkException, FilterDefinition] = {
     val nodeOrEdgeStringAttributes = Seq("space", "externalId")

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
@@ -85,6 +85,7 @@ abstract class FlexibleDataModelBaseRelation(config: RelationConfig, sqlContext:
       viewReference: Option[ViewReference]
   ): Either[CdfSparkException, FilterDefinition] =
     sparkFilter match {
+      // reserved attributes case, make sure to update toReservedAttributeFilter when adding more
       case EqualTo(attribute, _) if isReservedAttribute(instanceType, attribute) =>
         toReservedAttributeFilter(instanceType, sparkFilter)
       case IsNull(attribute) if isReservedAttribute(instanceType, attribute) =>
@@ -95,6 +96,7 @@ abstract class FlexibleDataModelBaseRelation(config: RelationConfig, sqlContext:
         toReservedAttributeFilter(instanceType, sparkFilter)
       case In(attribute, _) if isReservedAttribute(instanceType, attribute) =>
         toReservedAttributeFilter(instanceType, sparkFilter)
+      // end reserved attributes case
       case And(f1, f2) =>
         Vector(f1, f2)
           .traverse(toFilter(instanceType, _, viewReference))

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
@@ -5,7 +5,10 @@ import cats.implicits._
 import cognite.spark.v1.FlexibleDataModelBaseRelation.ProjectedFlexibleDataModelInstance
 import com.cognite.sdk.scala.v1.GenericClient
 import com.cognite.sdk.scala.v1.fdm.common.Usage
-import com.cognite.sdk.scala.v1.fdm.common.filters.FilterValueDefinition.{ComparableFilterValue, SeqFilterValue}
+import com.cognite.sdk.scala.v1.fdm.common.filters.FilterValueDefinition.{
+  ComparableFilterValue,
+  SeqFilterValue
+}
 import com.cognite.sdk.scala.v1.fdm.common.filters.{FilterDefinition, FilterValueDefinition}
 import com.cognite.sdk.scala.v1.fdm.common.properties.PropertyDefinition.ViewPropertyDefinition
 import com.cognite.sdk.scala.v1.fdm.common.properties.PropertyType._
@@ -67,13 +70,13 @@ abstract class FlexibleDataModelBaseRelation(config: RelationConfig, sqlContext:
   private def extractInstancePropertyValue(key: String, value: InstancePropertyValue): Any =
     FlexibleDataModelRelationUtils.extractInstancePropertyValue(schema.apply(key).dataType, value)
 
-  private def getVersionedViewExternalId(viewReference: ViewReference): String = {
+  private def getVersionedViewExternalId(viewReference: ViewReference): String =
     s"${viewReference.externalId}/${viewReference.version}"
-  }
 
-  private def getViewAttributeReference(viewReference: ViewReference, propertyName: String): Seq[String] = {
+  private def getViewAttributeReference(
+      viewReference: ViewReference,
+      propertyName: String): Seq[String] =
     Seq(viewReference.space, getVersionedViewExternalId(viewReference), propertyName)
-  }
 
   protected def toFilter(
       instanceType: InstanceType,
@@ -109,7 +112,9 @@ abstract class FlexibleDataModelBaseRelation(config: RelationConfig, sqlContext:
           new CdfSparkIllegalArgumentException(
             s"""Unsupported filter '${f.getClass.getSimpleName}', ${f.toString}
                | for space: ${viewReference.map(_.space).getOrElse("not specified")}
-               | and versionedExternalId: ${viewReference.map(getVersionedViewExternalId).getOrElse("not specified")}
+               | and versionedExternalId: ${viewReference
+                 .map(getVersionedViewExternalId)
+                 .getOrElse("not specified")}
                | and instanceType: $instanceType """.stripMargin))
     }
 
@@ -124,25 +129,37 @@ abstract class FlexibleDataModelBaseRelation(config: RelationConfig, sqlContext:
         toSeqFilterValueDefinition(attribute, values).map(
           FilterDefinition.In(getViewAttributeReference(viewReference, attribute), _))
       case GreaterThanOrEqual(attribute, value) =>
-        toComparableFilterValueDefinition(attribute, value).map(f =>
-          FilterDefinition.Range(property = getViewAttributeReference(viewReference, attribute), gte = Some(f)))
+        toComparableFilterValueDefinition(attribute, value).map(
+          f =>
+            FilterDefinition
+              .Range(property = getViewAttributeReference(viewReference, attribute), gte = Some(f)))
       case GreaterThan(attribute, value) =>
-        toComparableFilterValueDefinition(attribute, value).map(f =>
-          FilterDefinition.Range(property = getViewAttributeReference(viewReference, attribute), gt = Some(f)))
+        toComparableFilterValueDefinition(attribute, value).map(
+          f =>
+            FilterDefinition
+              .Range(property = getViewAttributeReference(viewReference, attribute), gt = Some(f)))
       case LessThanOrEqual(attribute, value) =>
-        toComparableFilterValueDefinition(attribute, value).map(f =>
-          FilterDefinition.Range(property = getViewAttributeReference(viewReference, attribute), lte = Some(f)))
+        toComparableFilterValueDefinition(attribute, value).map(
+          f =>
+            FilterDefinition
+              .Range(property = getViewAttributeReference(viewReference, attribute), lte = Some(f)))
       case LessThan(attribute, value) =>
-        toComparableFilterValueDefinition(attribute, value).map(f =>
-          FilterDefinition.Range(property = getViewAttributeReference(viewReference, attribute), lt = Some(f)))
+        toComparableFilterValueDefinition(attribute, value).map(
+          f =>
+            FilterDefinition
+              .Range(property = getViewAttributeReference(viewReference, attribute), lt = Some(f)))
       case StringStartsWith(attribute, value) =>
         Right(
           FilterDefinition
-            .Prefix(getViewAttributeReference(viewReference, attribute), FilterValueDefinition.String(value)))
+            .Prefix(
+              getViewAttributeReference(viewReference, attribute),
+              FilterValueDefinition.String(value)))
       case IsNotNull(attribute) =>
         Right(FilterDefinition.Exists(getViewAttributeReference(viewReference, attribute)))
       case IsNull(attribute) =>
-        Right(FilterDefinition.Not(FilterDefinition.Exists(getViewAttributeReference(viewReference, attribute))))
+        Right(
+          FilterDefinition.Not(
+            FilterDefinition.Exists(getViewAttributeReference(viewReference, attribute))))
       case f =>
         Left(
           new CdfSparkIllegalArgumentException(
@@ -368,8 +385,8 @@ abstract class FlexibleDataModelBaseRelation(config: RelationConfig, sqlContext:
   private def createNodeOrEdgeCommonAttributeRef(
       instanceType: InstanceType,
       attribute: String): Seq[String] = {
-    val instanceAttribute =  {
-      if(attribute.equalsIgnoreCase("_type"))
+    val instanceAttribute = {
+      if (attribute.equalsIgnoreCase("_type"))
         "type"
       else
         attribute

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelBaseRelation.scala
@@ -159,7 +159,7 @@ abstract class FlexibleDataModelBaseRelation(config: RelationConfig, sqlContext:
             FilterValueDefinition.String(String.valueOf(value))))
       case EqualTo(attribute, value: GenericRowWithSchema)
           if nodeOrEdgeReferenceAttributes.contains(attribute) =>
-        createEqualsAttributeFilter(createNodeOrEdgeCommonAttributeRef(instanceType, "space"), value)
+        createEqualsAttributeFilter(createNodeOrEdgeCommonAttributeRef(instanceType, attribute), value)
       case In(attribute, values) if nodeOrEdgeStringAttributes.contains(attribute) =>
         toSeqFilterValueDefinition(attribute, values)
           .filterOrElse(

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelConnectionRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelConnectionRelation.scala
@@ -116,7 +116,7 @@ private[spark] class FlexibleDataModelConnectionRelation(
     if (filters.isEmpty) {
       Right(edgeTypeFilter)
     } else {
-      filters.toVector.traverse(toNodeOrEdgeAttributeFilter(InstanceType.Edge, _)).map { f =>
+      filters.toVector.traverse(toFilter(InstanceType.Edge, _, None, None)).map { f =>
         FilterDefinition.And(edgeTypeFilter +: f)
       }
     }

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelConnectionRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelConnectionRelation.scala
@@ -116,7 +116,7 @@ private[spark] class FlexibleDataModelConnectionRelation(
     if (filters.isEmpty) {
       Right(edgeTypeFilter)
     } else {
-      filters.toVector.traverse(toFilter(InstanceType.Edge, _, None, None)).map { f =>
+      filters.toVector.traverse(toFilter(InstanceType.Edge, _, None)).map { f =>
         FilterDefinition.And(edgeTypeFilter +: f)
       }
     }

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelation.scala
@@ -141,7 +141,7 @@ private[spark] class FlexibleDataModelCorePropertyRelation(
             toFilter(
               InstanceType.Node,
               _,
-              space = ref.map(_.space),
+              FilterViewReference(ref.map(_)),
               versionedExternalId = ref.map(r => s"${r.externalId}/${r.version}")))
           .map(toAndFilter)
       case Usage.Edge =>

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelation.scala
@@ -141,8 +141,9 @@ private[spark] class FlexibleDataModelCorePropertyRelation(
             toFilter(
               InstanceType.Node,
               _,
-              FilterViewReference(ref.map(_)),
-              versionedExternalId = ref.map(r => s"${r.externalId}/${r.version}")))
+              ref
+            )
+          )
           .map(toAndFilter)
       case Usage.Edge =>
         filters.toVector
@@ -150,8 +151,9 @@ private[spark] class FlexibleDataModelCorePropertyRelation(
             toFilter(
               InstanceType.Edge,
               _,
-              space = ref.map(_.space),
-              versionedExternalId = ref.map(r => s"${r.externalId}/${r.version}")))
+              ref
+            )
+          )
           .map(toAndFilter)
       case Usage.All =>
         val nodeFilter = usageBasedPropertyFilter(Usage.Node, filters, ref)

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
@@ -61,7 +61,11 @@ private[spark] class FlexibleDataModelCorePropertySyncRelation(
       HasData(List(viewRef))
     }
     val requestFilters: Seq[FilterDefinition] = (filters.map {
-      toFilter(instanceType, _, None).toOption
+      // don't specify viewReference to avoid filter pushdown for non-reserved attributes
+      // for performance reasons, sync is incremental and filtering is done in spark to
+      // avoid edge cases where too much needs to be filtered out and service request would
+      // time out filtering it
+      toFilter(instanceType, _, viewReference = None).toOption
     } ++ Array(hasData)).flatten.toSeq
     FilterDefinition.And(requestFilters)
   }

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
@@ -61,7 +61,7 @@ private[spark] class FlexibleDataModelCorePropertySyncRelation(
       HasData(List(viewRef))
     }
     val requestFilters: Seq[FilterDefinition] = (filters.map {
-      toNodeOrEdgeAttributeFilter(instanceType, _).toOption
+      toFilter(instanceType, _, None, None).toOption
     } ++ Array(hasData)).flatten.toSeq
     FilterDefinition.And(requestFilters)
   }

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
@@ -61,7 +61,7 @@ private[spark] class FlexibleDataModelCorePropertySyncRelation(
       HasData(List(viewRef))
     }
     val requestFilters: Seq[FilterDefinition] = (filters.map {
-      toFilter(instanceType, _, None, None).toOption
+      toFilter(instanceType, _, None).toOption
     } ++ Array(hasData)).flatten.toSeq
     FilterDefinition.And(requestFilters)
   }

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertySyncRelation.scala
@@ -65,7 +65,7 @@ private[spark] class FlexibleDataModelCorePropertySyncRelation(
       // for performance reasons, sync is incremental and filtering is done in spark to
       // avoid edge cases where too much needs to be filtered out and service request would
       // time out filtering it
-      toFilter(instanceType, _, viewReference = None).toOption
+      toFilter(instanceType, _, viewReference = None, isSyncRequest = true).toOption
     } ++ Array(hasData)).flatten.toSeq
     FilterDefinition.And(requestFilters)
   }

--- a/src/test/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelationTest.scala
@@ -35,13 +35,13 @@ class FlexibleDataModelCorePropertyRelationTest
   private val containerNodesNonListExternalId = "sparkDsTestContainerNodesNonList2"
   private val containerEdgesNonListExternalId = "sparkDsTestContainerEdgesNonList2"
 
-  private val containerAllAmbiguousTypeExternalId = "sparkDsTestContainerAllAmbiguousType5"
-  private val containerNodesAmbiguousTypeExternalId = "sparkDsTestContainerNodesAmbiguousType5"
-  private val containerEdgesAmbiguousTypeExternalId = "sparkDsTestContainerEdgesAmbiguousType5"
+  private val containerAllAmbiguousTypeExternalId = "sparkDsTestContainerAllAmbiguousType6"
+  private val containerNodesAmbiguousTypeExternalId = "sparkDsTestContainerNodesAmbiguousType6"
+  private val containerEdgesAmbiguousTypeExternalId = "sparkDsTestContainerEdgesAmbiguousType6"
 
-  private val containerAllTypeExternalId = "sparkDsTestContainerAllType2"
-  private val containerNodesTypeExternalId = "sparkDsTestContainerNodesType2"
-  private val containerEdgesTypeExternalId = "sparkDsTestContainerEdgesType2"
+  private val containerAllTypeExternalId = "sparkDsTestContainerAllType3"
+  private val containerNodesTypeExternalId = "sparkDsTestContainerNodesType3"
+  private val containerEdgesTypeExternalId = "sparkDsTestContainerEdgesType3"
 
   private val containerAllListExternalId = "sparkDsTestContainerAllList2"
   private val containerNodesListExternalId = "sparkDsTestContainerNodesList2"
@@ -51,13 +51,13 @@ class FlexibleDataModelCorePropertyRelationTest
   private val viewNodesListAndNonListExternalId = "sparkDsTestViewNodesListAndNonList2"
   private val viewEdgesListAndNonListExternalId = "sparkDsTestViewEdgesListAndNonList2"
 
-  private val viewAllAmbiguousTypeExternalId = "sparkDsTestViewAllAmbiguousType5"
-  private val viewNodesAmbiguousTypeExternalId = "sparkDsTestViewNodesAmbiguousType5"
-  private val viewEdgesAmbiguousTypeExternalId = "sparkDsTestViewEdgesAmbiguousType5"
+  private val viewAllAmbiguousTypeExternalId = "sparkDsTestViewAllAmbiguousType6"
+  private val viewNodesAmbiguousTypeExternalId = "sparkDsTestViewNodesAmbiguousType6"
+  private val viewEdgesAmbiguousTypeExternalId = "sparkDsTestViewEdgesAmbiguousType6"
 
-  private val viewAllTypeExternalId = "sparkDsTestViewAllType5"
-  private val viewNodesTypeExternalId = "sparkDsTestViewNodesType5"
-  private val viewEdgesTypeExternalId = "sparkDsTestViewEdgesType5"
+  private val viewAllTypeExternalId = "sparkDsTestViewAllType6"
+  private val viewNodesTypeExternalId = "sparkDsTestViewNodesType6"
+  private val viewEdgesTypeExternalId = "sparkDsTestViewEdgesType6"
 
   private val viewAllNonListExternalId = "sparkDsTestViewAllNonList2"
   private val viewNodesNonListExternalId = "sparkDsTestViewNodesNonList2"


### PR DESCRIPTION
So there were always two cases:
 * filter on reserved keywords
 * filter on normal view attributes
 
 They were handled somewhat separately, but the entire code for filtering on reserved keywords was repeated. Similarly, the code for combined filter (not, and, or etc...) was repeated too.

This makes it so there is a single filter function with optional view version and space, which will check if the attribute is a reserved keyword and if so will use the filter on reserved keyword, if not will filter on view attributes.

This enables some cleanup in other parts as well, where these two were chained.

Some more cleanup was done to avoid having to individually check each attributes, and instead handle them together (while keeping in mind some are string attributes and others are references)

It's not perfect because you still need to pattern match the filter just to see if it's a reserved attribute or not...