### PR TITLE
CDF-26316: increase token invalidation time

### DIFF
--- a/src/main/scala/cognite/spark/v1/CdfSparkAuth.scala
+++ b/src/main/scala/cognite/spark/v1/CdfSparkAuth.scala
@@ -18,7 +18,7 @@ object CdfSparkAuth {
 
   final case class OAuth2ClientCredentials(credentials: OAuth2.ClientCredentials) extends CdfSparkAuth {
 
-    private val refreshSecondsBeforeExpiration = 300L
+    private val refreshSecondsBeforeExpiration = 600L
 
     override def provider(
         implicit clock: Clock[IO],
@@ -30,7 +30,7 @@ object CdfSparkAuth {
 
   final case class OAuth2Sessions(session: OAuth2.Session) extends CdfSparkAuth {
 
-    private val refreshSecondsBeforeExpiration = 300L
+    private val refreshSecondsBeforeExpiration = 600L
 
     override def provider(
         implicit clock: Clock[IO],


### PR DESCRIPTION
Looks like due to retries of slow requests it can be a while until a refresh attempt

Fix to check invalidation on each retry will take a little more time due to interface changes etc (a related draft https://github.com/cognitedata/cognite-sdk-scala/pull/896)

For now let's just increase the refresh safety margin

[CDF-26316]

[CDF-26316]: https://cognitedata.atlassian.net/browse/CDF-26316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ