### PR TITLE
FlexibleDataModelSyncTest: ignore broken test

### DIFF
--- a/src/test/scala/cognite/spark/v1/fdm/FlexibleDataModelSyncTest.scala
+++ b/src/test/scala/cognite/spark/v1/fdm/FlexibleDataModelSyncTest.scala
@@ -143,7 +143,7 @@ class FlexibleDataModelSyncTest extends FlatSpec
     syncedNodes3.length shouldBe 0
   }
 
-  (it should "sync with old cursor ").ignore in {
+  (it should "sync with old cursor ").ignore {
     // Let us see what happens when this cursor gets more than 3 days..
     val oldCursorValue = "\"Z0FBQUFBQmw0RjJXenpCbHl3Ny02MzRRN21lTEVkdm5hU3hpQTM4d05ERkwxV2xNSG5" +
       "wa2ltOHhXMXloWC05akN6TDEzWGExMkkwZlpocGVhdVZXSDBGMVpEdmIwSTlzVDhQQUVhOHBNV2pCNUFNMFBsREg" +

--- a/src/test/scala/cognite/spark/v1/fdm/FlexibleDataModelSyncTest.scala
+++ b/src/test/scala/cognite/spark/v1/fdm/FlexibleDataModelSyncTest.scala
@@ -143,7 +143,7 @@ class FlexibleDataModelSyncTest extends FlatSpec
     syncedNodes3.length shouldBe 0
   }
 
-  it should "sync with old cursor " in {
+  (it should "sync with old cursor ").ignore in {
     // Let us see what happens when this cursor gets more than 3 days..
     val oldCursorValue = "\"Z0FBQUFBQmw0RjJXenpCbHl3Ny02MzRRN21lTEVkdm5hU3hpQTM4d05ERkwxV2xNSG5" +
       "wa2ltOHhXMXloWC05akN6TDEzWGExMkkwZlpocGVhdVZXSDBGMVpEdmIwSTlzVDhQQUVhOHBNV2pCNUFNMFBsREg" +


### PR DESCRIPTION
Test currently fails with
```
[info]   com.cognite.sdk.scala.common.CdpApiException: Request with id 54a37b91-6d30-97c6-86f4-75c56c4c72c5 to https://bluefield.cognitedata.com/api/v1/projects/extractor-bluefield-testing/models/instances/sync failed with status 500: Internal server error. Please report this error to support@cognite.com and provide us with your request id: 54a37b91-6d30-97c6-86f4-75c56c4c72c5 and cluster name: bluefield.
```
but internally it seems more like 400 (cursor format changed or cursor is way too old?)