### PR TITLE
CDF-27181: /query in connection relation: add support for adding HasData filter

### DIFF
--- a/src/main/scala/cognite/spark/v1/fdm/FlexibleDataModelConnectionRelation.scala
+++ b/src/main/scala/cognite/spark/v1/fdm/FlexibleDataModelConnectionRelation.scala
@@ -3,7 +3,11 @@ package cognite.spark.v1.fdm
 import cats.effect.IO
 import cats.implicits.toTraverseOps
 import cognite.spark.v1.fdm.FlexibleDataModelBaseRelation.ProjectedFlexibleDataModelInstance
-import cognite.spark.v1.fdm.FlexibleDataModelQueryUtils.{generateTableExpression, sourceReference}
+import cognite.spark.v1.fdm.FlexibleDataModelQueryUtils.{
+  generateTableExpression,
+  queryFilterWithHasData,
+  sourceReference
+}
 import cognite.spark.v1.fdm.FlexibleDataModelRelationFactory.ConnectionConfig
 import cognite.spark.v1.fdm.FlexibleDataModelRelationUtils.{
   createConnectionInstances,
@@ -106,7 +110,9 @@ private[spark] class FlexibleDataModelConnectionRelation(
       val tableExpression =
         generateTableExpression(
           InstanceType.Edge,
-          Some(instanceFilters),
+          // Note: we don't provide a view reference atm, but for consistency with FlexibleDataModelCorePropertyRelation
+          //       let's have a shape that adds HasData filter for viewReference present case
+          queryFilterWithHasData(Some(instanceFilters), None),
           None
         )
       val selectExpression = SelectExpression(


### PR DESCRIPTION
In practice there's never a viewReference supplied so HasData filter
isn't added either way. But for consistency with property relation let's
have code ready for providing HasData if at some point viewReference
would be provided.

[CDF-27181]


[CDF-27181]: https://cognitedata.atlassian.net/browse/CDF-27181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ