### PR TITLE
remove unused useQuery = false and enforceColumnPushdown = false

### DIFF
--- a/src/main/scala/cognite/spark/v1/DefaultSource.scala
+++ b/src/main/scala/cognite/spark/v1/DefaultSource.scala
@@ -539,10 +539,7 @@ object DefaultSource {
       serverSideFilterNullValuesOnNonSchemaRawQueries =
         toBoolean(parameters, "filterNullFieldsOnNonSchemaRawQueries", defaultValue = false),
       maxOutstandingRawInsertRequests = toPositiveInt(parameters, "maxOutstandingRawInsertRequests"),
-      sendDebugFlag = toBoolean(parameters, "sendDebugFlag", defaultValue = false),
-      useQuery = toBoolean(parameters, "useQuery", defaultValue = false),
-      useQueryPushdownColumnsSelection =
-        toBoolean(parameters, "useQueryPushdownColumnsSelection", defaultValue = false),
+      sendDebugFlag = toBoolean(parameters, "sendDebugFlag", defaultValue = false)
     )
   }
 

--- a/src/main/scala/cognite/spark/v1/RelationConfig.scala
+++ b/src/main/scala/cognite/spark/v1/RelationConfig.scala
@@ -38,11 +38,7 @@ final case class RelationConfig(
     initialRetryDelayMillis: Int,
     serverSideFilterNullValuesOnNonSchemaRawQueries: Boolean,
     maxOutstandingRawInsertRequests: Option[Int],
-    sendDebugFlag: Boolean,
-    //When using query instead of list, DM will not send a next cursor if there is no index and there's sort pushdown as it would be a performance hazard
-    //Note that currently there's no sort pushdown in datasource, so that's safe
-    useQuery: Boolean,
-    useQueryPushdownColumnsSelection: Boolean
+    sendDebugFlag: Boolean
 ) {
 
   /** Desired number of Spark partitions ~= partitions / parallelismPerPartition */

--- a/src/main/scala/cognite/spark/v1/fdm/FlexibleDataModelConnectionRelation.scala
+++ b/src/main/scala/cognite/spark/v1/fdm/FlexibleDataModelConnectionRelation.scala
@@ -17,11 +17,7 @@ import cognite.spark.v1.{CdfSparkException, RelationConfig}
 import com.cognite.sdk.scala.v1.GenericClient
 import com.cognite.sdk.scala.v1.fdm.common.DirectRelationReference
 import com.cognite.sdk.scala.v1.fdm.common.filters.{FilterDefinition, FilterValueDefinition}
-import com.cognite.sdk.scala.v1.fdm.instances.{
-  InstanceCreate,
-  InstanceType,
-  SelectExpression
-}
+import com.cognite.sdk.scala.v1.fdm.instances.{InstanceCreate, InstanceType, SelectExpression}
 import fs2.Stream
 import io.circe.Json
 import org.apache.spark.sql.sources._

--- a/src/main/scala/cognite/spark/v1/fdm/FlexibleDataModelConnectionRelation.scala
+++ b/src/main/scala/cognite/spark/v1/fdm/FlexibleDataModelConnectionRelation.scala
@@ -19,7 +19,6 @@ import com.cognite.sdk.scala.v1.fdm.common.DirectRelationReference
 import com.cognite.sdk.scala.v1.fdm.common.filters.{FilterDefinition, FilterValueDefinition}
 import com.cognite.sdk.scala.v1.fdm.instances.{
   InstanceCreate,
-  InstanceFilterRequest,
   InstanceType,
   SelectExpression
 }
@@ -106,49 +105,31 @@ private[spark] class FlexibleDataModelConnectionRelation(
       case Right(v) => v
       case Left(err) => throw err
     }
-    if (config.useQuery) {
-      val tableExpression =
-        generateTableExpression(
-          InstanceType.Edge,
-          // Note: we don't provide a view reference atm, but for consistency with FlexibleDataModelCorePropertyRelation
-          //       let's have a shape that adds HasData filter for viewReference present case
-          queryFilterWithHasData(Some(instanceFilters), None),
-          None
+    val tableExpression =
+      generateTableExpression(
+        InstanceType.Edge,
+        // Note: we don't provide a view reference atm, but for consistency with FlexibleDataModelCorePropertyRelation
+        //       let's have a shape that adds HasData filter for viewReference present case
+        queryFilterWithHasData(Some(instanceFilters), None),
+        None
+      )
+    val selectExpression = SelectExpression(
+      sources = sourceReference(
+        InstanceType.Edge,
+        None,
+        // Note: since we don't supply viewReference here selectedFields will have no effect
+        selectedFields
+      ),
+    )
+    Vector(
+      client.instances
+        .queryStream(
+          inputTableExpression = tableExpression,
+          inputSelectExpression = selectExpression,
+          limit = config.limitPerPartition,
+          batchSize = config.batchSize
         )
-      val selectExpression = SelectExpression(
-        sources = sourceReference(
-          InstanceType.Edge,
-          None,
-          // Note: since we don't supply viewReference here selectedFields will have no effect
-          if (config.useQueryPushdownColumnsSelection) selectedFields else Array()
-        ),
-      )
-      Vector(
-        client.instances
-          .queryStream(
-            inputTableExpression = tableExpression,
-            inputSelectExpression = selectExpression,
-            limit = config.limitPerPartition,
-            batchSize = config.batchSize
-          )
-          .map(toProjectedInstance(_, None, selectedFields)))
-    } else {
-      val filterRequest = InstanceFilterRequest(
-        instanceType = Some(InstanceType.Edge),
-        filter = Some(instanceFilters),
-        sort = None,
-        limit = config.limitPerPartition,
-        cursor = None,
-        sources = None,
-        includeTyping = Some(true),
-        debug = optionalDebug(config.sendDebugFlag)
-      )
-      Vector(
-        client.instances
-          .filterStream(filterRequest, config.limitPerPartition)
-          .map(toProjectedInstance(_, None, selectedFields))
-      )
-    }
+        .map(toProjectedInstance(_, None, selectedFields)))
   }
 
   private def extractFilters(filters: Array[Filter]): Either[CdfSparkException, FilterDefinition] = {

--- a/src/main/scala/cognite/spark/v1/fdm/FlexibleDataModelConnectionRelation.scala
+++ b/src/main/scala/cognite/spark/v1/fdm/FlexibleDataModelConnectionRelation.scala
@@ -123,7 +123,8 @@ private[spark] class FlexibleDataModelConnectionRelation(
           inputTableExpression = tableExpression,
           inputSelectExpression = selectExpression,
           limit = config.limitPerPartition,
-          batchSize = config.batchSize
+          batchSize = config.batchSize,
+          debug = optionalDebug(config.sendDebugFlag),
         )
         .map(toProjectedInstance(_, None, selectedFields)))
   }

--- a/src/main/scala/cognite/spark/v1/fdm/FlexibleDataModelCorePropertyRelation.scala
+++ b/src/main/scala/cognite/spark/v1/fdm/FlexibleDataModelCorePropertyRelation.scala
@@ -122,16 +122,14 @@ private[spark] class FlexibleDataModelCorePropertyRelation(
           None
         )
       val selectExpression = SelectExpression(
-        sources = sourceReference(
-          instanceType,
-          viewReference,
-          selectedInstanceProps),
+        sources = sourceReference(instanceType, viewReference, selectedInstanceProps),
       )
       client.instances
         .queryStream(
           inputTableExpression = tableExpression,
           inputSelectExpression = selectExpression,
           limit = config.limitPerPartition,
+          debug = optionalDebug(config.sendDebugFlag),
           batchSize = config.batchSize
         )
         .map(toProjectedInstance(_, None, selectedInstanceProps))

--- a/src/main/scala/cognite/spark/v1/fdm/FlexibleDataModelCorePropertyRelation.scala
+++ b/src/main/scala/cognite/spark/v1/fdm/FlexibleDataModelCorePropertyRelation.scala
@@ -114,47 +114,27 @@ private[spark] class FlexibleDataModelCorePropertyRelation(
       case Left(err) => throw err
     }
 
-    if (config.useQuery) {
-      compatibleInstanceTypes(intendedUsage).distinct.map { instanceType =>
-        val tableExpression =
-          generateTableExpression(
-            instanceType,
-            queryFilterWithHasData(instanceFilter, viewReference),
-            None
-          )
-        val selectExpression = SelectExpression(
-          sources = sourceReference(
-            instanceType,
-            viewReference,
-            if (config.useQueryPushdownColumnsSelection) selectedInstanceProps else Array()),
+    compatibleInstanceTypes(intendedUsage).distinct.map { instanceType =>
+      val tableExpression =
+        generateTableExpression(
+          instanceType,
+          queryFilterWithHasData(instanceFilter, viewReference),
+          None
         )
-        client.instances
-          .queryStream(
-            inputTableExpression = tableExpression,
-            inputSelectExpression = selectExpression,
-            limit = config.limitPerPartition,
-            batchSize = config.batchSize
-          )
-          .map(toProjectedInstance(_, None, selectedInstanceProps))
-      }
-    } else {
-      val filterRequests = compatibleInstanceTypes(intendedUsage).map { instanceType =>
-        InstanceFilterRequest(
-          instanceType = Some(instanceType),
-          filter = instanceFilter,
-          sort = None,
+      val selectExpression = SelectExpression(
+        sources = sourceReference(
+          instanceType,
+          viewReference,
+          selectedInstanceProps),
+      )
+      client.instances
+        .queryStream(
+          inputTableExpression = tableExpression,
+          inputSelectExpression = selectExpression,
           limit = config.limitPerPartition,
-          cursor = None,
-          sources = viewReference.map(r => Vector(InstanceSource(r))),
-          includeTyping = Some(true),
-          debug = optionalDebug(config.sendDebugFlag)
+          batchSize = config.batchSize
         )
-      }
-      filterRequests.distinct.map { fr =>
-        client.instances
-          .filterStream(fr, config.limitPerPartition)
-          .map(toProjectedInstance(_, None, selectedInstanceProps))
-      }
+        .map(toProjectedInstance(_, None, selectedInstanceProps))
     }
   }
 

--- a/src/test/scala/cognite/spark/v1/SparkTest.scala
+++ b/src/test/scala/cognite/spark/v1/SparkTest.scala
@@ -284,9 +284,7 @@ trait SparkTest {
       tracingConfig = TracingConfig(new Kernel(Map.empty), None, None),
       serverSideFilterNullValuesOnNonSchemaRawQueries = false,
       maxOutstandingRawInsertRequests = None,
-      sendDebugFlag = false,
-      useQuery = false,
-      useQueryPushdownColumnsSelection = false
+      sendDebugFlag = false
     )
 
   private def getCounterSafe(metricsNamespace: String, resource: String): Option[Long] = {

--- a/src/test/scala/cognite/spark/v1/fdm/FlexibleDataModelEdgeTest.scala
+++ b/src/test/scala/cognite/spark/v1/fdm/FlexibleDataModelEdgeTest.scala
@@ -115,13 +115,10 @@ class FlexibleDataModelEdgeTest
 
 
   it should "fetch edges with filters" in {
-    testFetchEdgesWithFilters(useQuery = true, useQueryPushdownColumnsSelection = true)
-    testFetchEdgesWithFilters(useQuery = true, useQueryPushdownColumnsSelection = false)
-    testFetchEdgesWithFilters(useQuery = false, useQueryPushdownColumnsSelection = true)
-    testFetchEdgesWithFilters(useQuery = false, useQueryPushdownColumnsSelection = false)
+    testFetchEdgesWithFilters()
   }
 
-  def testFetchEdgesWithFilters(useQuery: Boolean, useQueryPushdownColumnsSelection: Boolean): Unit = {
+  def testFetchEdgesWithFilters(): Unit = {
     val startNodeExtIdPrefix = s"${startEndNodeViewExternalId}FetchStartNode"
     val endNodeExtIdPrefix = s"${startEndNodeViewExternalId}FetchEndNode"
 
@@ -166,9 +163,7 @@ class FlexibleDataModelEdgeTest
 
     val readConnectionsDf = readEdgeWithEdgeType(
       edgeSpace = spaceExternalId,
-      edgeExternalId = edgeTypeExtId,
-      useQuery = useQuery,
-      useQueryPushdownColumnsSelection = useQueryPushdownColumnsSelection
+      edgeExternalId = edgeTypeExtId
     )
 
     val tempViewUUID = UUID.randomUUID().toString.replace("-", "")
@@ -186,7 +181,7 @@ class FlexibleDataModelEdgeTest
     (instExtIds should contain).allElementsOf(Array("edge1"))
   }
 
-  def testFetchEdgeEdgeType(useQuery: Boolean): Unit = {
+  def testFetchEdgeEdgeType(): Unit = {
     val created = (for {
       c1 <- createConnectionWriteInstances(
         externalId = "edgeForEdgeTypeFilter1",
@@ -208,7 +203,7 @@ class FlexibleDataModelEdgeTest
       )
     } yield c1 ++ c2).unsafeRunSync()
 
-    val readConnectionsDf = readEdgeWithEdgeType(edgeSpace = spaceExternalId, edgeExternalId = "edgeType", useQuery = useQuery)
+    val readConnectionsDf = readEdgeWithEdgeType(edgeSpace = spaceExternalId, edgeExternalId = "edgeType")
 
     val tempViewUUID = UUID.randomUUID().toString.replace("-", "")
     readConnectionsDf.createTempView("connection_instances_table_edgetype" + tempViewUUID)
@@ -224,19 +219,16 @@ class FlexibleDataModelEdgeTest
   }
 
   it should "fetch edge with edgeType with both query and list" in {
-    testFetchEdgeEdgeType(useQuery = true)
-    testFetchEdgeEdgeType(useQuery = false)
+    testFetchEdgeEdgeType()
   }
 
-  def testFetchEdgeDataModel(useQuery: Boolean, useQueryPushdownColumnsSelection: Boolean): Unit = {
+  def testFetchEdgeDataModel(): Unit = {
     val df = readRowsFromModelWithEdgeType(
       spaceExternalId,
       edgeTestDataModelExternalId,
       viewVersion,
       spaceExternalId,
-      edgeTypeExtId,
-      useQuery = useQuery,
-      useQueryPushdownColumnsSelection = useQueryPushdownColumnsSelection
+      edgeTypeExtId
     )
 
     val tempViewUUID = UUID.randomUUID().toString.replace("-", "")
@@ -259,10 +251,7 @@ class FlexibleDataModelEdgeTest
   }
 
   it should "fetch edges from a data model both with query and list" in {
-    testFetchEdgeDataModel(useQuery = true, useQueryPushdownColumnsSelection = true)
-    testFetchEdgeDataModel(useQuery = true, useQueryPushdownColumnsSelection = false)
-    testFetchEdgeDataModel(useQuery = false, useQueryPushdownColumnsSelection = true)
-    testFetchEdgeDataModel(useQuery = false, useQueryPushdownColumnsSelection = false)
+    testFetchEdgeDataModel()
   }
 
 

--- a/src/test/scala/cognite/spark/v1/fdm/FlexibleDataModelNodeTest.scala
+++ b/src/test/scala/cognite/spark/v1/fdm/FlexibleDataModelNodeTest.scala
@@ -305,16 +305,15 @@ class FlexibleDataModelNodeTest
     getDeletedMetricsCount(viewEdges) shouldBe 1
   }
 
-  def checkAmbiguousTypeHandling(useQuery: Boolean): Unit = {
-    val useQueryToString: String = if(useQuery) "Query" else "List"
-    val startNodeExtId = s"${viewStartNodeAndEndNodesExternalId}InsertListStartNode$useQueryToString"
-    val endNodeExtId = s"${viewStartNodeAndEndNodesExternalId}InsertListEndNode$useQueryToString"
+  def checkAmbiguousTypeHandling(): Unit = {
+    val startNodeExtId = s"${viewStartNodeAndEndNodesExternalId}InsertListStartNodeQuery"
+    val endNodeExtId = s"${viewStartNodeAndEndNodesExternalId}InsertListEndNodeQuery"
     createStartAndEndNodesForEdgesIfNotExists(
       startNodeExtId,
       endNodeExtId,
       viewStartAndEndNodes.toSourceReference).unsafeRunSync()
 
-    val (viewAll, viewNodes, viewEdges) = setupAmbiguousTypeTest(useQueryToString).unsafeRunSync()
+    val (viewAll, viewNodes, viewEdges) = setupAmbiguousTypeTest("Query").unsafeRunSync()
     val randomId = generateNodeExternalId
     val instanceExtIdAll = s"${randomId}All"
     val instanceExtIdNode = s"${randomId}Node"
@@ -403,8 +402,7 @@ class FlexibleDataModelNodeTest
       viewSpaceExternalId = spaceExternalId,
       viewExternalId = viewEdges.externalId,
       viewVersion = viewEdges.version,
-      instanceSpaceExternalId = spaceExternalId,
-      useQuery = useQuery
+      instanceSpaceExternalId = spaceExternalId
     )
     val tempViewName = s"edge_ambiguous_type_test_instances_table${UUID.randomUUID().toString.replace("-", "")}"
     readEdgesDf.createTempView(tempViewName)
@@ -478,13 +476,11 @@ class FlexibleDataModelNodeTest
   }
 
   it should "handle ambiguous types when there is a type property in the view of the node" in {
-    checkAmbiguousTypeHandling(useQuery = false)
-    checkAmbiguousTypeHandling(useQuery = true)
+    checkAmbiguousTypeHandling()
   }
 
-  def testHandleUsingTypeForEdgesInstanceProperty(useQuery: Boolean,
-                                                  useQueryPushdownColumnsSelection: Boolean): Unit = {
-    val viewNameSuffix: String = if (useQuery) s"Query_${useQueryPushdownColumnsSelection}" else "List"
+  def testHandleUsingTypeForEdgesInstanceProperty(): Unit = {
+    val viewNameSuffix: String = "Query_true"
 
     val startNodeExtId = s"${viewStartNodeAndEndNodesExternalId}InsertListStartNode"
     val endNodeExtId = s"${viewStartNodeAndEndNodesExternalId}InsertListEndNode"
@@ -535,9 +531,7 @@ class FlexibleDataModelNodeTest
       viewSpaceExternalId = spaceExternalId,
       viewExternalId = viewEdges.externalId,
       viewVersion = viewEdges.version,
-      instanceSpaceExternalId = spaceExternalId,
-      useQuery = useQuery,
-      useQueryPushdownColumnsSelection = useQueryPushdownColumnsSelection
+      instanceSpaceExternalId = spaceExternalId
     )
     val tempViewName = s"edge_type_test_instances_table${UUID.randomUUID().toString.replace("-", "")}"
     readEdgesDf.createTempView(tempViewName)
@@ -591,9 +585,7 @@ class FlexibleDataModelNodeTest
   }
 
   it should "handle using type for edges instance property when there is no property named type in the associated view" in {
-    testHandleUsingTypeForEdgesInstanceProperty(useQuery = true, useQueryPushdownColumnsSelection = true)
-    testHandleUsingTypeForEdgesInstanceProperty(useQuery = true, useQueryPushdownColumnsSelection = false)
-    testHandleUsingTypeForEdgesInstanceProperty(useQuery = false, useQueryPushdownColumnsSelection = false)
+    testHandleUsingTypeForEdgesInstanceProperty()
   }
 
   it should "succeed when inserting all nullable & non nullable list values" in {
@@ -753,7 +745,7 @@ class FlexibleDataModelNodeTest
     getDeletedMetricsCount(viewEdges) shouldBe 1
   }
 
-  def fetchAllInstancesSelectAll(useQuery: Boolean): Unit = {
+  def fetchAllInstancesSelectAll(): Unit = {
     val startNodeExtId = s"${viewStartNodeAndEndNodesExternalId}InsertAllStartNode"
     val endNodeExtId = s"${viewStartNodeAndEndNodesExternalId}InsertAllEndNode"
     createStartAndEndNodesForEdgesIfNotExists(
@@ -806,8 +798,7 @@ class FlexibleDataModelNodeTest
       viewSpaceExternalId = spaceExternalId,
       viewExternalId = viewNodes.externalId,
       viewVersion = viewNodes.version,
-      instanceSpaceExternalId = spaceExternalId,
-      useQuery = useQuery
+      instanceSpaceExternalId = spaceExternalId
     )
 
     val syncNodesDf = syncRows(
@@ -823,8 +814,7 @@ class FlexibleDataModelNodeTest
       viewSpaceExternalId = spaceExternalId,
       viewExternalId = viewEdges.externalId,
       viewVersion = viewEdges.version,
-      instanceSpaceExternalId = spaceExternalId,
-      useQuery = useQuery
+      instanceSpaceExternalId = spaceExternalId
     )
 
     val syncEdgesDf = syncRows(
@@ -840,8 +830,7 @@ class FlexibleDataModelNodeTest
       viewSpaceExternalId = spaceExternalId,
       viewExternalId = viewAll.externalId,
       viewVersion = viewAll.version,
-      instanceSpaceExternalId = spaceExternalId,
-      useQuery = useQuery
+      instanceSpaceExternalId = spaceExternalId
     )
 
     val readNodesDfViewAll = readRows(
@@ -849,8 +838,7 @@ class FlexibleDataModelNodeTest
       viewSpaceExternalId = spaceExternalId,
       viewExternalId = viewAll.externalId,
       viewVersion = viewAll.version,
-      instanceSpaceExternalId = spaceExternalId,
-      useQuery = useQuery
+      instanceSpaceExternalId = spaceExternalId
     )
 
 
@@ -914,11 +902,10 @@ class FlexibleDataModelNodeTest
   }
 
   it should "succeed when fetching instances with select *" in {
-    fetchAllInstancesSelectAll(useQuery = true)
-    fetchAllInstancesSelectAll(useQuery = false)
+    fetchAllInstancesSelectAll()
   }
 
-  def testFilterEdgesByTypeStarNodeEndNode(useQuery: Boolean): Unit = {
+  def testFilterEdgesByTypeStarNodeEndNode(): Unit = {
     val startNodeExtId = s"${viewStartNodeAndEndNodesExternalId}FilterByEdgePropsStartNode"
     val endNodeExtId = s"${viewStartNodeAndEndNodesExternalId}FilterByEdgePropsEndNode"
     createStartAndEndNodesForEdgesIfNotExists(
@@ -958,8 +945,7 @@ class FlexibleDataModelNodeTest
       viewSpaceExternalId = spaceExternalId,
       viewExternalId = viewEdges.externalId,
       viewVersion = viewEdges.version,
-      instanceSpaceExternalId = spaceExternalId,
-      useQuery = useQuery
+      instanceSpaceExternalId = spaceExternalId
     )
     val tempViewName = s"edge_filter_instances_table${UUID.randomUUID().toString.replace("-", "")}"
     readEdgesDf.createTempView(tempViewName)
@@ -981,16 +967,14 @@ class FlexibleDataModelNodeTest
   }
 
   it should "succeed when filtering edges with type, startNode & endNode" in {
-    testFilterEdgesByTypeStarNodeEndNode(useQuery = true)
-    testFilterEdgesByTypeStarNodeEndNode(useQuery = false)
+    testFilterEdgesByTypeStarNodeEndNode()
   }
 
   it should "succeed when filtering nodes with type" in {
-    testFilterNodesWithType(useQuery = true)
-    testFilterNodesWithType(useQuery = false)
+    testFilterNodesWithType()
   }
 
-  def testFilterNodesWithType(useQuery: Boolean): Unit = {
+  def testFilterNodesWithType(): Unit = {
     val nullTypedNode = s"${viewStartNodeAndEndNodesExternalId}FilterByTypeNullType"
     val nonNullTypedNode = s"${viewStartNodeAndEndNodesExternalId}FilterByType"
     val typeNode = s"${viewStartNodeAndEndNodesExternalId}FilterByTypeType"
@@ -1007,8 +991,7 @@ class FlexibleDataModelNodeTest
       viewSpaceExternalId = spaceExternalId,
       viewExternalId = viewTypedNode.externalId,
       viewVersion = viewTypedNode.version,
-      instanceSpaceExternalId = spaceExternalId,
-      useQuery = useQuery
+      instanceSpaceExternalId = spaceExternalId
     )
 
     val tempViewName = s"node_filter_instances_table${UUID.randomUUID().toString.replace("-", "")}"
@@ -1026,11 +1009,10 @@ class FlexibleDataModelNodeTest
   }
 
   it should "succeed when filtering instances by properties" in {
-    testFilterInstancesByProperties(useQuery = true)
-    testFilterInstancesByProperties(useQuery = false)
+    testFilterInstancesByProperties()
   }
 
-  def testFilterInstancesByProperties(useQuery: Boolean): Unit = {
+  def testFilterInstancesByProperties(): Unit = {
     val (view, instanceExtIds) = setupFilteringByPropertiesTest.unsafeRunSync()
 
     val readDf = readRows(
@@ -1038,8 +1020,7 @@ class FlexibleDataModelNodeTest
       viewSpaceExternalId = spaceExternalId,
       viewExternalId = view.externalId,
       viewVersion = view.version,
-      instanceSpaceExternalId = spaceExternalId,
-      useQuery = useQuery
+      instanceSpaceExternalId = spaceExternalId
     )
 
     val syncDf = syncRows(
@@ -1111,11 +1092,10 @@ class FlexibleDataModelNodeTest
   }
 
   it should "successfully read from relation properties" in {
-    testReadFromRelationProperties(useQuery = true)
-    testReadFromRelationProperties(useQuery = false)
+    testReadFromRelationProperties()
   }
 
-  def testReadFromRelationProperties(useQuery: Boolean): Unit = {
+  def testReadFromRelationProperties(): Unit = {
     val viewDef = setupRelationReadPropsTest.unsafeRunSync()
     val nodeExtId1 = s"${viewDef.externalId}Relation1"
 
@@ -1145,8 +1125,7 @@ class FlexibleDataModelNodeTest
       viewSpaceExternalId = viewDef.space,
       viewVersion = viewDef.version,
       viewExternalId = viewDef.externalId,
-      instanceSpaceExternalId = viewDef.space,
-      useQuery = useQuery
+      instanceSpaceExternalId = viewDef.space
     )
     val tempViewName = s"temp_view_with_relations_${UUID.randomUUID().toString.replace("-", "")}"
     dfFromModel.createTempView(tempViewName)
@@ -1251,7 +1230,7 @@ class FlexibleDataModelNodeTest
     propertyMapForInstances(nodeExtId2).get("doubleProp") shouldBe None
   }
 
-  def testReadExternaldRefs(useQuery: Boolean): Unit = {
+  def testReadExternaldRefs(): Unit = {
     val viewDef = setupExternalIdReferenceTest.unsafeRunSync()
     val nodeExtId1 = s"${viewDef.externalId}FilesSeq1"
 
@@ -1278,8 +1257,7 @@ class FlexibleDataModelNodeTest
       viewSpaceExternalId = spaceExternalId,
       viewExternalId = viewDef.externalId,
       viewVersion = viewDef.version,
-      instanceSpaceExternalId = spaceExternalId,
-      useQuery = useQuery
+      instanceSpaceExternalId = spaceExternalId
     )
     val tempViewName = s"file_reference_table${UUID.randomUUID().toString.replace("-", "")}"
     readDf.createTempView(tempViewName)
@@ -1297,12 +1275,10 @@ class FlexibleDataModelNodeTest
   }
 
   it should "successfully read from list of external id refs (files/Sequences)" in {
-    testReadExternaldRefs(useQuery = true)
-    testReadExternaldRefs(useQuery = false)
+    testReadExternaldRefs()
   }
 
-  def testFilterInstance(debug: Boolean, useQuery: Boolean,
-                         useQueryPushdownColumnsSelection: Boolean): Assertion = {
+  def testFilterInstance(debug: Boolean): Assertion = {
     setUpDataModel()
     val df = readRowsFromModel(
       modelSpace = spaceExternalId,
@@ -1310,9 +1286,7 @@ class FlexibleDataModelNodeTest
       modelVersion = viewVersion,
       viewExternalId = viewStartNodeAndEndNodesExternalId,
       instanceSpace = None,
-      debug,
-      useQuery,
-      useQueryPushdownColumnsSelection
+      debug
     )
 
     val tempViewUUID = UUID.randomUUID().toString.replace("-", "")
@@ -1332,15 +1306,8 @@ class FlexibleDataModelNodeTest
   }
 
   it should "successfully filter instances from a data model, and debug flag should have no impact on results" in {
-    testFilterInstance(debug = false, useQuery = true, useQueryPushdownColumnsSelection = true)
-    testFilterInstance(debug = true, useQuery = true, useQueryPushdownColumnsSelection = true)
-  }
-
-  it should "successfully filter instances from a data model, and query vs list flag should have no impact on results" in {
-    testFilterInstance(debug = true, useQuery = true, useQueryPushdownColumnsSelection = true)
-    testFilterInstance(debug = true, useQuery = true, useQueryPushdownColumnsSelection = false)
-    testFilterInstance(debug = true, useQuery = false, useQueryPushdownColumnsSelection = true)
-    testFilterInstance(debug = true, useQuery = false, useQueryPushdownColumnsSelection = false)
+    testFilterInstance(debug = false)
+    testFilterInstance(debug = true)
   }
 
   it should "successfully insert instances to a data model" in {

--- a/src/test/scala/cognite/spark/v1/fdm/utils/FDMSparkDataframeTestOperations.scala
+++ b/src/test/scala/cognite/spark/v1/fdm/utils/FDMSparkDataframeTestOperations.scala
@@ -110,9 +110,7 @@ object FDMSparkDataframeTestOperations extends SparkTest with Matchers {
     viewSpaceExternalId: String,
     viewExternalId: String,
     viewVersion: String,
-    instanceSpaceExternalId: String,
-    useQuery: Boolean = false,
-    useQueryPushdownColumnsSelection: Boolean = false): DataFrame = {
+    instanceSpaceExternalId: String): DataFrame = {
     spark.read
       .format(DefaultSource.sparkFormatString)
       .option("type", FlexibleDataModelRelationFactory.ResourceType)
@@ -130,15 +128,12 @@ object FDMSparkDataframeTestOperations extends SparkTest with Matchers {
       .option("instanceSpace", instanceSpaceExternalId)
       .option("metricsPrefix", s"$viewExternalId-$viewVersion")
       .option("collectMetrics", true)
-      .option("useQuery", useQuery)
-      .option("useQueryPushdownColumnsSelection", useQueryPushdownColumnsSelection)
       .load()
   }
 
 
 
-  def readEdgeWithEdgeType(edgeSpace: String, edgeExternalId: String, useQuery: Boolean = false,
-                           useQueryPushdownColumnsSelection:Boolean  = false): DataFrame =
+  def readEdgeWithEdgeType(edgeSpace: String, edgeExternalId: String): DataFrame =
     spark.read
         .format(DefaultSource.sparkFormatString)
         .option("type", FlexibleDataModelRelationFactory.ResourceType)
@@ -154,8 +149,6 @@ object FDMSparkDataframeTestOperations extends SparkTest with Matchers {
         .option("instanceType", "edge")
         .option("metricsPrefix", s"$edgeExternalId-$viewVersion")
         .option("collectMetrics", value = true)
-        .option("useQuery", useQuery)
-        .option("useQueryPushdownColumnsSelection", useQueryPushdownColumnsSelection)
         .load()
 
   def readRowsFromModel(
@@ -164,9 +157,7 @@ object FDMSparkDataframeTestOperations extends SparkTest with Matchers {
       modelVersion: String,
       viewExternalId: String,
       instanceSpace: Option[String],
-      debug: Boolean = false,
-      useQuery: Boolean = false,
-      useQueryPushdownColumnsSelection: Boolean = false): DataFrame = {
+      debug: Boolean = false): DataFrame = {
       spark.read
         .format(DefaultSource.sparkFormatString)
         .option("type", FlexibleDataModelRelationFactory.ResourceType)
@@ -185,8 +176,6 @@ object FDMSparkDataframeTestOperations extends SparkTest with Matchers {
         .option("metricsPrefix", s"$modelExternalId-$modelVersion")
         .option("collectMetrics", value = true)
         .option("sendDebugFlag", value = debug)
-        .option("useQuery", value = useQuery)
-        .option("useQueryPushdownColumnsSelection", value = useQueryPushdownColumnsSelection)
         .load()
   }
 
@@ -195,9 +184,7 @@ object FDMSparkDataframeTestOperations extends SparkTest with Matchers {
      modelExternalId: String,
      modelVersion: String,
      edgeTypeSpace: String,
-     edgeTypeExternalId: String,
-     useQuery: Boolean = false,
-     useQueryPushdownColumnsSelection: Boolean = false
+     edgeTypeExternalId: String
   ): DataFrame =
     spark.read
       .format(DefaultSource.sparkFormatString)
@@ -216,8 +203,6 @@ object FDMSparkDataframeTestOperations extends SparkTest with Matchers {
       .option("edgeTypeExternalId", edgeTypeExternalId)
       .option("metricsPrefix", s"$modelExternalId-$modelVersion")
       .option("collectMetrics", value = true)
-      .option("useQuery", useQuery)
-      .option("useQueryPushdownColumnsSelection", useQueryPushdownColumnsSelection)
       .load()
 
   def syncRows(


### PR DESCRIPTION
No longer used from jetfire-backend. It is now always true.

Jetfire-backend has been modified already to always send "true" to these two, this stops reading them entirely and just assumes true.

next step: jetfire-backend will no longer sends these at all.