### PR TITLE
Remove mimetype check

### DIFF
--- a/src/main/scala/cognite/spark/v1/FileContentRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FileContentRelation.scala
@@ -46,9 +46,6 @@ class FileContentRelation(config: RelationConfig, fileExternalId: String, inferS
       )(backend => backend.close())
     } yield backend
 
-  val acceptedMimeTypes: Seq[String] =
-    Seq("application/jsonlines", "application/x-ndjson", "application/jsonl")
-
   @transient private lazy val dataFrame: DataFrame = createDataFrame
 
   override def schema: StructType =
@@ -64,15 +61,10 @@ class FileContentRelation(config: RelationConfig, fileExternalId: String, inferS
 
         val validUrl = for {
           file <- client.files.retrieveByExternalId(fileExternalId)
-          mimeType <- IO.pure(file.mimeType)
           _ <- IO.raiseWhen(!file.uploaded)(
             new CdfSparkException(
               f"Could not read file because no file was uploaded for externalId: $fileExternalId")
           )
-          _ <- IO.raiseWhen(mimeType.exists(!acceptedMimeTypes.contains(_)))(
-            new CdfSparkException("Wrong mimetype. Expects application/jsonlines")
-          )
-
           downloadLink <- client.files
             .downloadLink(FileDownloadExternalId(fileExternalId))
           uri <- IO.pure(uri"${downloadLink.downloadUrl}")

--- a/src/test/scala/cognite/spark/v1/FileContentRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/FileContentRelationTest.scala
@@ -129,19 +129,6 @@ class FileContentRelationTest  extends FlatSpec with Matchers with SparkTest wit
       )
   }
 
-  it should "fail with a sensible error if the mimetype is wrong" in {
-    val exception = sparkIntercept {
-      val sourceDf: DataFrame = dataFrameReaderUsingOidc
-        .useOIDCWrite
-        .option("type", "filecontent")
-        .option("externalId", fileWithWrongMimeTypeExternalId)
-        .load()
-      sourceDf.createOrReplaceTempView("fileContent")
-      spark.sqlContext.sql(s"select * from filecontent").collect()
-    }
-    assert(exception.getMessage.contains("Wrong mimetype. Expects application/jsonlines"))
-  }
-
   it should "infer the schema" in {
     val sourceDf: DataFrame = dataFrameReaderUsingOidc
       .useOIDCWrite


### PR DESCRIPTION
Seems like uploading a file through fusion with .ndjson extension will automatically set some different mimetype. Let's just remove this.