### PR TITLE
CDF-26346: FixedTraceSttpBackend: allow setting max time & count for span propagation

### DIFF
--- a/src/main/scala/cognite/spark/v1/CdpConnector.scala
+++ b/src/main/scala/cognite/spark/v1/CdpConnector.scala
@@ -199,7 +199,9 @@ object CdpConnector {
           maxParallelRequests = config.parallelismPerPartition,
           metricsPrefix = metricsPrefix
         ),
-        config.tracingParent
+        config.tracingConfig.tracingParent,
+        config.tracingConfig.maxRequests,
+        config.tracingConfig.maxTime,
       )
     val authProvider = config.auth.provider(implicitly, authSttpBackend).unsafeRunBlocking()
 
@@ -213,7 +215,9 @@ object CdpConnector {
           maxParallelRequests = config.parallelismPerPartition,
           metricsPrefix = metricsPrefix
         ),
-        config.tracingParent
+        config.tracingConfig.tracingParent,
+        config.tracingConfig.maxRequests,
+        config.tracingConfig.maxTime,
       )
     }
 

--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -25,6 +25,7 @@ import org.log4s.getLogger
 import org.typelevel.ci.CIString
 import sttp.model.Uri
 
+import java.time.Instant
 import scala.reflect.classTag
 
 class DefaultSource
@@ -404,6 +405,13 @@ object DefaultSource {
         .map(kv => (CIString(kv._1.substring(TRACING_PARAMETER_PREFIX.length)), kv._2))
         .toMap)
 
+  def extractTracingConfig(parameters: Map[String, String]): TracingConfig =
+    new TracingConfig(
+      extractTracingHeadersKernel(parameters),
+      parameters.get("tracingMaxRequests").map(_.toLong),
+      parameters.get("tracingMaxTimestampSecondsUtc").map(_.toLong).map(Instant.ofEpochSecond)
+    )
+
   def saveTracingHeaders(knl: Kernel): Seq[(String, String)] =
     knl.toHeaders.toList.map(kv => (TRACING_PARAMETER_PREFIX + kv._1, kv._2))
 
@@ -507,7 +515,7 @@ object DefaultSource {
       ignoreNullFields = toBoolean(parameters, "ignoreNullFields", defaultValue = true),
       rawEnsureParent = toBoolean(parameters, "rawEnsureParent", defaultValue = true),
       enableSinglePartitionDeleteAssetHierarchy = enableSinglePartitionDeleteAssetHierarchy,
-      tracingParent = extractTracingHeadersKernel(parameters),
+      tracingConfig = extractTracingConfig(parameters),
       useSharedThrottle = toBoolean(parameters, "useSharedThrottle", defaultValue = false),
       serverSideFilterNullValuesOnNonSchemaRawQueries =
         toBoolean(parameters, "filterNullFieldsOnNonSchemaRawQueries", defaultValue = false),

--- a/src/main/scala/cognite/spark/v1/RelationConfig.scala
+++ b/src/main/scala/cognite/spark/v1/RelationConfig.scala
@@ -2,6 +2,14 @@ package cognite.spark.v1
 
 import natchez.Kernel
 
+import java.time.Instant
+
+final case class TracingConfig(
+    tracingParent: Kernel,
+    maxRequests: Option[Long],
+    maxTime: Option[Instant],
+)
+
 final case class RelationConfig(
     auth: CdfSparkAuth,
     clientTag: Option[String],
@@ -26,7 +34,7 @@ final case class RelationConfig(
     ignoreNullFields: Boolean,
     rawEnsureParent: Boolean,
     enableSinglePartitionDeleteAssetHierarchy: Boolean, // flag to test whether single partition helps avoid NPE in asset hierarchy builder
-    tracingParent: Kernel,
+    tracingConfig: TracingConfig,
     initialRetryDelayMillis: Int,
     useSharedThrottle: Boolean,
     serverSideFilterNullValuesOnNonSchemaRawQueries: Boolean,

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -272,7 +272,7 @@ trait SparkTest {
       ignoreNullFields = true,
       rawEnsureParent = false,
       enableSinglePartitionDeleteAssetHierarchy = false,
-      tracingParent = new Kernel(Map.empty),
+      tracingConfig = TracingConfig(new Kernel(Map.empty), None, None),
       useSharedThrottle = false,
       serverSideFilterNullValuesOnNonSchemaRawQueries = false,
       maxOutstandingRawInsertRequests = None


### PR DESCRIPTION
Spark job can be very long and have many requests, which can be taxing
on span collector, trace assembly, and won't work for the UI either.

Currently spark executors don't export spans and so can't produce new
"root" spans with "span links" to parent to still have a connection,
all we can do is stop propagation at a threshold.
(There's no standard way to tell downstream service that our span needs
to become a linked span rather than a parent)

New optional params are
- `tracingMaxRequests`
- `tracingMaxTimestampSecondsUtc`

FixedTraceSttpBackend will stop attaching trace context once either of
those is reached

[CDF-26346]


[CDF-26346]: https://cognitedata.atlassian.net/browse/CDF-26346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ