### PR TITLE
Character line size limit

### DIFF
--- a/src/main/scala/cognite/spark/v1/FileContentRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FileContentRelation.scala
@@ -122,7 +122,7 @@ class FileContentRelation(config: RelationConfig, fileExternalId: String, inferS
               .handleErrorWith {
                 case e: fs2.text.LineTooLongException =>
                   throw new CdfSparkException(
-                    s"""Line too long in file with external id: "$fileExternalId" SizeLimit in characters: $lineSizeLimitCharacters""",
+                    s"""Line too long in file with external id: "$fileExternalId" SizeLimit in characters: $e.max, but $e.length characters accumulated""",
                     e)
                 case other =>
                   throw other

--- a/src/main/scala/cognite/spark/v1/FileContentRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FileContentRelation.scala
@@ -36,7 +36,7 @@ class FileContentRelation(config: RelationConfig, fileExternalId: String, inferS
     with WithSizeLimit {
 
   override val fileSizeLimitBytes: Long = 5 * FileUtils.ONE_GB
-  //We enforce a 2.5MB limit per line. In jvm each character takes 2bytes so we divide by two to get the limit in characters.
+  //We enforce an arbitrarily chosen 2.5MB JVM mem limit per line. In jvm each character takes 2bytes so we divide by two to get the limit in characters.
   private val lineSizeLimitBytes: Int = (2.5 * FileUtils.ONE_MB).toInt
   override val lineSizeLimitCharacters: Int = lineSizeLimitBytes / 2
 

--- a/src/main/scala/cognite/spark/v1/FileContentRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FileContentRelation.scala
@@ -118,9 +118,11 @@ class FileContentRelation(config: RelationConfig, fileExternalId: String, inferS
               .through(enforceSizeLimit)
               .through(fs2.text.utf8.decode)
               .through(fs2.text.linesLimited(lineSizeLimitCharacters))
-              .handleErrorWith{
+              .handleErrorWith {
                 case e: fs2.text.LineTooLongException =>
-                  throw new CdfSparkException(s"""Line too long in file with external id: "$fileExternalId" SizeLimit in characters: $lineSizeLimitCharacters""", e)
+                  throw new CdfSparkException(
+                    s"""Line too long in file with external id: "$fileExternalId" SizeLimit in characters: $lineSizeLimitCharacters""",
+                    e)
                 case other =>
                   throw other
               }
@@ -141,7 +143,8 @@ class FileContentRelation(config: RelationConfig, fileExternalId: String, inferS
       in.scanChunks(0L) { (acc, chunk) =>
         val newSize = acc + chunk.size
         if (newSize > fileSizeLimitBytes)
-          throw new CdfSparkException(s"""File with external id: "$fileExternalId" size too big. SizeLimit in bytes: $fileSizeLimitBytes""")
+          throw new CdfSparkException(
+            s"""File with external id: "$fileExternalId" size too big. SizeLimit in bytes: $fileSizeLimitBytes""")
         else
           (newSize, chunk)
     }

--- a/src/main/scala/cognite/spark/v1/FileContentRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FileContentRelation.scala
@@ -23,7 +23,8 @@ import scala.concurrent.duration.Duration
 
 //The trait exist for testing purposes
 trait WithSizeLimit {
-  val sizeLimit: Long
+  val fileSizeLimitBytes: Long
+  val lineSizeLimitCharacters: Int
 }
 
 class FileContentRelation(config: RelationConfig, fileExternalId: String, inferSchema: Boolean)(
@@ -34,7 +35,9 @@ class FileContentRelation(config: RelationConfig, fileExternalId: String, inferS
     with Serializable
     with WithSizeLimit {
 
-  override val sizeLimit: Long = 5 * FileUtils.ONE_GB
+  override val fileSizeLimitBytes: Long = 5 * FileUtils.ONE_GB
+  private val lineSizeLimitBytes: Int = (2.5 * FileUtils.ONE_MB).toInt
+  override val lineSizeLimitCharacters: Int = lineSizeLimitBytes / 2
 
   @transient private lazy val sttpFileContentStreamingBackendResource
     : Resource[IO, SttpBackend[IO, Fs2Streams[IO] with WebSockets]] =
@@ -114,7 +117,13 @@ class FileContentRelation(config: RelationConfig, fileExternalId: String, inferS
             byteStream
               .through(enforceSizeLimit)
               .through(fs2.text.utf8.decode)
-              .through(fs2.text.lines)
+              .through(fs2.text.linesLimited(lineSizeLimitCharacters))
+              .handleErrorWith{
+                case e: fs2.text.LineTooLongException =>
+                  throw new CdfSparkException(s"""Line too long in file with external id: "$fileExternalId" SizeLimit in characters: $lineSizeLimitCharacters""", e)
+                case other =>
+                  throw other
+              }
           case Left(error) =>
             Stream.raiseError[IO](new Exception(s"Error while requesting underlying file: $error"))
         }
@@ -131,8 +140,8 @@ class FileContentRelation(config: RelationConfig, fileExternalId: String, inferS
     in =>
       in.scanChunks(0L) { (acc, chunk) =>
         val newSize = acc + chunk.size
-        if (newSize > sizeLimit)
-          throw new CdfSparkException(s"File size too big. SizeLimit: $sizeLimit")
+        if (newSize > fileSizeLimitBytes)
+          throw new CdfSparkException(s"""File with external id: "$fileExternalId" size too big. SizeLimit in bytes: $fileSizeLimitBytes""")
         else
           (newSize, chunk)
     }

--- a/src/main/scala/cognite/spark/v1/FileContentRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FileContentRelation.scala
@@ -36,6 +36,7 @@ class FileContentRelation(config: RelationConfig, fileExternalId: String, inferS
     with WithSizeLimit {
 
   override val fileSizeLimitBytes: Long = 5 * FileUtils.ONE_GB
+  //We enforce a 2.5MB limit per line. In jvm each character takes 2bytes so we divide by two to get the limit in characters.
   private val lineSizeLimitBytes: Int = (2.5 * FileUtils.ONE_MB).toInt
   override val lineSizeLimitCharacters: Int = lineSizeLimitBytes / 2
 

--- a/src/main/scala/cognite/spark/v1/FileContentRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FileContentRelation.scala
@@ -122,7 +122,7 @@ class FileContentRelation(config: RelationConfig, fileExternalId: String, inferS
               .handleErrorWith {
                 case e: fs2.text.LineTooLongException =>
                   throw new CdfSparkException(
-                    s"""Line too long in file with external id: "$fileExternalId" SizeLimit in characters: $e.max, but $e.length characters accumulated""",
+                    s"""Line too long in file with external id: "$fileExternalId" SizeLimit in characters: ${e.max}, but ${e.length} characters accumulated""",
                     e)
                 case other =>
                   throw other

--- a/src/test/scala/cognite/spark/v1/FileContentRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/FileContentRelationTest.scala
@@ -251,7 +251,7 @@ class FileContentRelationTest  extends FlatSpec with Matchers with SparkTest wit
       override val lineSizeLimitCharacters: Int = 5
     }
 
-    val expectedMessage = "Line too long in file with external id: \"fileContentTransformationFile\" SizeLimit in characters: 5"
+    val expectedMessage = "Line too long in file with external id: \"fileContentTransformationFile\" SizeLimit in characters: 5, but 47 characters accumulated"
     val exception = sparkIntercept {
       relation.createDataFrame
     }

--- a/src/test/scala/cognite/spark/v1/FileContentRelationTest.scala
+++ b/src/test/scala/cognite/spark/v1/FileContentRelationTest.scala
@@ -224,16 +224,34 @@ class FileContentRelationTest  extends FlatSpec with Matchers with SparkTest wit
     )
   }
 
-  it should "get size from endpoint and check for it" in {
+  it should "limit by file size in byte" in {
     val relation = new FileContentRelation(
       getDefaultConfig(auth = CdfSparkAuth.OAuth2ClientCredentials(credentials = writeCredentials), projectName = OIDCWrite.project, cluster = OIDCWrite.cluster, applicationName = Some("jetfire-test")),
       fileExternalId = fileExternalId,
       true
     )(spark.sqlContext) {
-      override val sizeLimit: Long = 100
+      override val fileSizeLimitBytes: Long = 100
     }
 
-    val expectedMessage = "File size too big. SizeLimit: 100"
+    val expectedMessage = "File with external id: \"fileContentTransformationFile\" size too big. SizeLimit in bytes: 100"
+    val exception = sparkIntercept {
+      relation.createDataFrame
+    }
+    withClue(s"Expected '$expectedMessage' but got: '${exception.getMessage}'") {
+      exception.getMessage.contains(expectedMessage) should be(true)
+    }
+  }
+
+  it should "limit by line size in character" in {
+    val relation = new FileContentRelation(
+      getDefaultConfig(auth = CdfSparkAuth.OAuth2ClientCredentials(credentials = writeCredentials), projectName = OIDCWrite.project, cluster = OIDCWrite.cluster, applicationName = Some("jetfire-test")),
+      fileExternalId = fileExternalId,
+      true
+    )(spark.sqlContext) {
+      override val lineSizeLimitCharacters: Int = 5
+    }
+
+    val expectedMessage = "Line too long in file with external id: \"fileContentTransformationFile\" SizeLimit in characters: 5"
     val exception = sparkIntercept {
       relation.createDataFrame
     }


### PR DESCRIPTION
There is a debate between using byte size and character size.

This is my preferred approach because:
 * while it's easy for a customer to check the byte size of a file, it's less straightforwards with a line, because it depends on encoding, and the file won't report it to them directly.
 * it avoids unnecessary processing and uses ready-made fs2 methods

here is a draft of the alternative to give you an idea of what the flow would be like:
https://github.com/cognitedata/cdp-spark-datasource/pull/995

(not if the alternative is preferred, the processing code needs a heavy coat of cleanup but the main idea is there)