### PR TITLE
Add pre-commit hooks for scalafmt and file hygiene

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+    -   id: trailing-whitespace
+        description: Trims trailing whitespace from all files.
+    -   id: end-of-file-fixer
+        description: Ensures files end with a newline.
+    -   id: check-added-large-files
+        description: Prevents committing large data files (e.g., parquet, csv).
+        args: ['--maxkb=10000']  # Limits files to 10MB
+
+-   repo: local
+    hooks:
+    -   id: scalafmt
+        name: scalafmt
+        description: Formats only the changed/staged Scala files via the standalone scalafmt CLI.
+        entry: scalafmt
+        language: system
+        files: '\.(scala|sbt|sc)$'
+        exclude: '(^|/)(scalafix-inputs/.*|scalafix-outputs/.*)$'

--- a/README.md
+++ b/README.md
@@ -1606,3 +1606,26 @@ res0: Long = 1000
 
 Note that if you're on an older version than `1.1.0` you'll need to use the old name,
 `cdp-spark-datasource`.
+
+## Development
+
+### Pre-commit setup
+Run the following to set up the pre-commit hooks defined in `.pre-commit-config.yaml`.
+After installation, the hooks run automatically on every `git commit`.
+
+```bash
+# Install the pre-commit tool
+pip install pre-commit
+
+# Install the git hooks for this repo
+pre-commit install
+
+# (Optional) run all hooks against the whole repo once
+pre-commit run --all-files
+```
+
+Hooks currently installed:
+1. scalafmt - formats staged Scala/sbt sources (standalone `scalafmt` CLI; requires `scalafmt` on PATH, e.g. via Coursier)
+2. end-of-file-fixer - ensures files end with a newline
+3. trailing-whitespace - trims trailing whitespace
+4. check-added-large-files - blocks files larger than 10 MB


### PR DESCRIPTION
## Summary
- Add a minimal `.pre-commit-config.yaml` with generic hygiene hooks (trailing whitespace, EOF fixer, large-file check) and a standalone `scalafmt` hook for staged Scala/sbt sources
- Document pre-commit setup in README under a new Development section

Mirrors CI `scalafmtCheck` / `scalafmtSbtCheck` locally on commit. No `sbt test:compile` hook (kept minimal).

## Test plan
- [x] Deliberate misformat on a staged `.scala` file is auto-fixed by the hook
- [x] `sbt scalafmtCheck` passes after hook reformat on that file
- [x] Did not run hygiene hooks repo-wide (avoids unrelated bulk whitespace churn)