### PR TITLE
Handle connection error on cursor update

### DIFF
--- a/src/main/scala/cognite/spark/v1/SyncCursorCallback.scala
+++ b/src/main/scala/cognite/spark/v1/SyncCursorCallback.scala
@@ -5,13 +5,13 @@ import com.cognite.sdk.scala.sttp.{GzipBackend, RetryingBackend}
 import io.circe.Codec
 import io.circe.generic.semiauto.deriveCodec
 import org.log4s.getLogger
-
-import scala.concurrent.duration._
-import sttp.client3.{SttpBackend, basicRequest}
 import sttp.client3.asynchttpclient.SttpClientBackendFactory
 import sttp.client3.asynchttpclient.cats.AsyncHttpClientCatsBackend
 import sttp.client3.circe.{asJson, circeBodySerializer}
+import sttp.client3.{SttpBackend, basicRequest}
 import sttp.model.{MediaType, Uri}
+
+import scala.concurrent.duration._
 
 case class IncrementalCursor(name: String, value: String)
 case class IncrementalCursorResponse(name: String, value: String, updated: Boolean)
@@ -37,7 +37,25 @@ object SyncCursorCallback {
       callbackUrl: String,
       cursorName: String,
       cursorValue: String,
-      jobId: String): IO[IncrementalCursorResponse] = {
+      jobId: String
+  ): IO[IncrementalCursorResponse] =
+    sendCursorCallbackRequest(callbackUrl, cursorName, cursorValue, jobId, retryingBackend)
+      .map({
+        // We do not fail the whole transformation on a non-submitted cursor, as it is
+        // not critical for this job. Multiple failed runs so that the customer exceeds
+        // its max age, will lead to a fallback to restart.
+        case Left(error) =>
+          logger.warn(s"Failed to submit cursor $cursorName for jobId $jobId: ${error.getMessage}")
+          IncrementalCursorResponse(cursorName, cursorValue, updated = false)
+        case Right(value) => value
+      })
+
+  private[v1] def sendCursorCallbackRequest(
+      callbackUrl: String,
+      cursorName: String,
+      cursorValue: String,
+      jobId: String,
+      backend: SttpBackend[IO, Any]): IO[Either[Throwable, IncrementalCursorResponse]] = {
     val uri = Uri.parse(s"$callbackUrl/$jobId") match {
       case Left(value) => throw new IllegalArgumentException(s"Failed to parse URI '$value'")
       case Right(value) => value
@@ -50,16 +68,9 @@ object SyncCursorCallback {
       .body(IncrementalCursor(cursorName, cursorValue))
       .post(uri)
       .response(asJson[IncrementalCursorResponse])
-      .mapResponse {
-        // We do not fail the whole transformation on a non-submitted cursor, as it is
-        // not critical for this job. Multiple failed runs so that the customer exceeds
-        // its max age, will lead to a fallback to restart.
-        case Left(error) =>
-          logger.warn(s"Failed to submit cursor $cursorName for jobId $jobId: ${error.getMessage}")
-          IncrementalCursorResponse(cursorName, cursorValue, updated = false)
-        case Right(value) => value
-      }
-      .send(retryingBackend)
+      .send(backend)
       .map(_.body)
+      .attempt
+      .map(_.flatMap(identity))
   }
 }

--- a/src/test/scala/cognite/spark/v1/SyncCursorCallbackTest.scala
+++ b/src/test/scala/cognite/spark/v1/SyncCursorCallbackTest.scala
@@ -1,0 +1,42 @@
+package cognite.spark.v1
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import sttp.client3.impl.cats.implicits.asyncMonadError
+import sttp.client3.testing.SttpBackendStub
+import sttp.client3.{HttpError, SttpClientException, UriContext, basicRequest}
+import sttp.model.StatusCode
+import sttp.monad.MonadAsyncError
+
+class SyncCursorCallbackTest extends FlatSpec with Matchers with EitherValues {
+  it should "not throw on error response" in {
+    val response = SyncCursorCallback
+      .sendCursorCallbackRequest(
+        "localhost",
+        "name",
+        "value",
+        "job",
+        SttpBackendStub(implicitly[MonadAsyncError[IO]]).whenAnyRequest.thenRespondServerError())
+      .unsafeRunSync()
+
+    response.left.value shouldBe (HttpError("Internal server error", StatusCode.InternalServerError))
+  }
+
+  it should "should not throw on connection error" in {
+    val connectionException =
+      new SttpClientException.ConnectException(basicRequest.get(uri"localhost"), new RuntimeException)
+    val response = SyncCursorCallback
+      .sendCursorCallbackRequest(
+        "localhost",
+        "name",
+        "value",
+        "job",
+        SttpBackendStub(implicitly[MonadAsyncError[IO]]).whenAnyRequest
+          .thenRespond(Left(connectionException))
+      )
+      .unsafeRunSync()
+
+    response.left.value shouldBe (connectionException)
+  }
+}


### PR DESCRIPTION
We used to only handle non-OK responses from `jetfire-backend`, meaning that connection errors such as timeouts or connection refused would throw and be unhandled

Examples:
* https://jetfire-admin.iap.az-eastus-1.cognite.dev/jobs/filter?uuid=6f5ca314-e0c4-4ee3-95d7-8e8064f95a18
* https://jetfire-admin.iap.az-eastus-1.cognite.dev/jobs/filter?uuid=bc4d6305-142a-4703-ad9e-721e38a9d840
* https://jetfire-admin.iap.az-eastus-1.cognite.dev/jobs/filter?uuid=0fc73d32-4466-4005-b78e-e0cfe30a8744