### PR TITLE
fix in filter

### DIFF
--- a/src/main/scala/cognite/spark/v1/fdm/FlexibleDataModelBaseRelation.scala
+++ b/src/main/scala/cognite/spark/v1/fdm/FlexibleDataModelBaseRelation.scala
@@ -524,15 +524,20 @@ abstract class FlexibleDataModelBaseRelation(config: RelationConfig, sqlContext:
     val result = values.headOption match {
       case Some(s: String) =>
         io.circe.parser.parse(s).toOption match {
-          case Some(_) =>
+          // Check if it's a complex Json Object first.
+          case Some(x) if x.isArray || x.isObject =>
             Try(FilterValueDefinition.ObjectList(values.flatMap(v =>
               io.circe.parser.parse(String.valueOf(v)).toOption))).toEither
-          case None =>
+          case _ =>
             Try(FilterValueDefinition.StringList(values.map(_.asInstanceOf[String]))).toEither
         }
-      case Some(_: Int | _: Long) =>
+      case Some(_: Int) =>
+        Try(FilterValueDefinition.IntegerList(values.map(_.asInstanceOf[Int].toLong))).toEither
+      case Some(_: Long) =>
         Try(FilterValueDefinition.IntegerList(values.map(_.asInstanceOf[Long]))).toEither
-      case Some(_: Float | _: Double) =>
+      case Some(_: Float) =>
+        Try(FilterValueDefinition.DoubleList(values.map(_.asInstanceOf[Float].toDouble))).toEither
+      case Some(_: Double) =>
         Try(FilterValueDefinition.DoubleList(values.map(_.asInstanceOf[Double]))).toEither
       case Some(_: Boolean) =>
         Try(FilterValueDefinition.BooleanList(values.map(_.asInstanceOf[Boolean]))).toEither

--- a/src/test/scala/cognite/spark/v1/fdm/FlexibleDataModelNodeTest.scala
+++ b/src/test/scala/cognite/spark/v1/fdm/FlexibleDataModelNodeTest.scala
@@ -992,8 +992,10 @@ class FlexibleDataModelNodeTest
       s"""
          |where
          |forEqualsFilter = 'str1' and
+         |forInFilter not in ('1', '2', '3') and
          |forInFilter in ('str1', 'str2', 'str3') and
          |forGteFilter >= 1 and
+         |forGteFilter in (1, 2, 3) and
          |forGtFilter > 1 and
          |forLteFilter <= 2 and
          |forLtFilter < 4 and
@@ -1736,7 +1738,7 @@ class FlexibleDataModelNodeTest
                       viewRef,
                       Some(Map(
                         "forEqualsFilter" -> Some(InstancePropertyValue.String("str2")),
-                        "forInFilter" -> Some(InstancePropertyValue.String("str2")),
+                        "forInFilter" -> Some(InstancePropertyValue.String("1")),
                         "forGteFilter" -> Some(InstancePropertyValue.Int32(5)),
                         "forGtFilter" -> Some(InstancePropertyValue.Int32(2)),
                         "forLteFilter" -> Some(InstancePropertyValue.Int64(1)),

--- a/src/test/scala/cognite/spark/v1/fdm/FlexibleDataModelNodeTest.scala
+++ b/src/test/scala/cognite/spark/v1/fdm/FlexibleDataModelNodeTest.scala
@@ -1738,7 +1738,7 @@ class FlexibleDataModelNodeTest
                       viewRef,
                       Some(Map(
                         "forEqualsFilter" -> Some(InstancePropertyValue.String("str2")),
-                        "forInFilter" -> Some(InstancePropertyValue.String("1")),
+                        "forInFilter" -> Some(InstancePropertyValue.String("str2")),
                         "forGteFilter" -> Some(InstancePropertyValue.Int32(5)),
                         "forGtFilter" -> Some(InstancePropertyValue.Int32(2)),
                         "forLteFilter" -> Some(InstancePropertyValue.Int64(1)),


### PR DESCRIPTION
fixes: https://cognitedata.atlassian.net/browse/CDF-22435

Looks like the "in" filter is broken in various ways, and in general toFilterValueListDefinition which also means = on lists was broken.

Examples of broken requests before and after:

```
select
  cast(`externalId` as STRING) as externalId,
  cast(`code` as STRING) as code
from
  cdf_data_models("spaaace", "test_in_number_bug", "1", "Facility2")
where code in ("1", "2")
```
This would map the array into an array of int. It would get picked up as a Json, thus serialized as a json value which would be 1 not "1" as expected.

```
select
  cast(`externalId` as STRING) as externalId,
  cast(`code` as STRING) as code
from
  cdf_data_models("spaaace", "test_in_number_bug", "1", "Facility2")
where code in (1, 2)
```
This wouldn't work at all. It would be picked up by `case Some(_: Int | _: Long) =>` then crash when trying to do `_.asInstanceOf[Long]`

_________
Potential regrassion:

If the column type is a Integer, then 


```
select
  cast(`externalId` as STRING) as externalId,
  cast(`code` as STRING) as code
from
  cdf_data_models("spaaace", "test_in_number_bug", "1", "Facility2")
where code in ("1", "2")
```

currently works even though the "correct" synthax should be:


```
select
  cast(`externalId` as STRING) as externalId,
  cast(`code` as STRING) as code
from
  cdf_data_models("spaaace", "test_in_number_bug", "1", "Facility2")
where code in (1, 2)
```

I haven't found any example of such a use.
_________

Remaining problems:

Looks like filtering on list of Json does not work and never worked
We should probably use the schema instead of trying to parse the values like this, since the schema can tell us the types 

This Json filtering problem is not exclusive to lists. For example this: 

```
select
  cast(`externalId` as STRING) as externalId,
  cast(`code` as STRING) as code,
  cast("null" as STRING) as code3
from
  cdf_data_models("spaaace", "test_in_number_bug", "1", "Facility2")
where code3 = "null"
```
doesn't work because of the filter, even though code3 is of type Json, and the "null" value can be inserted as shown

________________
Follow up

We need to also fix JSON in filters, looks like it doesn't work properly right now
