### PR TITLE
Support optional filtering of null values from RAW

### DIFF
--- a/README.md
+++ b/README.md
@@ -1474,6 +1474,8 @@ Optionally, you can have Spark infer the DataFrame schema with the following opt
 
 - `rawEnsureParent`: When set to true, the parent database and table will be creates if it does not exists already.
 
+- `filterNullFieldsOnNonSchemaRawQueries`: Set this to `"true"`to enable experimental support for filtering empty columns server side in the Raw API, without impacting the inferred schema. Aimed to become enabled by default in the future once it has been fully tested.
+
 ```scala
 val df = spark.read.format("cognite.spark.v1")
   .option("type", "raw")

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val circeVersion = "0.14.9"
 val sttpVersion = "3.5.2"
 val natchezVersion = "0.3.1"
 val Specs2Version = "4.20.3"
-val cogniteSdkVersion = "2.30.860"
+val cogniteSdkVersion = "2.31.861"
 
 val prometheusVersion = "0.16.0"
 val log4sVersion = "1.10.0"
@@ -41,7 +41,7 @@ lazy val commonSettings = Seq(
   organization := "com.cognite.spark.datasource",
   organizationName := "Cognite",
   organizationHomepage := Some(url("https://cognite.com")),
-  version := "3.20." + patchVersion,
+  version := "3.21." + patchVersion,
   isSnapshot := patchVersion.endsWith("-SNAPSHOT"),
   crossScalaVersions := supportedScalaVersions,
   semanticdbEnabled := true,

--- a/build.scala-2.12.sbt.lock
+++ b/build.scala-2.12.sbt.lock
@@ -1,6 +1,6 @@
 {
   "lockVersion" : 1,
-  "timestamp" : "2024-10-31T16:04:08.459482Z",
+  "timestamp" : "2024-11-13T11:30:40.138510863Z",
   "configurations" : [
     "compile",
     "optional",
@@ -94,11 +94,11 @@
     {
       "org" : "com.cognite",
       "name" : "cognite-sdk-scala_2.12",
-      "version" : "2.30.860",
+      "version" : "2.31.861",
       "artifacts" : [
         {
           "name" : "cognite-sdk-scala_2.12.jar",
-          "hash" : "sha1:559a261df9d7bd698ec97dc45ae416870ecd2f62"
+          "hash" : "sha1:ae52606e613a31e1979830a6036f265328033908"
         }
       ],
       "configurations" : [

--- a/build.scala-2.13.sbt.lock
+++ b/build.scala-2.13.sbt.lock
@@ -1,6 +1,6 @@
 {
   "lockVersion" : 1,
-  "timestamp" : "2024-10-31T16:04:15.967563Z",
+  "timestamp" : "2024-11-13T11:30:56.507065520Z",
   "configurations" : [
     "compile",
     "optional",
@@ -94,11 +94,11 @@
     {
       "org" : "com.cognite",
       "name" : "cognite-sdk-scala_2.13",
-      "version" : "2.30.860",
+      "version" : "2.31.861",
       "artifacts" : [
         {
           "name" : "cognite-sdk-scala_2.13.jar",
-          "hash" : "sha1:2712efe507294923d9cc5ca2998f3d452096ac14"
+          "hash" : "sha1:245bd96891942232ba8d5a8e2c7ff1714cf2c230"
         }
       ],
       "configurations" : [

--- a/macro/build.scala-2.12.sbt.lock
+++ b/macro/build.scala-2.12.sbt.lock
@@ -1,6 +1,6 @@
 {
   "lockVersion" : 1,
-  "timestamp" : "2024-10-31T16:04:18.098577Z",
+  "timestamp" : "2024-11-13T11:30:59.215321253Z",
   "configurations" : [
     "compile",
     "optional",
@@ -75,11 +75,11 @@
     {
       "org" : "com.cognite",
       "name" : "cognite-sdk-scala_2.12",
-      "version" : "2.30.860",
+      "version" : "2.31.861",
       "artifacts" : [
         {
           "name" : "cognite-sdk-scala_2.12.jar",
-          "hash" : "sha1:559a261df9d7bd698ec97dc45ae416870ecd2f62"
+          "hash" : "sha1:ae52606e613a31e1979830a6036f265328033908"
         }
       ],
       "configurations" : [

--- a/macro/build.scala-2.13.sbt.lock
+++ b/macro/build.scala-2.13.sbt.lock
@@ -1,6 +1,6 @@
 {
   "lockVersion" : 1,
-  "timestamp" : "2024-10-31T16:04:19.995959Z",
+  "timestamp" : "2024-11-13T11:31:01.766754723Z",
   "configurations" : [
     "compile",
     "optional",
@@ -75,11 +75,11 @@
     {
       "org" : "com.cognite",
       "name" : "cognite-sdk-scala_2.13",
-      "version" : "2.30.860",
+      "version" : "2.31.861",
       "artifacts" : [
         {
           "name" : "cognite-sdk-scala_2.13.jar",
-          "hash" : "sha1:2712efe507294923d9cc5ca2998f3d452096ac14"
+          "hash" : "sha1:245bd96891942232ba8d5a8e2c7ff1714cf2c230"
         }
       ],
       "configurations" : [

--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -478,8 +478,8 @@ object DefaultSource {
       enableSinglePartitionDeleteAssetHierarchy = enableSinglePartitionDeleteAssetHierarchy,
       tracingParent = extractTracingHeadersKernel(parameters),
       useSharedThrottle = toBoolean(parameters, "useSharedThrottle", defaultValue = false),
-      filterNullsOnNonSchemaQueries =
-        toBoolean(parameters, "filterNullsOnNonSchemaQueries", defaultValue = false)
+      serverSideFilterNullValuesOnNonSchemaRawQueries =
+        toBoolean(parameters, "filterNullFieldsOnNonSchemaRawQueries", defaultValue = false)
     )
   }
 

--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -477,7 +477,9 @@ object DefaultSource {
       rawEnsureParent = toBoolean(parameters, "rawEnsureParent", defaultValue = true),
       enableSinglePartitionDeleteAssetHierarchy = enableSinglePartitionDeleteAssetHierarchy,
       tracingParent = extractTracingHeadersKernel(parameters),
-      useSharedThrottle = toBoolean(parameters, "useSharedThrottle", defaultValue = false)
+      useSharedThrottle = toBoolean(parameters, "useSharedThrottle", defaultValue = false),
+      filterNullsOnNonSchemaQueries =
+        toBoolean(parameters, "filterNullsOnNonSchemaQueries", defaultValue = false)
     )
   }
 

--- a/src/main/scala/cognite/spark/v1/RawTableRelation.scala
+++ b/src/main/scala/cognite/spark/v1/RawTableRelation.scala
@@ -66,6 +66,7 @@ class RawTableRelation(
           filter = RawRowFilter(),
           requestedKeys = None,
           schema = None,
+          filterNulls = false,
           collectMetrics = collectSchemaInferenceMetrics,
           collectTestMetrics = false
         )
@@ -83,15 +84,17 @@ class RawTableRelation(
     }
   }
 
-  private def getStreams(filter: RawRowFilter, cursors: Vector[String])(
+  private def getStreams(filter: RawRowFilter, filterNullFields: Boolean, cursors: Vector[String])(
       limit: Option[Int],
       numPartitions: Int)(client: GenericClient[IO]): Seq[Stream[IO, RawRow]] = {
     assert(numPartitions == cursors.length)
-    val rawClient = client.rawRows(database, table)
+    val rawClient = client.rawRows(database, table, filterNullFields)
     cursors.map(rawClient.filterOnePartition(filter, _, limit))
   }
 
   private def getStreamByKeys(client: GenericClient[IO], keys: Set[String]): Stream[IO, RawRow] = {
+    // Note that retrieveByKey does not currently support filtering out null fields. When/If that is
+    // added, we should also pass in the flag to filter out those here.
     val rawClient = client.rawRows(database, table)
     Stream
       .emits(keys.toSeq)
@@ -127,6 +130,7 @@ class RawTableRelation(
       filter: RawRowFilter,
       requestedKeys: Option[Set[String]],
       schema: Option[StructType],
+      filterNulls: Boolean,
       collectMetrics: Boolean = config.collectMetrics,
       collectTestMetrics: Boolean = config.collectTestMetrics): RDD[Row] = {
     val configWithLimit =
@@ -142,11 +146,11 @@ class RawTableRelation(
           val partitionCursors =
             CdpConnector
               .clientFromConfig(config)
-              .rawRows(database, table)
+              .rawRows(database, table, filterNulls)
               .getPartitionCursors(filter, configWithLimit.partitions)
               .unsafeRunSync()
               .toVector
-          getStreams(filter, partitionCursors)(
+          getStreams(filter, filterNulls, partitionCursors)(
             configWithLimit.limitPerPartition,
             configWithLimit.partitions)
       }
@@ -203,7 +207,13 @@ class RawTableRelation(
     }
 
     val rdd =
-      readRows(config.limitPerPartition, None, rawRowFilter, requestedKeys, jsonSchema)
+      readRows(
+        config.limitPerPartition,
+        None,
+        rawRowFilter,
+        requestedKeys,
+        jsonSchema,
+        config.filterNullsOnNonSchemaQueries)
 
     rdd.map(row => {
       val filteredCols = requiredColumns.map(colName => row.get(schema.fieldIndex(colName)))

--- a/src/main/scala/cognite/spark/v1/RawTableRelation.scala
+++ b/src/main/scala/cognite/spark/v1/RawTableRelation.scala
@@ -213,7 +213,7 @@ class RawTableRelation(
         rawRowFilter,
         requestedKeys,
         jsonSchema,
-        config.filterNullsOnNonSchemaQueries)
+        config.serverSideFilterNullValuesOnNonSchemaRawQueries)
 
     rdd.map(row => {
       val filteredCols = requiredColumns.map(colName => row.get(schema.fieldIndex(colName)))

--- a/src/main/scala/cognite/spark/v1/RelationConfig.scala
+++ b/src/main/scala/cognite/spark/v1/RelationConfig.scala
@@ -28,7 +28,8 @@ final case class RelationConfig(
     enableSinglePartitionDeleteAssetHierarchy: Boolean, // flag to test whether single partition helps avoid NPE in asset hierarchy builder
     tracingParent: Kernel,
     initialRetryDelayMillis: Int,
-    useSharedThrottle: Boolean
+    useSharedThrottle: Boolean,
+    filterNullsOnNonSchemaQueries: Boolean,
 ) {
 
   /** Desired number of Spark partitions ~= partitions / parallelismPerPartition */

--- a/src/main/scala/cognite/spark/v1/RelationConfig.scala
+++ b/src/main/scala/cognite/spark/v1/RelationConfig.scala
@@ -29,7 +29,7 @@ final case class RelationConfig(
     tracingParent: Kernel,
     initialRetryDelayMillis: Int,
     useSharedThrottle: Boolean,
-    filterNullsOnNonSchemaQueries: Boolean,
+    serverSideFilterNullValuesOnNonSchemaRawQueries: Boolean,
 ) {
 
   /** Desired number of Spark partitions ~= partitions / parallelismPerPartition */

--- a/src/test/scala/cognite/spark/v1/RawTableRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/RawTableRelationTest.scala
@@ -958,7 +958,7 @@ class RawTableRelationTest
     validateWhenFilteringIsNotEnabled(df)
   }
 
-  private def validateWhenFilteringIsNotEnabled(df: DataFrame): Unit {
+  private def validateWhenFilteringIsNotEnabled(df: DataFrame): Unit = {
     val rows: Map[String, Map[String, Json]] = RawJsonConverter.rowsToRawItems(df.columns, "key", df.collect().toSeq)
       .map(r => (r.key, r.columns))
       .toMap

--- a/src/test/scala/cognite/spark/v1/RawTableRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/RawTableRelationTest.scala
@@ -261,7 +261,7 @@ class RawTableRelationTest
       .option("inferSchema", inferSchema)
       .option("inferSchemaLimit", "100")
 
-    filterNullFields.foreach(v => df.option("filterNullsOnNonSchemaQueries", v.toString))
+    filterNullFields.foreach(v => df.option("filterNullFieldsOnNonSchemaRawQueries", v.toString))
 
     metricsPrefix match {
       case Some(prefix) =>

--- a/src/test/scala/cognite/spark/v1/RawTableRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/RawTableRelationTest.scala
@@ -958,7 +958,7 @@ class RawTableRelationTest
     validateWhenFilteringIsNotEnabled(df)
   }
 
-  private def validateWhenFilteringIsNotEnabled(df: DataFrame) {
+  private def validateWhenFilteringIsNotEnabled(df: DataFrame): Unit {
     val rows: Map[String, Map[String, Json]] = RawJsonConverter.rowsToRawItems(df.columns, "key", df.collect().toSeq)
       .map(r => (r.key, r.columns))
       .toMap

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -273,7 +273,8 @@ trait SparkTest {
       rawEnsureParent = false,
       enableSinglePartitionDeleteAssetHierarchy = false,
       tracingParent = new Kernel(Map.empty),
-      useSharedThrottle = false
+      useSharedThrottle = false,
+      filterNullsOnNonSchemaQueries = false
     )
 
   private def getCounterSafe(metricsNamespace: String, resource: String): Option[Long] = {

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -274,7 +274,7 @@ trait SparkTest {
       enableSinglePartitionDeleteAssetHierarchy = false,
       tracingParent = new Kernel(Map.empty),
       useSharedThrottle = false,
-      filterNullsOnNonSchemaQueries = false
+      serverSideFilterNullValuesOnNonSchemaRawQueries = false
     )
 
   private def getCounterSafe(metricsNamespace: String, resource: String): Option[Long] = {


### PR DESCRIPTION
This change exposes the Raw-API support for filtering nulls server side through the cdp data source. It does not impact schema interference, as that is still done without filtering.