### PR TITLE
filecontent: report itemsRead metric

### DIFF
--- a/src/main/scala/cognite/spark/v1/FileContentRelation.scala
+++ b/src/main/scala/cognite/spark/v1/FileContentRelation.scala
@@ -85,7 +85,8 @@ class FileContentRelation(config: RelationConfig, fileExternalId: String, inferS
         StreamIterator(
           Stream
             .eval(validUrl)
-            .flatMap(readUrlContentLines),
+            .flatMap(readUrlContentLines)
+            .evalTap(_ => IO.delay { itemsRead.inc() }),
           maxParallelism * 2,
           None
         )


### PR DESCRIPTION
Since filecontent doesn't go through `SdkV1Relation.{buildScan, getStream}` to implement reads
read metrics weren't being automatically reported.

Now it will do `itemsRead.inc()` once per line
