### PR TITLE
remove duplication in createNodeOrEdge

### DIFF
--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelation.scala
@@ -55,8 +55,8 @@ private[spark] class FlexibleDataModelCorePropertyRelation(
     val firstRow = rows.headOption
     (firstRow, viewReference) match {
       case (Some(fr), _) =>
-        upsertNodesOrEdges(rows, fr.schema, viewReference, allProperties, instanceSpace).flatMap(results =>
-          incMetrics(itemsUpserted, results.length))
+        upsertNodesOrEdges(rows, fr.schema, viewReference, allProperties, instanceSpace)
+          .flatMap(results => incMetrics(itemsUpserted, results.length))
       case (None, _) => incMetrics(itemsUpserted, 0)
     }
   }

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelation.scala
@@ -53,7 +53,7 @@ private[spark] class FlexibleDataModelCorePropertyRelation(
 
   override def upsert(rows: Seq[Row]): IO[Unit] = {
     val firstRow = rows.headOption
-    (firstRow, viewReference) match {
+    firstRow match {
       case (Some(fr), _) =>
         upsertNodesOrEdges(rows, fr.schema, viewReference, allProperties, instanceSpace)
           .flatMap(results => incMetrics(itemsUpserted, results.length))

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelCorePropertyRelation.scala
@@ -54,10 +54,10 @@ private[spark] class FlexibleDataModelCorePropertyRelation(
   override def upsert(rows: Seq[Row]): IO[Unit] = {
     val firstRow = rows.headOption
     firstRow match {
-      case (Some(fr), _) =>
+      case Some(fr) =>
         upsertNodesOrEdges(rows, fr.schema, viewReference, allProperties, instanceSpace)
           .flatMap(results => incMetrics(itemsUpserted, results.length))
-      case (None, _) => incMetrics(itemsUpserted, 0)
+      case None => incMetrics(itemsUpserted, 0)
     }
   }
 

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelRelationUtils.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelRelationUtils.scala
@@ -163,14 +163,14 @@ object FlexibleDataModelRelationUtils {
           externalId = extId,
           startNode = startNode,
           endNode = endNode,
-          sources = source.map(src =>
-            Seq(
-              EdgeOrNodeData(
-                source = src,
-                properties = Some(props.toMap)
-              )
-            )
-          )
+          sources = source.map(
+            src =>
+              Seq(
+                EdgeOrNodeData(
+                  source = src,
+                  properties = Some(props.toMap)
+                )
+            ))
         )
     }
 
@@ -193,14 +193,14 @@ object FlexibleDataModelRelationUtils {
             externalId = externalId,
             startNode = startNode,
             endNode = endNode,
-            sources = source.map(src =>
-              Seq(
-                EdgeOrNodeData(
-                  source = src,
-                  properties = Some(props.toMap)
-                )
-              )
-            )
+            sources = source.map(
+              src =>
+                Seq(
+                  EdgeOrNodeData(
+                    source = src,
+                    properties = Some(props.toMap)
+                  )
+              ))
           )
         )
       case (_, None, None) =>
@@ -208,14 +208,14 @@ object FlexibleDataModelRelationUtils {
           NodeWrite(
             space = instanceSpace,
             externalId = externalId,
-            sources = source.map(src =>
-              Seq(
-                EdgeOrNodeData(
-                  source = src,
-                  properties = Some(props.toMap)
-                )
-              )
-            ),
+            sources = source.map(
+              src =>
+                Seq(
+                  EdgeOrNodeData(
+                    source = src,
+                    properties = Some(props.toMap)
+                  )
+              )),
             `type` = nodeTypeDirectRelation
           )
         )
@@ -254,14 +254,14 @@ object FlexibleDataModelRelationUtils {
         NodeWrite(
           space = space,
           externalId = externalId,
-          sources = source.map(src =>
-            Seq(
-              EdgeOrNodeData(
-                source = src,
-                properties = Some(props.toMap)
-              )
-            )
-          ),
+          sources = source.map(
+            src =>
+              Seq(
+                EdgeOrNodeData(
+                  source = src,
+                  properties = Some(props.toMap)
+                )
+            )),
           `type` = extractNodeTypeDirectRelation(schema, instanceSpace.orElse(Some(space)), row).toOption
         )
     }
@@ -492,14 +492,13 @@ object FlexibleDataModelRelationUtils {
   private def validateSourceSchema(
       source: Option[SourceReference],
       schema: StructType,
-      propertyDefMap: Map[String, ViewPropertyDefinition]): Either[CdfSparkException, Boolean] = {
+      propertyDefMap: Map[String, ViewPropertyDefinition]): Either[CdfSparkException, Boolean] =
     source match {
       case Some(_) =>
         validateRowFieldsWithPropertyDefinitions(schema, propertyDefMap)
       case None =>
         Right(true)
     }
-  }
 
   private def validateRowFieldsWithPropertyDefinitions(
       schema: StructType,

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelRelationUtils.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelRelationUtils.scala
@@ -54,7 +54,7 @@ object FlexibleDataModelRelationUtils {
       source: Option[SourceReference],
       instanceSpace: Option[String],
       ignoreNullFields: Boolean = true): Either[CdfSparkException, Vector[EdgeWrite]] =
-    validateRowFieldsWithPropertyDefinitions(schema, propertyDefMap) *> createEdgeWriteData(
+    validateSourceSchema(source, schema, propertyDefMap) *> createEdgeWriteData(
       schema,
       source,
       propertyDefMap,

--- a/src/main/scala/cognite/spark/v1/FlexibleDataModelRelationUtils.scala
+++ b/src/main/scala/cognite/spark/v1/FlexibleDataModelRelationUtils.scala
@@ -38,7 +38,7 @@ object FlexibleDataModelRelationUtils {
       propertyDefMap: Map[String, ViewPropertyDefinition],
       source: Option[SourceReference],
       instanceSpace: Option[String],
-      ignoreNullFields: Boolean = true) =
+      ignoreNullFields: Boolean = true): Either[CdfSparkException, Vector[NodeWrite]] =
     validateSourceSchema(source, schema, propertyDefMap) *> createNodeWriteData(
       schema,
       source,

--- a/src/test/scala/cognite/spark/v1/FlexibleDataModelRelationUtilsTest.scala
+++ b/src/test/scala/cognite/spark/v1/FlexibleDataModelRelationUtilsTest.scala
@@ -51,7 +51,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
     val values = Seq[Array[Any]](Array("str1"), Array("str2"))
     val rows = values.map(r => new GenericRowWithSchema(r, schema)).toSeq
 
-    val result = createNodes(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodes(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     verifyErrorMessage(result, "Couldn't find required string property 'externalId'")
   }
 
@@ -77,7 +77,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createNodes(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodes(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     verifyErrorMessage(result, "'externalId' cannot be null")
   }
 
@@ -100,7 +100,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
     val values = Seq[Array[Any]](Array("stringProp1", "extId1", 1), Array(null, "extId1", null))
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createNodes(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodes(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     verifyErrorMessage(result, "cannot be null")
   }
 
@@ -122,7 +122,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
     val values = Seq[Array[Any]](Array("extId1", 1), Array("extId2", null))
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createNodes(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodes(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     verifyErrorMessage(result, "Could not find required properties")
   }
 
@@ -153,7 +153,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
         Array("space1", "stringProp2", "extId2", 5, Array(2.1, 2.2), null))
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createNodes(rows, schema, propertyMap, destRef, None)
+    val result = createNodes(rows, schema, propertyMap, Some(destRef), None)
     result.isRight shouldBe true
 
     val nodes = result.toOption.getOrElse(Vector.empty)
@@ -208,7 +208,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
       )
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
-    val result = createEdges(rows, schema, propertyMap, destRef, None)
+    val result = createEdges(rows, schema, propertyMap, Some(destRef), None)
     result.isRight shouldBe true
 
     val edges = result.toOption.getOrElse(Vector.empty)
@@ -336,7 +336,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
       )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createNodes(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodes(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     result.isRight shouldBe true
 
     val nodes = result.toOption.getOrElse(Vector.empty)
@@ -382,7 +382,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
         Array("stringProp2", "extId2", 5, Array(2.1, 2.2), null))
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createNodes(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodes(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     result.isRight shouldBe true
 
     val nodes = result.toOption.getOrElse(Vector.empty)
@@ -432,7 +432,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
       Array("stringProp2", "extId2", Array(2.1, 2.2)))
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createNodes(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodes(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     result.isRight shouldBe true
 
     val nodes = result.toOption.getOrElse(Vector.empty)
@@ -485,7 +485,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
       )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createNodes(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodes(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     result.isRight shouldBe true
 
     val nodes = result.toOption.getOrElse(Vector.empty)
@@ -539,7 +539,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
         Array(null, "stringProp2", "extId2", 5, Array(2.1, 2.2), null))
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createNodes(rows, schema, propertyMap, destRef, None)
+    val result = createNodes(rows, schema, propertyMap, Some(destRef), None)
     result match {
       case Left(err) =>
         err.getMessage.contains(
@@ -565,7 +565,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
     val values = Seq[Array[Any]](Array("str1", 1), Array("str2", null))
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     verifyErrorMessage(result, "Couldn't find required string property 'externalId'")
   }
 
@@ -587,7 +587,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
     val values = Seq[Array[Any]](Array("str1", null, "externalId1"), Array("str2", 2, "externalId2"))
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     verifyErrorMessage(result, "Could not find required property 'type'")
   }
 
@@ -621,7 +621,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     verifyErrorMessage(result, "Could not find required property 'startNode'")
   }
 
@@ -660,7 +660,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     verifyErrorMessage(result, "Could not find required property 'endNode'")
   }
 
@@ -705,7 +705,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createEdges(rows, schema, propertyMap, destRef, None)
+    val result = createEdges(rows, schema, propertyMap, Some(destRef), None)
     verifyErrorMessage(result, "'space' cannot be null")
   }
 
@@ -754,7 +754,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
       )
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
-    val result = createEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     result.isRight shouldBe true
 
     val nodes = result.toOption.getOrElse(Vector.empty)
@@ -822,7 +822,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     result.isRight shouldBe true
 
     val nodes = result.toOption.getOrElse(Vector.empty)
@@ -896,7 +896,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     result.isRight shouldBe true
 
     val nodes = result.toOption.getOrElse(Vector.empty)
@@ -940,7 +940,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
     val values = Seq[Array[Any]](Array("str1"), Array("str2"))
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createNodesOrEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodesOrEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     verifyErrorMessage(result, "Couldn't find required string property 'externalId'")
   }
 
@@ -966,7 +966,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createNodesOrEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodesOrEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     verifyErrorMessage(result, "'externalId' cannot be null")
   }
 
@@ -989,7 +989,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
     val values = Seq[Array[Any]](Array("stringProp1", "extId1", 1), Array(null, "extId1", null))
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createNodesOrEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodesOrEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     verifyErrorMessage(result, "cannot be null")
   }
 
@@ -1019,7 +1019,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
         Array("stringProp2", "extId2", 5, Array(2.1, 2.2), null))
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createNodesOrEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodesOrEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     result.isRight shouldBe true
 
     val nodes = result.toOption.getOrElse(Vector.empty).asInstanceOf[Vector[NodeWrite]]
@@ -1070,7 +1070,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
       Array("stringProp2", "extId2", Array(2.1, 2.2)))
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createNodesOrEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodesOrEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     result.isRight shouldBe true
 
     val nodes = result.toOption.getOrElse(Vector.empty).asInstanceOf[Vector[NodeWrite]]
@@ -1123,7 +1123,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
       )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createNodesOrEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodesOrEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     result.isRight shouldBe true
 
     val nodes = result.toOption.getOrElse(Vector.empty).asInstanceOf[Vector[NodeWrite]]
@@ -1195,7 +1195,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
       )
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
-    val result = createNodesOrEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodesOrEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     result.isRight shouldBe true
 
     val nodes = result.toOption.getOrElse(Vector.empty).asInstanceOf[Vector[EdgeWrite]]
@@ -1264,7 +1264,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createNodesOrEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodesOrEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     result.isRight shouldBe true
 
     val nodes = result.toOption.getOrElse(Vector.empty).asInstanceOf[Vector[EdgeWrite]]
@@ -1339,7 +1339,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
 
-    val result = createNodesOrEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodesOrEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     result.isRight shouldBe true
 
     val nodes = result.toOption.getOrElse(Vector.empty).asInstanceOf[Vector[EdgeWrite]]
@@ -1408,7 +1408,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
       )
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
-    val result = createNodesOrEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodesOrEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     verifyErrorMessage(result, "Only found: 'externalId', 'startNode', 'endNode'")
   }
 
@@ -1454,7 +1454,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
       )
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
-    val result = createNodesOrEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodesOrEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     verifyErrorMessage(result, "Only found: 'externalId', 'type', 'endNode'")
   }
 
@@ -1500,7 +1500,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
       )
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
-    val result = createNodesOrEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodesOrEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     verifyErrorMessage(result, "Only found: 'externalId', 'type', 'startNode'")
   }
 
@@ -1559,7 +1559,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
       )
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
-    val result = createNodesOrEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodesOrEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     result.isRight shouldBe true
 
     val nodesOrEdges = result.toOption.getOrElse(Vector.empty)
@@ -1648,7 +1648,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
       )
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
-    val result = createNodesOrEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodesOrEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     result.isRight shouldBe true
 
     val nodesOrEdges = result.toOption.getOrElse(Vector.empty)
@@ -1743,7 +1743,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
       )
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
-    val result = createNodesOrEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodesOrEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     result.isRight shouldBe true
 
     val nodesOrEdges = result.toOption.getOrElse(Vector.empty)
@@ -1854,7 +1854,7 @@ class FlexibleDataModelRelationUtilsTest extends FlatSpec with Matchers {
       )
     )
     val rows = values.map(r => new GenericRowWithSchema(r, schema))
-    val result = createNodesOrEdges(rows, schema, propertyMap, destRef, Some("instanceSpaceExternalId1"))
+    val result = createNodesOrEdges(rows, schema, propertyMap, Some(destRef), Some("instanceSpaceExternalId1"))
     result.isRight shouldBe true
 
     val nodesOrEdges = result.toOption.getOrElse(Vector.empty)


### PR DESCRIPTION
This PR proposes removing a duplicate flow for empty sources.

Currently we handle the situations where sources are empty (writing a node/edge as a standalone, not referencing any view) and the situations where we are writing the instance to a view completely separately, with method overload.

This proposes removing the separated flow, and handling it together, with the sources being optional.

Advantages:
 * removal of redundant code
 * easier to maintain (only have to maintain one flow)
 * relatively straightforward handling of None when sources are empty

The price is that it's very slightly more complex and if we want to make more code specific to one situation in the future we might have to duplicate some parts again.

Reasoning for doing this now:
 * Edge property support is coming soon, and I'd rather not have to deal with two separate functions depending if the source exists or not.