### PR TITLE
Pin coursier/setup-action by full version, sbtn->sbt to try fix the build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -68,7 +68,7 @@ jobs:
       - run: |
           git rev-list --count --first-parent HEAD > patch_version.txt
       - name: Set up JDK 8
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v1.3.8
         with:
           jvm: adopt:8
       - name: Build JAR file

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,9 +17,10 @@ jobs:
       - uses: coursier/setup-action@v1
         with:
           jvm: adopt:8
+          apps: sbt
       - name: Compile
         run: |
-          find / | grep sbt
+          find / 2>/dev/null | grep sbt
           sbt -Dsbt.log.noformat=true +{,macroSub/,structType/}dependencyLockCheck
           sbt +compile
       - name: Run tests

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,6 +19,7 @@ jobs:
           jvm: adopt:8
       - name: Compile
         run: |
+          find / | grep sbt
           sbt -Dsbt.log.noformat=true +{,macroSub/,structType/}dependencyLockCheck
           sbt +compile
       - name: Run tests

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -68,7 +68,7 @@ jobs:
       - run: |
           git rev-list --count --first-parent HEAD > patch_version.txt
       - name: Set up JDK 8
-        uses: coursier/setup-action@v1.3.8
+        uses: coursier/setup-action@v1.3.7
         with:
           jvm: adopt:8
       - name: Build JAR file

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0
       - run: |
           git rev-list --count --first-parent HEAD > patch_version.txt
-      - uses: coursier/setup-action@v1
+      - uses: coursier/setup-action@v1.3.9
         with:
           jvm: adopt:8
           apps: sbt
@@ -69,9 +69,10 @@ jobs:
       - run: |
           git rev-list --count --first-parent HEAD > patch_version.txt
       - name: Set up JDK 8
-        uses: coursier/setup-action@v1.3.7
+        uses: coursier/setup-action@v1.3.9
         with:
           jvm: adopt:8
+          apps: sbt
       - name: Build JAR file
         run: |
           LIB_PACKAGE="+library/package"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,6 @@ jobs:
           apps: sbt
       - name: Compile
         run: |
-          find / 2>/dev/null | grep sbt
           sbt -Dsbt.log.noformat=true +{,macroSub/,structType/}dependencyLockCheck
           sbt +compile
       - name: Run tests


### PR DESCRIPTION
Looks like something has changed and https://github.com/coursier/setup-action/ installing `sbtn` no longer installed `sbt` binary.
Let's pin action version for more explicit upgrades, and install `sbt` instead of `sbtn` to hopefully fix the build.

Without it build fail with
```
Run sbt -Dsbt.log.noformat=true +{,macroSub/,structType/}dependencyLockCheck
/home/runner/work/_temp/a737f15b-e7ab-4208-ba7f-f620b1b062d2.sh: line 1: sbt: command not found
Error: Process completed with exit code 127.
```